### PR TITLE
infra: GCPセットアップスクリプト追加

### DIFF
--- a/scripts/gcp-add-members.sh
+++ b/scripts/gcp-add-members.sh
@@ -1,0 +1,188 @@
+#!/bin/bash
+# =============================================================================
+# GCPプロジェクト作成 & チームメンバー追加スクリプト
+#
+# 前提:
+#   - gcloud CLI がインストール済み
+#   - オーナー権限を持つGoogleアカウントでログイン済み
+#     (gcloud auth login)
+#   - 請求先アカウントが存在する
+#
+# 使い方:
+#   ./scripts/gcp-add-members.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+MEMBERS_FILE="$SCRIPT_DIR/gcp-members.txt"
+
+# ─── 設定 ────────────────────────────────────────────────────
+PROJECT_ID="cycle-journal"
+PROJECT_NAME="CycleJournal"
+REGION="asia-northeast1"
+
+# メンバーに付与するロール (管理者レベル、請求系を除く)
+ROLES=(
+  "roles/editor"
+  "roles/resourcemanager.projectIamAdmin"
+  "roles/iam.serviceAccountAdmin"
+  "roles/iam.serviceAccountKeyAdmin"
+  "roles/run.admin"
+  "roles/cloudsql.admin"
+  "roles/secretmanager.admin"
+  "roles/cloudbuild.builds.editor"
+  "roles/artifactregistry.admin"
+  "roles/logging.admin"
+  "roles/monitoring.admin"
+  "roles/storage.admin"
+)
+
+# ─── 関数 ────────────────────────────────────────────────────
+check_prerequisites() {
+  if ! command -v gcloud &>/dev/null; then
+    echo "エラー: gcloud CLI がインストールされていません"
+    echo "  https://cloud.google.com/sdk/docs/install"
+    exit 1
+  fi
+
+  local account
+  account=$(gcloud config get-value account 2>/dev/null)
+  if [ -z "$account" ] || [ "$account" = "(unset)" ]; then
+    echo "エラー: gcloud にログインしていません"
+    echo "  gcloud auth login を実行してください"
+    exit 1
+  fi
+  echo "ログイン中のアカウント: $account"
+}
+
+create_project() {
+  echo ""
+  echo "[1/4] GCPプロジェクトを確認中..."
+
+  if gcloud projects describe "$PROJECT_ID" &>/dev/null; then
+    echo "  プロジェクト '$PROJECT_ID' は既に存在します。スキップします。"
+  else
+    echo "  プロジェクト '$PROJECT_ID' を作成中..."
+    gcloud projects create "$PROJECT_ID" --name="$PROJECT_NAME"
+    echo "  プロジェクトを作成しました。"
+  fi
+
+  gcloud config set project "$PROJECT_ID"
+}
+
+link_billing() {
+  echo ""
+  echo "[2/4] 請求先アカウントを確認中..."
+
+  local current_billing
+  current_billing=$(gcloud billing projects describe "$PROJECT_ID" \
+    --format="value(billingAccountName)" 2>/dev/null || true)
+
+  if [ -n "$current_billing" ]; then
+    echo "  請求先は既にリンク済み: $current_billing"
+    return
+  fi
+
+  echo "  利用可能な請求先アカウント:"
+  gcloud billing accounts list --format="table(name, displayName, open)"
+  echo ""
+
+  read -rp "  リンクする請求先アカウントID (例: 012345-6789AB-CDEF01): " billing_id
+  if [ -z "$billing_id" ]; then
+    echo "  スキップしました。後で手動でリンクしてください。"
+    return
+  fi
+
+  gcloud billing projects link "$PROJECT_ID" --billing-account="$billing_id"
+  echo "  請求先をリンクしました。"
+}
+
+enable_apis() {
+  echo ""
+  echo "[3/4] 必要なAPIを有効化中..."
+
+  local apis=(
+    "cloudresourcemanager.googleapis.com"
+    "iam.googleapis.com"
+    "run.googleapis.com"
+    "sqladmin.googleapis.com"
+    "secretmanager.googleapis.com"
+    "cloudbuild.googleapis.com"
+    "artifactregistry.googleapis.com"
+    "logging.googleapis.com"
+    "monitoring.googleapis.com"
+  )
+
+  for api in "${apis[@]}"; do
+    echo "  有効化: $api"
+    gcloud services enable "$api" --project="$PROJECT_ID" 2>/dev/null || true
+  done
+}
+
+add_members() {
+  echo ""
+  echo "[4/4] チームメンバーを追加中..."
+
+  if [ ! -f "$MEMBERS_FILE" ]; then
+    echo "  エラー: $MEMBERS_FILE が見つかりません"
+    exit 1
+  fi
+
+  local count=0
+  while IFS= read -r line; do
+    # 空行とコメントをスキップ
+    line=$(echo "$line" | xargs)
+    [[ -z "$line" || "$line" == \#* ]] && continue
+
+    local email="$line"
+    echo ""
+    echo "  メンバー追加: $email"
+
+    for role in "${ROLES[@]}"; do
+      echo "    + $role"
+      gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+        --member="user:$email" \
+        --role="$role" \
+        --quiet \
+        > /dev/null
+    done
+
+    count=$((count + 1))
+  done < "$MEMBERS_FILE"
+
+  echo ""
+  if [ "$count" -eq 0 ]; then
+    echo "  警告: メンバーが0人です。$MEMBERS_FILE にGmailアドレスを追加してください。"
+  else
+    echo "  $count 人のメンバーを追加しました。"
+  fi
+}
+
+# ─── メイン ───────────────────────────────────────────────────
+echo "========================================"
+echo "  GCPプロジェクト セットアップ"
+echo "========================================"
+
+check_prerequisites
+create_project
+link_billing
+enable_apis
+add_members
+
+echo ""
+echo "========================================"
+echo "  セットアップ完了!"
+echo "========================================"
+echo ""
+echo "チームメンバーに以下を共有してください:"
+echo "  1. gcloud CLI をインストール"
+echo "     https://cloud.google.com/sdk/docs/install"
+echo ""
+echo "  2. ログインしてプロジェクトを設定"
+echo "     gcloud auth login"
+echo "     gcloud config set project $PROJECT_ID"
+echo ""
+echo "  3. 開発用セットアップスクリプトを実行"
+echo "     ./scripts/gcp-setup-local.sh"
+echo ""

--- a/scripts/gcp-members.txt
+++ b/scripts/gcp-members.txt
@@ -1,0 +1,7 @@
+# GCPプロジェクトに追加するチームメンバーのGmailアドレス
+# 1行に1アドレス、#で始まる行はコメント
+#
+# 例:
+# taro@gmail.com
+# hanako@gmail.com
+andoakitoai@gmail.com

--- a/scripts/gcp-setup-local.sh
+++ b/scripts/gcp-setup-local.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# =============================================================================
+# GCP 開発者向けローカル環境セットアップ
+#
+# チームメンバーがクローン後に実行するスクリプト。
+# gcloud CLIの認証とプロジェクト設定を行います。
+#
+# 使い方:
+#   ./scripts/gcp-setup-local.sh
+# =============================================================================
+
+set -euo pipefail
+
+PROJECT_ID="cycle-journal"
+REGION="asia-northeast1"
+
+echo "========================================"
+echo "  CycleJournal - GCP ローカルセットアップ"
+echo "========================================"
+echo ""
+
+# ─── gcloud CLI チェック ──────────────────────────────────────
+echo "[1/4] gcloud CLI を確認中..."
+
+if ! command -v gcloud &>/dev/null; then
+  echo ""
+  echo "  gcloud CLI がインストールされていません。"
+  echo "  以下からインストールしてください:"
+  echo "    https://cloud.google.com/sdk/docs/install"
+  exit 1
+fi
+
+echo "  OK: $(gcloud version 2>/dev/null | head -1)"
+
+# ─── 認証 ────────────────────────────────────────────────────
+echo ""
+echo "[2/4] Google アカウント認証..."
+
+current_account=$(gcloud config get-value account 2>/dev/null || true)
+if [ -n "$current_account" ] && [ "$current_account" != "(unset)" ]; then
+  echo "  現在のアカウント: $current_account"
+  read -rp "  このアカウントを使いますか? (Y/n): " use_current
+  if [[ "$use_current" =~ ^[Nn] ]]; then
+    gcloud auth login
+  fi
+else
+  echo "  ブラウザが開きます。Googleアカウントでログインしてください。"
+  gcloud auth login
+fi
+
+# ─── プロジェクト設定 ─────────────────────────────────────────
+echo ""
+echo "[3/4] GCPプロジェクトを設定中..."
+
+gcloud config set project "$PROJECT_ID"
+gcloud config set compute/region "$REGION"
+
+echo "  プロジェクト: $PROJECT_ID"
+echo "  リージョン:   $REGION"
+
+# ─── アプリケーションデフォルト認証 ──────────────────────────
+echo ""
+echo "[4/4] アプリケーションデフォルト認証を設定中..."
+echo "  ローカル開発でGCPサービスにアクセスするための認証です。"
+
+gcloud auth application-default login
+
+echo ""
+echo "========================================"
+echo "  セットアップ完了!"
+echo "========================================"
+echo ""
+echo "確認コマンド:"
+echo "  gcloud config list                    # 現在の設定を確認"
+echo "  gcloud projects get-iam-policy $PROJECT_ID  # IAM権限を確認"
+echo ""


### PR DESCRIPTION
## Summary
- GCPプロジェクト作成・API有効化・メンバー追加を一括実行するスクリプト (`gcp-add-members.sh`)
- チームメンバーのローカル環境セットアップスクリプト (`gcp-setup-local.sh`)
- 請求系以外の管理者レベル権限を付与する構成（editor, IAM admin, Cloud Run/SQL/Storage admin 等）

## Test plan
- [x] `gcp-add-members.sh` でプロジェクト作成・請求先リンク・API有効化・メンバー追加を実行済み
- [x] `andoakitoai@gmail.com` に12ロール付与を確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)