### PR TITLE
chore: 署名設定をxcconfigに分離し複数開発者対応

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Local signing config (each developer has their own)
+Local.xcconfig
+
+# Xcode user data
+xcuserdata/
+*.xcuserstate
+
+# Build products
+build/
+DerivedData/
+
+# OS files
+.DS_Store

--- a/Cycle.xcodeproj/project.pbxproj
+++ b/Cycle.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		2E0FCB122EBF921700B9081E /* Cycle.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Cycle.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E0FCB1F2EBF921C00B9081E /* CycleTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CycleTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E0FCB292EBF921C00B9081E /* CycleUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CycleUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		2E0FCB402EBF930000B9081E /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -75,6 +76,7 @@
 		2E0FCB092EBF921700B9081E = {
 			isa = PBXGroup;
 			children = (
+				2E0FCB402EBF930000B9081E /* Local.xcconfig */,
 				2E0FCB142EBF921700B9081E /* Cycle */,
 				2E0FCB222EBF921C00B9081E /* CycleTests */,
 				2E0FCB2C2EBF921C00B9081E /* CycleUITests */,
@@ -321,7 +323,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -378,7 +380,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -390,12 +392,12 @@
 		};
 		2E0FCB342EBF921D00B9081E /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2E0FCB402EBF930000B9081E /* Local.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 784249657M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -408,7 +410,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wisdomhills.Cycle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -422,12 +423,12 @@
 		};
 		2E0FCB352EBF921D00B9081E /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2E0FCB402EBF930000B9081E /* Local.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 784249657M;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -440,7 +441,6 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.wisdomhills.Cycle;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_APPROACHABLE_CONCURRENCY = YES;
@@ -459,7 +459,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wisdomhills.CycleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -480,7 +480,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 26.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.wisdomhills.CycleTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Local.xcconfig.template
+++ b/Local.xcconfig.template
@@ -1,0 +1,12 @@
+// Local signing configuration
+// Copy this file to Local.xcconfig and fill in your values
+//
+// To find your DEVELOPMENT_TEAM:
+//   1. Open Xcode → Settings → Accounts
+//   2. Select your Apple ID → View Details
+//   3. Your Team ID is shown there
+//
+// For free accounts, change PRODUCT_BUNDLE_IDENTIFIER to something unique
+
+DEVELOPMENT_TEAM = YOUR_TEAM_ID_HERE
+PRODUCT_BUNDLE_IDENTIFIER = com.yourname.Cycle


### PR DESCRIPTION
## Summary
- `Local.xcconfig` で各開発者が独自の Team ID / Bundle ID を設定できるように分離
- `IPHONEOS_DEPLOYMENT_TARGET` を 26.0 → 17.0 に修正（Xcode 16.3 で動作するように）
- `.gitignore` を追加（`Local.xcconfig`, `xcuserdata` 等を除外）

## セットアップ手順（他の開発者向け）
1. `Local.xcconfig.template` を `Local.xcconfig` にコピー
2. 自分の `DEVELOPMENT_TEAM` と `PRODUCT_BUNDLE_IDENTIFIER` を記入
3. Xcode でビルド

## Test plan
- [x] シミュレータ（iPhone 16 Pro）でビルド成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)