### PR TITLE
infra: prod環境デプロイ + iOS prod URL設定

### DIFF
--- a/infra/prod.tfvars
+++ b/infra/prod.tfvars
@@ -1,0 +1,3 @@
+project_id  = "cycle-journal"
+region      = "asia-northeast1"
+environment = "prod"

--- a/ios/Cycle/Services/APIClient.swift
+++ b/ios/Cycle/Services/APIClient.swift
@@ -16,7 +16,7 @@ enum APIEnvironment {
         case .development:
             return "https://cycle-api-dev-1031235624127.asia-northeast1.run.app"
         case .production:
-            return "https://api.cyclejournal.app" // TODO: 本番URL
+            return "https://cycle-api-prod-1031235624127.asia-northeast1.run.app"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Terraform prod workspace で本番Cloud Runをデプロイ
- iOS APIClient の production URL を更新

## Changes
- `infra/prod.tfvars` — prod環境用の変数ファイル
- `ios/Cycle/Services/APIClient.swift` — `.production` URL を `cycle-api-prod-1031235624127.asia-northeast1.run.app` に設定

## Deployed
- prod: `https://cycle-api-prod-1031235624127.asia-northeast1.run.app/health` → `{"stage":"prod"}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)