### PR TITLE
fix: Apple Sign Inのbundle ID不一致を修正

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -7,7 +7,7 @@ class Settings(BaseSettings):
     environment: str = "dev"
     gcp_project_id: str = "cycle-journal"
     gcp_region: str = "asia-northeast1"
-    apple_bundle_id: str = "com.cycle.journal"
+    apple_bundle_id: str = "com.akitoando.CycleJournal"
     google_client_id: str = ""  # iOS用Google OAuth Client ID
 
     # Vertex AI Claude

--- a/infra/cloud_run.tf
+++ b/infra/cloud_run.tf
@@ -41,7 +41,7 @@ resource "google_cloud_run_v2_service" "api" {
 
       env {
         name  = "APPLE_BUNDLE_ID"
-        value = "com.cycle.journal"
+        value = "com.akitoando.CycleJournal"
       }
 
       env {


### PR DESCRIPTION
## Summary
- バックエンドの`APPLE_BUNDLE_ID`が`com.cycle.journal`になっていたが、実際のiOSアプリのバンドルIDは`com.akitoando.CycleJournal`
- JWT audience検証が失敗し、Sign in with Appleがエラーになっていた（App Store Review rejectionの原因）
- `api/app/config.py` と `infra/cloud_run.tf` の両方を修正

## Test plan
- [ ] バックエンドデプロイ後、実機でSign in with Appleが成功することを確認
- [ ] Google Sign-Inが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)