### PR TITLE
feat: アカウント削除機能（Apple Sign in revoke 対応）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,13 @@
+{
+  "extraKnownMarketplaces": {
+    "tomokiishimine-marketplace": {
+      "source": {
+        "source": "github",
+        "repo": "TomokiIshimine/tomokiishimine-marketplace"
+      }
+    }
+  },
+  "enabledPlugins": {
+    "claude-code-workflow-kit@tomokiishimine-marketplace": true
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ __pycache__/
 # Environment
 .env
 .env.local
+
+# Claude Code (local-only)
+.claude/settings.local.json
+.claude/worktrees/

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -10,6 +10,12 @@ class Settings(BaseSettings):
     apple_bundle_id: str = "com.akitoando.CycleJournal"
     google_client_id: str = ""  # iOS用Google OAuth Client ID
 
+    # Sign in with Apple - revoke / token exchange 用
+    # 未設定の場合は revoke / code 交換は no-op になる（ローカル開発フォールバック）
+    apple_team_id: str = ""
+    apple_key_id: str = ""
+    apple_private_key: str = ""  # .p8 ファイルの中身（PEM）
+
     # JWT (サーバー発行トークン)
     jwt_secret_key: str = "dev-insecure-local-only"  # prodはSecret Managerで上書き
     jwt_algorithm: str = "HS256"

--- a/api/app/models/auth.py
+++ b/api/app/models/auth.py
@@ -7,6 +7,10 @@ from pydantic import BaseModel
 
 class VerifyTokenRequest(BaseModel):
     identity_token: str
+    # iOS から `ASAuthorizationAppleIDCredential.authorizationCode` を base64/utf8 で送る。
+    # 受け取った場合はサーバ側で Apple refresh_token に交換し、アカウント削除時の
+    # revoke 用に保存する。任意フィールド（無くてもサインインは成立する）。
+    authorization_code: str | None = None
 
 
 class GoogleVerifyRequest(BaseModel):

--- a/api/app/routers/auth.py
+++ b/api/app/routers/auth.py
@@ -15,7 +15,10 @@ from app.models.auth import (
     VerifyTokenData,
     VerifyTokenRequest,
 )
-from app.services.apple_auth import verify_apple_token
+from app.services.apple_auth import (
+    exchange_apple_code,
+    verify_apple_token,
+)
 from app.services.firestore_client import users_ref
 from app.services.google_auth import verify_google_token
 from app.services.token_service import (
@@ -49,12 +52,24 @@ async def verify_token(
     apple_user_id = claims.get("sub", "")
     email = claims.get("email")
 
+    # authorization_code があれば Apple refresh_token に交換してユーザードキュメントに保存する。
+    # アカウント削除時に Apple 側で revoke するために必要（App Store ガイドライン 5.1.1(v)）。
+    # 失敗しても識別トークン検証自体は成功しているのでサインインは続行する。
+    apple_refresh_token: str | None = None
+    if body.authorization_code:
+        try:
+            token_response = await exchange_apple_code(body.authorization_code)
+            apple_refresh_token = token_response.get("refresh_token")
+        except Exception:
+            apple_refresh_token = None
+
     user_id, is_new_user, created_at = await _find_or_create_user(
         db=db,
         user_id=apple_user_id,
         email=email,
         provider_field="apple_user_id",
         provider_value=apple_user_id,
+        apple_refresh_token=apple_refresh_token,
     )
 
     access_token, expires_in = create_access_token(user_id, "apple")
@@ -154,6 +169,7 @@ async def _find_or_create_user(
     email: str | None,
     provider_field: str,
     provider_value: str,
+    apple_refresh_token: str | None = None,
 ) -> tuple[str, bool, datetime]:
     """Firestoreでユーザーを検索 or 作成."""
     ref = users_ref(db)
@@ -164,7 +180,7 @@ async def _find_or_create_user(
     is_new_user = not snapshot.exists
 
     if is_new_user:
-        user_data = {
+        user_data: dict = {
             provider_field: provider_value,
             "email": email,
             "display_name": None,
@@ -172,9 +188,19 @@ async def _find_or_create_user(
             "created_at": now,
             "updated_at": now,
         }
+        if apple_refresh_token:
+            user_data["apple_refresh_token"] = apple_refresh_token
         await user_doc.set(user_data)
         created_at = now
     else:
         created_at = snapshot.get("created_at") or now
+        # 既存ユーザーで新しい apple_refresh_token を取得した場合は更新する。
+        if apple_refresh_token:
+            await user_doc.update(
+                {
+                    "apple_refresh_token": apple_refresh_token,
+                    "updated_at": now,
+                }
+            )
 
     return user_id, is_new_user, created_at

--- a/api/app/routers/users.py
+++ b/api/app/routers/users.py
@@ -6,6 +6,7 @@ from google.cloud.firestore import AsyncClient
 from app.dependencies import get_current_user, get_firestore
 from app.exceptions import NotFoundError
 from app.models.user import UserData, UserSettings
+from app.services.account_service import delete_user_account
 from app.services.firestore_client import users_ref
 
 router = APIRouter(prefix="/users", tags=["Users"])
@@ -38,3 +39,21 @@ async def get_me(
             updated_at=data.get("updated_at"),
         )
     }
+
+
+@router.delete("/me")
+async def delete_me(
+    user_id: str = Depends(get_current_user),
+    db: AsyncClient = Depends(get_firestore),
+):
+    """認証済みユーザー自身のアカウントを完全に削除する.
+
+    - Apple Sign in 連携時は Apple 側で refresh token を revoke
+    - サーバ発行の refresh tokens をすべて削除
+    - ユーザーが所有する sessions / tasks とそのサブコレクションを削除
+    - users/{user_id} ドキュメントを削除
+
+    削除統計をレスポンスに含める（クライアントは ok のみ確認すれば十分）。
+    """
+    stats = await delete_user_account(db, user_id)
+    return {"data": {"ok": True, **stats}}

--- a/api/app/services/account_service.py
+++ b/api/app/services/account_service.py
@@ -1,0 +1,115 @@
+"""Account deletion service.
+
+ユーザーアカウントを完全に削除する。Apple Sign in 連携時は Apple 側で
+refresh token を revoke し、その後 Firestore のユーザー関連データを全消去する。
+
+App Store Review Guideline 5.1.1(v) 準拠。
+"""
+
+import logging
+
+from google.cloud.firestore import AsyncClient
+from google.cloud.firestore_v1.base_query import FieldFilter
+
+from app.services.apple_auth import revoke_apple_refresh_token
+from app.services.firestore_client import (
+    refresh_tokens_ref,
+    sessions_ref,
+    tasks_ref,
+    users_ref,
+)
+
+logger = logging.getLogger(__name__)
+
+
+async def delete_user_account(db: AsyncClient, user_id: str) -> dict[str, int | bool]:
+    """ユーザーに紐づく全データを削除する.
+
+    Returns: 削除統計 dict（呼び出し元でログ・監視しやすいように）
+        - apple_revoked: Apple 側で revoke できたか (True/False)
+        - sessions_deleted: 削除したセッション数
+        - tasks_deleted: 削除したタスク数
+        - refresh_tokens_deleted: 削除した server-issued refresh token 数
+        - user_doc_deleted: ユーザードキュメント削除可否 (True/False)
+    """
+    user_doc_ref = users_ref(db).document(user_id)
+    snapshot = await user_doc_ref.get()
+
+    apple_revoked = False
+    if snapshot.exists:
+        data = snapshot.to_dict() or {}
+        apple_token = data.get("apple_refresh_token")
+        if apple_token:
+            apple_revoked = await revoke_apple_refresh_token(apple_token)
+
+    sessions_deleted = await _delete_owned_documents(
+        db,
+        sessions_ref(db),
+        user_id=user_id,
+        subcollections=("messages",),
+    )
+    tasks_deleted = await _delete_owned_documents(
+        db,
+        tasks_ref(db),
+        user_id=user_id,
+        subcollections=("reflections",),
+    )
+    refresh_deleted = await _delete_user_refresh_tokens(db, user_id)
+
+    user_doc_deleted = False
+    if snapshot.exists:
+        await user_doc_ref.delete()
+        user_doc_deleted = True
+
+    logger.info(
+        "Deleted account user_id=%s apple_revoked=%s sessions=%d tasks=%d "
+        "refresh_tokens=%d user_doc=%s",
+        user_id,
+        apple_revoked,
+        sessions_deleted,
+        tasks_deleted,
+        refresh_deleted,
+        user_doc_deleted,
+    )
+
+    return {
+        "apple_revoked": apple_revoked,
+        "sessions_deleted": sessions_deleted,
+        "tasks_deleted": tasks_deleted,
+        "refresh_tokens_deleted": refresh_deleted,
+        "user_doc_deleted": user_doc_deleted,
+    }
+
+
+async def _delete_owned_documents(
+    db: AsyncClient,
+    collection,
+    *,
+    user_id: str,
+    subcollections: tuple[str, ...] = (),
+) -> int:
+    """`user_id` フィールドが一致するドキュメントとそのサブコレクションを全削除する."""
+    query = collection.where(filter=FieldFilter("user_id", "==", user_id))
+    deleted = 0
+    async for doc in query.stream():
+        for sub_name in subcollections:
+            await _delete_subcollection(doc.reference.collection(sub_name))
+        await doc.reference.delete()
+        deleted += 1
+    return deleted
+
+
+async def _delete_subcollection(sub_collection) -> None:
+    async for sub_doc in sub_collection.stream():
+        await sub_doc.reference.delete()
+
+
+async def _delete_user_refresh_tokens(db: AsyncClient, user_id: str) -> int:
+    query = refresh_tokens_ref(db).where(
+        filter=FieldFilter("user_id", "==", user_id)
+    )
+    deleted = 0
+    async for doc in query.stream():
+        await doc.reference.delete()
+        deleted += 1
+    return deleted

--- a/api/app/services/apple_auth.py
+++ b/api/app/services/apple_auth.py
@@ -1,9 +1,12 @@
-"""Apple Sign in with Apple - JWKS fetch, cache, and JWT verification.
+"""Apple Sign in with Apple - identity token verification and revoke flow.
 
-Ported from api/src/handlers/auth.py (Lambda version).
+- verify_apple_token: identity_token を JWKS で検証し claims を返す
+- exchange_apple_code: authorization_code を Apple refresh_token に交換する
+- revoke_apple_refresh_token: Apple 側で refresh token を revoke する
 """
 
 import json
+import logging
 import time
 from typing import Any
 
@@ -13,10 +16,20 @@ from jwt.algorithms import RSAAlgorithm
 
 from app.config import settings
 
+logger = logging.getLogger(__name__)
+
 # Apple公開鍵のキャッシュ
 _apple_public_keys_cache: dict[str, Any] = {}
 _cache_timestamp: float = 0
 CACHE_TTL = 3600  # 1時間
+
+# Apple OAuth エンドポイント
+APPLE_TOKEN_URL = "https://appleid.apple.com/auth/token"
+APPLE_REVOKE_URL = "https://appleid.apple.com/auth/revoke"
+APPLE_AUDIENCE = "https://appleid.apple.com"
+
+# client_secret JWT の有効期限 (秒) - Apple は最大 6 ヶ月だが短命運用
+CLIENT_SECRET_TTL = 60 * 15  # 15 分
 
 
 async def get_apple_public_keys() -> dict[str, Any]:
@@ -70,3 +83,102 @@ async def verify_apple_token(identity_token: str) -> dict[str, Any]:
     )
 
     return claims
+
+
+# ----- client_secret 生成 / token 交換 / revoke -----
+
+def _is_revoke_configured() -> bool:
+    return bool(
+        settings.apple_team_id
+        and settings.apple_key_id
+        and settings.apple_private_key
+    )
+
+
+def _generate_client_secret() -> str:
+    """Apple OAuth 用の client_secret JWT を生成する (ES256)."""
+    if not _is_revoke_configured():
+        raise ValueError(
+            "Apple sign-in revoke is not configured: "
+            "APPLE_TEAM_ID / APPLE_KEY_ID / APPLE_PRIVATE_KEY が設定されていません"
+        )
+    now = int(time.time())
+    headers = {"kid": settings.apple_key_id}
+    payload = {
+        "iss": settings.apple_team_id,
+        "iat": now,
+        "exp": now + CLIENT_SECRET_TTL,
+        "aud": APPLE_AUDIENCE,
+        "sub": settings.apple_bundle_id,
+    }
+    return jwt.encode(
+        payload,
+        settings.apple_private_key,
+        algorithm="ES256",
+        headers=headers,
+    )
+
+
+async def exchange_apple_code(authorization_code: str) -> dict[str, Any]:
+    """authorization_code を Apple の refresh_token / id_token に交換する."""
+    client_secret = _generate_client_secret()
+    data = {
+        "client_id": settings.apple_bundle_id,
+        "client_secret": client_secret,
+        "code": authorization_code,
+        "grant_type": "authorization_code",
+    }
+    async with httpx.AsyncClient(timeout=10) as client:
+        response = await client.post(
+            APPLE_TOKEN_URL,
+            data=data,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+    if response.status_code != 200:
+        raise ValueError(
+            f"Apple token exchange failed: {response.status_code} {response.text}"
+        )
+    return response.json()
+
+
+async def revoke_apple_refresh_token(refresh_token: str) -> bool:
+    """Apple の refresh_token を revoke する.
+
+    Returns: 成功時 True、未設定または失敗時 False。
+    アカウント削除フローでは失敗してもユーザー削除は続行するため、例外は投げない。
+    """
+    if not _is_revoke_configured():
+        logger.warning("Apple sign-in revoke is not configured; skipping")
+        return False
+    if not refresh_token:
+        return False
+    try:
+        client_secret = _generate_client_secret()
+    except ValueError:
+        return False
+
+    data = {
+        "client_id": settings.apple_bundle_id,
+        "client_secret": client_secret,
+        "token": refresh_token,
+        "token_type_hint": "refresh_token",
+    }
+    try:
+        async with httpx.AsyncClient(timeout=10) as client:
+            response = await client.post(
+                APPLE_REVOKE_URL,
+                data=data,
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+    except httpx.HTTPError as exc:
+        logger.warning("Apple revoke request failed: %s", exc)
+        return False
+
+    if response.status_code != 200:
+        logger.warning(
+            "Apple revoke returned %d: %s",
+            response.status_code,
+            response.text,
+        )
+        return False
+    return True

--- a/api/app/services/token_service.py
+++ b/api/app/services/token_service.py
@@ -113,6 +113,23 @@ async def revoke_refresh_token(db: AsyncClient, token: str) -> None:
     await refresh_tokens_ref(db).document(token_hash).delete()
 
 
+async def revoke_all_refresh_tokens_for_user(db: AsyncClient, user_id: str) -> int:
+    """指定ユーザーの全 refresh_tokens を Firestore から削除する。
+
+    Returns: 削除した token 数。
+    """
+    from google.cloud.firestore_v1.base_query import FieldFilter
+
+    query = refresh_tokens_ref(db).where(
+        filter=FieldFilter("user_id", "==", user_id)
+    )
+    deleted = 0
+    async for doc in query.stream():
+        await doc.reference.delete()
+        deleted += 1
+    return deleted
+
+
 async def rotate_refresh_token(
     db: AsyncClient, old_token: str
 ) -> tuple[str, str, int]:

--- a/api/tests/test_apple_revoke.py
+++ b/api/tests/test_apple_revoke.py
@@ -1,0 +1,75 @@
+"""Apple Sign in client_secret 生成 / revoke 関連のテスト."""
+
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+def _generate_test_es256_pem() -> str:
+    """テスト用 ES256 鍵を PEM 形式で生成."""
+    private_key = ec.generate_private_key(ec.SECP256R1())
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return pem.decode("utf-8")
+
+
+def test_generate_client_secret_includes_required_claims(monkeypatch):
+    from app.config import settings
+    from app.services.apple_auth import _generate_client_secret
+
+    monkeypatch.setattr(settings, "apple_team_id", "TEAM12345A")
+    monkeypatch.setattr(settings, "apple_key_id", "KEY1234ABC")
+    monkeypatch.setattr(settings, "apple_private_key", _generate_test_es256_pem())
+    monkeypatch.setattr(settings, "apple_bundle_id", "com.example.test")
+
+    token = _generate_client_secret()
+
+    header = jwt.get_unverified_header(token)
+    assert header["alg"] == "ES256"
+    assert header["kid"] == "KEY1234ABC"
+
+    payload = jwt.decode(token, options={"verify_signature": False})
+    assert payload["iss"] == "TEAM12345A"
+    assert payload["sub"] == "com.example.test"
+    assert payload["aud"] == "https://appleid.apple.com"
+    assert payload["exp"] > payload["iat"]
+
+
+def test_generate_client_secret_raises_when_unconfigured(monkeypatch):
+    from app.config import settings
+    from app.services.apple_auth import _generate_client_secret
+
+    monkeypatch.setattr(settings, "apple_team_id", "")
+    monkeypatch.setattr(settings, "apple_key_id", "")
+    monkeypatch.setattr(settings, "apple_private_key", "")
+
+    with pytest.raises(ValueError):
+        _generate_client_secret()
+
+
+@pytest.mark.asyncio
+async def test_revoke_returns_false_when_unconfigured(monkeypatch):
+    from app.config import settings
+    from app.services.apple_auth import revoke_apple_refresh_token
+
+    monkeypatch.setattr(settings, "apple_team_id", "")
+
+    result = await revoke_apple_refresh_token("some-token")
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_revoke_returns_false_for_empty_token(monkeypatch):
+    from app.config import settings
+    from app.services.apple_auth import revoke_apple_refresh_token
+
+    monkeypatch.setattr(settings, "apple_team_id", "TEAM12345A")
+    monkeypatch.setattr(settings, "apple_key_id", "KEY1234ABC")
+    monkeypatch.setattr(settings, "apple_private_key", _generate_test_es256_pem())
+
+    result = await revoke_apple_refresh_token("")
+    assert result is False

--- a/api/tests/test_users_delete.py
+++ b/api/tests/test_users_delete.py
@@ -1,0 +1,64 @@
+"""DELETE /users/me エンドポイントのテスト."""
+
+from unittest.mock import AsyncMock, patch
+
+
+def test_delete_me_revokes_apple_token_when_present(auth_client, mock_firestore):
+    """apple_refresh_token があれば Apple revoke を呼んで全データ削除する."""
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {
+        "apple_refresh_token": "apple-refresh-abc",
+    }
+
+    with patch(
+        "app.services.account_service.revoke_apple_refresh_token",
+        new_callable=AsyncMock,
+    ) as mock_revoke:
+        mock_revoke.return_value = True
+
+        response = auth_client.delete("/users/me")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["ok"] is True
+    assert body["apple_revoked"] is True
+    assert body["user_doc_deleted"] is True
+    mock_revoke.assert_awaited_once_with("apple-refresh-abc")
+    mock_firestore._mock_doc.delete.assert_awaited()
+
+
+def test_delete_me_skips_revoke_when_no_apple_token(auth_client, mock_firestore):
+    """apple_refresh_token が無い場合は Apple revoke を呼ばないが削除は完了する."""
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {}
+
+    with patch(
+        "app.services.account_service.revoke_apple_refresh_token",
+        new_callable=AsyncMock,
+    ) as mock_revoke:
+        response = auth_client.delete("/users/me")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["ok"] is True
+    assert body["apple_revoked"] is False
+    assert body["user_doc_deleted"] is True
+    mock_revoke.assert_not_called()
+
+
+def test_delete_me_idempotent_when_user_doc_missing(auth_client, mock_firestore):
+    """ユーザードキュメントが既に無くてもエンドポイントはエラーにならない."""
+    mock_firestore._mock_snapshot.exists = False
+
+    with patch(
+        "app.services.account_service.revoke_apple_refresh_token",
+        new_callable=AsyncMock,
+    ) as mock_revoke:
+        response = auth_client.delete("/users/me")
+
+    assert response.status_code == 200
+    body = response.json()["data"]
+    assert body["ok"] is True
+    assert body["apple_revoked"] is False
+    assert body["user_doc_deleted"] is False
+    mock_revoke.assert_not_called()

--- a/infra/cloud_run.tf
+++ b/infra/cloud_run.tf
@@ -45,6 +45,26 @@ resource "google_cloud_run_v2_service" "api" {
       }
 
       env {
+        name  = "APPLE_TEAM_ID"
+        value = var.apple_team_id
+      }
+
+      env {
+        name  = "APPLE_KEY_ID"
+        value = var.apple_key_id
+      }
+
+      env {
+        name = "APPLE_PRIVATE_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.apple_auth.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
         name  = "USE_LANGGRAPH"
         value = var.use_langgraph ? "true" : "false"
       }
@@ -69,6 +89,7 @@ resource "google_cloud_run_v2_service" "api" {
   depends_on = [
     google_project_service.apis,
     google_secret_manager_secret_version.jwt_secret,
+    google_secret_manager_secret.apple_auth,
   ]
 }
 

--- a/infra/prod.tfvars
+++ b/infra/prod.tfvars
@@ -1,3 +1,5 @@
-project_id  = "cycle-journal"
-region      = "asia-northeast1"
-environment = "prod"
+project_id    = "cycle-journal"
+region        = "asia-northeast1"
+environment   = "prod"
+apple_team_id = "AXSR25N22T"
+apple_key_id  = "TXTX42VXG4"

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -1,3 +1,5 @@
-project_id  = "cycle-journal"
-region      = "asia-northeast1"
-environment = "dev"
+project_id    = "cycle-journal"
+region        = "asia-northeast1"
+environment   = "dev"
+apple_team_id = "AXSR25N22T"
+apple_key_id  = "TXTX42VXG4"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -26,3 +26,13 @@ variable "google_client_id" {
   type        = string
   default     = "1031235624127-6fgcbv1khltu4snpktpdd0cab025coab.apps.googleusercontent.com"
 }
+
+variable "apple_team_id" {
+  description = "Apple Developer Team ID (Sign in with Apple revoke 用)"
+  type        = string
+}
+
+variable "apple_key_id" {
+  description = "Apple Sign in with Apple Key ID (.p8 と対になる)"
+  type        = string
+}

--- a/ios/Cycle/Features/Auth/Store/AuthStore.swift
+++ b/ios/Cycle/Features/Auth/Store/AuthStore.swift
@@ -223,6 +223,26 @@ class AuthStore: NSObject, ObservableObject {
         clearLocalAuth()
     }
 
+    /// アカウントを完全に削除する。
+    /// サーバ側で Apple revoke + Firestore データ全削除を行ったのち、ローカルもクリアする。
+    /// 失敗時は `error` をセットして isLoading を戻すだけで、認証状態は維持する。
+    func deleteAccount() async {
+        isLoading = true
+        error = nil
+
+        do {
+            try await authService.deleteAccount()
+        } catch {
+            self.error = "アカウントの削除に失敗しました: \(error.localizedDescription)"
+            self.isLoading = false
+            return
+        }
+
+        GIDSignIn.sharedInstance.signOut()
+        clearLocalAuth()
+        isLoading = false
+    }
+
     /// 認証状態を確認
     func checkAuthState() async {
         // 旧バージョンからアップデートしたユーザー: identityToken のみ → 再サインイン要求
@@ -297,8 +317,15 @@ class AuthStore: NSObject, ObservableObject {
             return
         }
 
+        // authorization_code はアカウント削除時の Apple revoke に必要なのでサーバへ送る。
+        let authorizationCode = credential.authorizationCode
+            .flatMap { String(data: $0, encoding: .utf8) }
+
         do {
-            let response = try await authService.verifyToken(identityToken)
+            let response = try await authService.verifyToken(
+                identityToken,
+                authorizationCode: authorizationCode
+            )
 
             let fullName: String? = {
                 if let givenName = credential.fullName?.givenName,

--- a/ios/Cycle/Features/Settings/Views/SettingsView.swift
+++ b/ios/Cycle/Features/Settings/Views/SettingsView.swift
@@ -19,6 +19,8 @@ struct SettingsView: View {
     @State private var showingSignOutAlert = false
     @State private var showingClearDataAlert = false
     @State private var showingComponentCatalog = false
+    @State private var showingDeleteAccountAlert = false
+    @State private var isDeletingAccount = false
 
     var body: some View {
         NavigationStack {
@@ -57,6 +59,20 @@ struct SettingsView: View {
                                 Text("サインアウト")
                             }
                         }
+
+                        Button(role: .destructive, action: { showingDeleteAccountAlert = true }) {
+                            HStack {
+                                if isDeletingAccount {
+                                    ProgressView()
+                                        .padding(.trailing, 4)
+                                } else {
+                                    Image(systemName: "trash")
+                                }
+                                Text(isDeletingAccount ? "アカウントを削除中..." : "アカウントを削除")
+                            }
+                        }
+                        .disabled(isDeletingAccount)
+                        .accessibilityIdentifier("delete_account_button")
                     } else {
                         // 未ログイン
                         HStack {
@@ -258,6 +274,18 @@ struct SettingsView: View {
                 Button("削除", role: .destructive) {}
             } message: {
                 Text("日記、タスク、コーチ会話の全データを削除します。この操作は取り消せません。")
+            }
+            .alert("アカウントを削除", isPresented: $showingDeleteAccountAlert) {
+                Button("キャンセル", role: .cancel) {}
+                Button("削除", role: .destructive) {
+                    Task {
+                        isDeletingAccount = true
+                        await authStore.deleteAccount()
+                        isDeletingAccount = false
+                    }
+                }
+            } message: {
+                Text("アカウントとすべてのデータ（日記・タスク・コーチ会話）がサーバーから完全に削除されます。\nこの操作は取り消せません。")
             }
             .task {
                 await checkNotificationPermission()

--- a/ios/Cycle/Services/AuthService.swift
+++ b/ios/Cycle/Services/AuthService.swift
@@ -9,6 +9,9 @@ import Foundation
 
 struct AuthVerifyRequest: Encodable {
     let identityToken: String
+    /// `ASAuthorizationAppleIDCredential.authorizationCode` を utf8 文字列化したもの。
+    /// サーバ側で Apple refresh token に交換し、アカウント削除時の revoke に使う。
+    let authorizationCode: String?
 }
 
 struct GoogleVerifyRequest: Encodable {
@@ -47,8 +50,14 @@ class AuthService {
     private let apiClient = APIClient.shared
 
     /// Apple Identity Tokenを検証
-    func verifyToken(_ identityToken: String) async throws -> AuthVerifyResponse {
-        let request = AuthVerifyRequest(identityToken: identityToken)
+    func verifyToken(
+        _ identityToken: String,
+        authorizationCode: String? = nil
+    ) async throws -> AuthVerifyResponse {
+        let request = AuthVerifyRequest(
+            identityToken: identityToken,
+            authorizationCode: authorizationCode
+        )
 
         let response: APIResponse<AuthVerifyResponse> = try await apiClient.post(
             path: "/auth/verify",
@@ -94,5 +103,11 @@ class AuthService {
             body: request,
             requiresAuth: false
         )
+    }
+
+    /// 認証済みユーザー自身のアカウントを完全削除する。
+    /// サーバ側で Apple revoke + Firestore データ全削除を行う。
+    func deleteAccount() async throws {
+        try await apiClient.delete(path: "/users/me", requiresAuth: true)
     }
 }


### PR DESCRIPTION
## Summary

App Store Review Guideline **5.1.1(v)**「アカウント作成できるなら削除手段も提供する」必須要件を満たす実装。
2026-05-04 のリジェクト指摘への対応。

## バックエンド

- **`DELETE /users/me`** 追加（要 Bearer token）
  - apple_refresh_token があれば Apple `https://appleid.apple.com/auth/revoke` を呼ぶ
  - tasks / sessions / refresh_tokens から `user_id` 一致のドキュメントを削除
  - sessions の messages サブコレクション、tasks の reflections サブコレクションも削除
  - 最後に `users/{user_id}` ドキュメントを削除
- **`/auth/verify`** で `authorization_code` を任意で受信
  - 受信した場合は Apple `/auth/token` で交換 → refresh_token をユーザードキュメントに保存
  - これによりアカウント削除時に Apple 側で revoke 可能になる
- **`apple_auth.py`** に `_generate_client_secret()` (ES256)、`exchange_apple_code()`、`revoke_apple_refresh_token()` を追加
- **`account_service.py`** を新設して削除ロジックを集約（テスタブル）
- **pytest 7 件追加**（client_secret claims 検証、DELETE /users/me の 3 シナリオ）

## iOS

- `AuthService.deleteAccount()` / `AuthStore.deleteAccount()` 追加
- `AuthVerifyRequest` に `authorizationCode` フィールド追加
- `AuthStore.handleSignInSuccess` で `credential.authorizationCode` を取得して送信
- `SettingsView` ログイン済みセクションに「アカウントを削除」ボタン追加
  - 確認ダイアログ → サーバー削除 → ローカル keychain クリア → 未ログイン状態に遷移

## Terraform

- `apple_team_id` / `apple_key_id` を variables 化
- `cloud_run.tf` の env に `APPLE_TEAM_ID` / `APPLE_KEY_ID` を追加
- `APPLE_PRIVATE_KEY` を Secret Manager `apple-auth-config-{env}` から参照
- `.p8` 本体は `gcloud secrets versions add` で投入済み（dev / prod 両方）

## マージ後にユーザー側で必要な作業

```bash
cd infra
terraform init  # 初回 or provider 更新時
terraform apply -var-file=terraform.tfvars  # dev
terraform apply -var-file=prod.tfvars       # prod
```

→ Cloud Run リビジョンが更新され Apple env が反映される。

## Test plan

- [x] `pytest tests/` → 23 passed
- [x] `xcodebuild -scheme Cycle -destination 'generic/platform=iOS Simulator' build` → BUILD SUCCEEDED
- [ ] `terraform apply` 実行 → Cloud Run env 反映確認
- [ ] シミュレータで Sign in → Settings → 「アカウントを削除」 → 確認ダイアログ → 削除成功 → 未ログイン画面に戻ること
- [ ] サーバログで `Deleted account user_id=… apple_revoked=True` が出ること
- [ ] Apple Developer Portal の Sign in users 一覧から該当ユーザーが消えていること
- [ ] App Store Connect で TestFlight 配布 → App Review に再提出（録画も添付）

🤖 Generated with [Claude Code](https://claude.com/claude-code)