### PR TITLE
chore: claude-code-workflow-kit プラグインを追加

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "tomokiishimine-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "TomokiIshimine/tomokiishimine-marketplace"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "claude-code-workflow-kit@tomokiishimine-marketplace": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ __pycache__/
 # Environment
 .env
 .env.local
+
+# Claude Code (local-only)
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- `.claude/settings.json` で `tomokiishimine-marketplace` を登録し、`claude-code-workflow-kit` プラグインを有効化
- `.gitignore` に個人ローカル設定（`.claude/settings.local.json` / `.claude/worktrees/`）を追加してチーム共有設定のみ追跡

## Test plan
- [ ] PR をマージ後、各メンバーが Claude Code を再起動してマーケットプレイス信頼確認に承認
- [ ] `/plugin` でプラグインが有効になっていることを確認
- [ ] /develop など workflow-kit 由来の slash command が利用できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)