### PR TITLE
feat: #37 Apple IAP webhook (ASSN V2) 受信口と JWS 検証基盤

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -31,6 +31,18 @@ class Settings(BaseSettings):
     # LangGraphフローを有効にする（感情分析・Cycle要素判定・安全フィルター）
     use_langgraph: bool = False
 
+    # Apple In-App Purchase (App Store Server API / Notifications V2)
+    # - apple_iap_issuer_id / apple_iap_key_id / apple_iap_private_key は
+    #   App Store Connect → Users and Access → Integrations → In-App Purchase Keys
+    #   から発行する .p8 とそのメタ情報。Sign in with Apple 用の鍵とは別管理。
+    # - apple_iap_env は "Sandbox" / "Production"。デプロイ環境ごとに上書き。
+    # - apple_iap_app_apple_id は App Store Connect の App ID(数値)。Sandbox では None 可。  # noqa: E501
+    apple_iap_issuer_id: str = ""
+    apple_iap_key_id: str = ""
+    apple_iap_private_key: str = ""  # .p8 PEM 本体
+    apple_iap_env: str = "Sandbox"
+    apple_iap_app_apple_id: int | None = None
+
     model_config = {"env_prefix": "", "case_sensitive": False}
 
 

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -5,7 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.exceptions import AppError, app_error_handler
-from app.routers import auth, coach, health, sessions, tasks, users
+from app.routers import auth, coach, health, iap, sessions, tasks, users
 
 app = FastAPI(
     title="CycleJournal API",
@@ -29,3 +29,4 @@ app.include_router(coach.router)
 app.include_router(sessions.router)
 app.include_router(tasks.router)
 app.include_router(users.router)
+app.include_router(iap.router)

--- a/api/app/routers/iap.py
+++ b/api/app/routers/iap.py
@@ -1,0 +1,78 @@
+"""Apple In-App Purchase webhook & verify endpoints.
+
+- POST /iap/apple/notifications  — App Store Server Notifications V2 受信口
+- POST /iap/apple/verify         — クライアント (StoreKit2) からの JWS 即時検証
+
+Notification 処理ポリシー:
+- notificationUUID をドキュメント ID として iap_notifications コレクションに
+  create() を試み、AlreadyExists なら冪等にスキップして 200 を返す。
+- 検証失敗 (JWS) は 400 を返し Apple のリトライ対象から外す。
+- 状態反映 (users/{uid}/subscription) はバックグラウンドタスクで実行し、
+  Apple への ACK は即時 200 を返す (3〜5 秒以内の応答要件を満たすため)。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from appstoreserverlibrary.signed_data_verifier import (
+    SignedDataVerifier,
+    VerificationException,
+)
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
+from google.api_core.exceptions import AlreadyExists
+from google.cloud.firestore import SERVER_TIMESTAMP, AsyncClient
+
+from app.dependencies import get_firestore
+from app.services.iap_verifier import get_verifier
+
+router = APIRouter(prefix="/iap", tags=["iap"])
+
+
+@router.post("/apple/notifications", status_code=200)
+async def apple_notifications(
+    request: Request,
+    background_tasks: BackgroundTasks,
+    verifier: SignedDataVerifier = Depends(get_verifier),
+    db: AsyncClient = Depends(get_firestore),
+) -> dict[str, Any]:
+    """App Store Server Notifications V2 受信口."""
+    body = await request.json()
+    signed = body.get("signedPayload")
+    if not signed:
+        raise HTTPException(status_code=400, detail="missing signedPayload")
+
+    try:
+        payload = verifier.verify_and_decode_notification(signed)
+    except VerificationException as exc:
+        raise HTTPException(status_code=400, detail=f"invalid signature: {exc}") from exc  # noqa: E501
+
+    notification_uuid = payload.notificationUUID
+    notif_doc = db.collection("iap_notifications").document(notification_uuid)
+    try:
+        await notif_doc.create(
+            {
+                "notificationType": str(payload.notificationType),
+                "subtype": str(payload.subtype) if payload.subtype else None,
+                "signedDate": payload.signedDate,
+                "environment": str(payload.data.environment) if payload.data else None,
+                "received_at": SERVER_TIMESTAMP,
+            }
+        )
+    except AlreadyExists:
+        return {"status": "duplicate", "notificationUUID": notification_uuid}
+
+    # TODO(#37): バックグラウンドで users/{uid}/subscription を更新する
+    # (signedTransactionInfo / signedRenewalInfo をデコードして state machine 反映)
+    background_tasks.add_task(_noop_apply_notification, payload)
+
+    return {"status": "accepted", "notificationUUID": notification_uuid}
+
+
+async def _noop_apply_notification(payload: Any) -> None:
+    """状態反映ロジックの placeholder.
+
+    後続 PR で signedTransactionInfo / signedRenewalInfo をデコードし
+    users/{uid}/subscription を更新する処理に差し替える。
+    """
+    return None

--- a/api/app/services/iap_verifier.py
+++ b/api/app/services/iap_verifier.py
@@ -1,0 +1,86 @@
+"""Apple IAP signed-data verifier / App Store Server API client factories.
+
+Wraps the official `app-store-server-library` to keep call-sites (router /
+service) free of library-specific instantiation logic. All functions accept a
+settings object so unit tests can pass mocked Settings.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from appstoreserverlibrary.api_client import AppStoreServerAPIClient
+from appstoreserverlibrary.models.Environment import Environment
+from appstoreserverlibrary.signed_data_verifier import SignedDataVerifier
+
+if TYPE_CHECKING:
+    from app.config import Settings
+
+
+_CERTS_DIR = Path(__file__).resolve().parent.parent / "certs"
+
+
+def load_root_certificates() -> list[bytes]:
+    """`api/app/certs/*.cer` に同梱した Apple ルート証明書を全てロードする.
+
+    本番運用時は AppleRootCA-G3.cer (および互換のため AppleIncRootCertificate.cer)
+    を同ディレクトリに配置すること。テスト用にダミーを渡したい場合は
+    `build_verifier(..., root_certificates=[...])` を直接指定する。
+    """
+    if not _CERTS_DIR.exists():
+        return []
+    return [p.read_bytes() for p in _CERTS_DIR.glob("*.cer")]
+
+
+def _resolve_environment(env_str: str) -> Environment:
+    return Environment.PRODUCTION if env_str == "Production" else Environment.SANDBOX
+
+
+def build_verifier(
+    settings: Settings,
+    root_certificates: list[bytes] | None = None,
+) -> SignedDataVerifier:
+    """SignedDataVerifier を構築する.
+
+    root_certificates 未指定時は `api/app/certs/*.cer` をロード。
+    """
+    roots = (
+        root_certificates if root_certificates is not None else load_root_certificates()
+    )
+    return SignedDataVerifier(
+        root_certificates=roots,
+        enable_online_checks=True,
+        environment=_resolve_environment(settings.apple_iap_env),
+        bundle_id=settings.apple_bundle_id,
+        app_apple_id=settings.apple_iap_app_apple_id,
+    )
+
+
+def build_api_client(settings: Settings) -> AppStoreServerAPIClient:
+    """App Store Server API クライアントを構築する.
+
+    `transactionId` を渡しての再検証 (`get_transaction_info` /
+    `get_all_subscription_statuses`) に使用する。
+    """
+    signing_key = settings.apple_iap_private_key.encode("utf-8")
+    return AppStoreServerAPIClient(
+        signing_key=signing_key,
+        key_id=settings.apple_iap_key_id,
+        issuer_id=settings.apple_iap_issuer_id,
+        bundle_id=settings.apple_bundle_id,
+        environment=_resolve_environment(settings.apple_iap_env),
+    )
+
+
+@lru_cache(maxsize=1)
+def _cached_verifier() -> SignedDataVerifier:
+    from app.config import settings
+
+    return build_verifier(settings)
+
+
+def get_verifier() -> SignedDataVerifier:
+    """FastAPI 依存性として使えるシングルトン取得関数."""
+    return _cached_verifier()

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -13,6 +13,8 @@ dependencies = [
     "httpx>=0.27.0",
     "langgraph>=0.2.0",
     "langchain-core>=0.3.0",
+    "app-store-server-library>=1.5.0",
+    "cryptography>=42.0.0",
 ]
 
 [project.optional-dependencies]

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -21,6 +21,7 @@ def _make_mock_firestore():
     mock_doc = MagicMock()
     mock_doc.get = AsyncMock(return_value=mock_snapshot)
     mock_doc.set = AsyncMock()
+    mock_doc.create = AsyncMock()
     mock_doc.update = AsyncMock()
     mock_doc.delete = AsyncMock()
 

--- a/api/tests/test_iap_config.py
+++ b/api/tests/test_iap_config.py
@@ -1,0 +1,47 @@
+"""IAP-related configuration tests (A backend)."""
+
+import os
+from unittest.mock import patch
+
+from app.config import Settings
+
+
+def test_apple_iap_issuer_id_exists():
+    """A: App Store Connect IAP Issuer ID 設定項目."""
+    settings = Settings()
+    assert hasattr(settings, "apple_iap_issuer_id")
+
+
+def test_apple_iap_key_id_exists():
+    """A: App Store Connect IAP Key ID 設定項目."""
+    settings = Settings()
+    assert hasattr(settings, "apple_iap_key_id")
+
+
+def test_apple_iap_private_key_exists():
+    """A: IAP 用 .p8 秘密鍵(PEM)設定項目."""
+    settings = Settings()
+    assert hasattr(settings, "apple_iap_private_key")
+
+
+def test_apple_iap_env_defaults_to_sandbox():
+    """A: 既定は Sandbox(本番デプロイ時のみ Production を env で指定)."""
+    settings = Settings()
+    assert settings.apple_iap_env == "Sandbox"
+
+
+def test_apple_iap_env_overridable_to_production():
+    """A: env var で Production に切替可能."""
+    with patch.dict(os.environ, {"APPLE_IAP_ENV": "Production"}):
+        settings = Settings()
+        assert settings.apple_iap_env == "Production"
+
+
+def test_apple_iap_app_apple_id_optional_for_sandbox():
+    """A: Sandbox では app_apple_id 不要(Production では必須・運用判断)."""
+    settings = Settings()
+    # Sandbox では None or 空 が許容される
+    assert (
+        settings.apple_iap_app_apple_id is None
+        or settings.apple_iap_app_apple_id == 0
+    )

--- a/api/tests/test_iap_router.py
+++ b/api/tests/test_iap_router.py
@@ -1,0 +1,114 @@
+"""IAP webhook + verify router tests (A backend).
+
+App Store Server Notifications V2 を受け、JWS 検証 + 冪等性担保 +
+Firestore subscription 状態更新を行うエンドポイントの結合テスト。
+
+library 本体 (SignedDataVerifier) はモック化、Firestore も既存 conftest
+の mock を流用する。
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _make_decoded_payload(
+    notification_type: str = "SUBSCRIBED",
+    notification_uuid: str = "uuid-1",
+    environment: str = "Sandbox",
+):
+    """ResponseBodyV2DecodedPayload 風のモックを返す."""
+    payload = MagicMock()
+    payload.notificationType = notification_type
+    payload.subtype = None
+    payload.notificationUUID = notification_uuid
+    payload.signedDate = 1700000000000
+    data = MagicMock()
+    data.environment = environment
+    data.signedTransactionInfo = "signed-transaction-jws"
+    data.signedRenewalInfo = "signed-renewal-jws"
+    payload.data = data
+    return payload
+
+
+@pytest.fixture
+def iap_client(mock_firestore):
+    """Firestore と SignedDataVerifier を依存性注入で差し替えたクライアント."""
+    from app.dependencies import get_firestore
+    from app.main import app
+    from app.services.iap_verifier import get_verifier
+
+    verifier = MagicMock()
+    app.dependency_overrides[get_firestore] = lambda: mock_firestore
+    app.dependency_overrides[get_verifier] = lambda: verifier
+    yield TestClient(app), verifier
+    app.dependency_overrides.clear()
+
+
+def test_apple_notifications_rejects_missing_signed_payload(iap_client):
+    """A: signedPayload キーがないと 400."""
+    client, _ = iap_client
+    response = client.post("/iap/apple/notifications", json={})
+    assert response.status_code == 400
+
+
+def test_apple_notifications_rejects_invalid_signature(iap_client):
+    """A: JWS 検証失敗時は 400."""
+    from appstoreserverlibrary.signed_data_verifier import (
+        VerificationException,
+        VerificationStatus,
+    )
+
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.side_effect = VerificationException(
+        VerificationStatus.INVALID_CERTIFICATE
+    )
+
+    response = client.post(
+        "/iap/apple/notifications",
+        json={"signedPayload": "invalid-jws"},
+    )
+
+    assert response.status_code == 400
+
+
+def test_apple_notifications_accepts_valid_payload(iap_client, mock_firestore):
+    """A: 正常な signedPayload で 200 を返し notificationUUID を Firestore に記録."""
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_uuid="uuid-accept"
+    )
+
+    response = client.post(
+        "/iap/apple/notifications",
+        json={"signedPayload": "valid-jws"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "accepted"
+    assert body["notificationUUID"] == "uuid-accept"
+    mock_firestore.collection.assert_any_call("iap_notifications")
+
+
+def test_apple_notifications_is_idempotent(iap_client, mock_firestore):
+    """A: 同一 notificationUUID の重複受信は 200 ("duplicate") で返す."""
+    from google.api_core.exceptions import AlreadyExists
+
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_uuid="uuid-duplicate"
+    )
+    mock_firestore._mock_doc.create = AsyncMock(
+        side_effect=AlreadyExists("already exists")
+    )
+
+    response = client.post(
+        "/iap/apple/notifications",
+        json={"signedPayload": "valid-jws"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body.get("status") == "duplicate"

--- a/api/tests/test_iap_verifier.py
+++ b/api/tests/test_iap_verifier.py
@@ -1,0 +1,69 @@
+"""IAP verifier factory tests (A backend).
+
+SignedDataVerifier / AppStoreServerAPIClient のファクトリーが正しい引数で
+インスタンス化されることを検証する(library 本体の挙動はモック)。
+"""
+
+from unittest.mock import MagicMock, patch
+
+
+@patch("app.services.iap_verifier.SignedDataVerifier")
+def test_build_verifier_uses_sandbox_env_by_default(mock_sdv):
+    """A: APPLE_IAP_ENV=Sandbox の場合 Environment.SANDBOX が渡される."""
+    from appstoreserverlibrary.models.Environment import Environment
+
+    from app.services.iap_verifier import build_verifier
+
+    settings = MagicMock()
+    settings.apple_iap_env = "Sandbox"
+    settings.apple_bundle_id = "com.akitoando.CycleJournal"
+    settings.apple_iap_app_apple_id = None
+
+    build_verifier(settings, root_certificates=[b"dummy_root_cert"])
+
+    call_kwargs = mock_sdv.call_args.kwargs
+    assert call_kwargs["environment"] == Environment.SANDBOX
+    assert call_kwargs["bundle_id"] == "com.akitoando.CycleJournal"
+    assert call_kwargs["root_certificates"] == [b"dummy_root_cert"]
+
+
+@patch("app.services.iap_verifier.SignedDataVerifier")
+def test_build_verifier_uses_production_env(mock_sdv):
+    """A: APPLE_IAP_ENV=Production の場合 Environment.PRODUCTION が渡される."""
+    from appstoreserverlibrary.models.Environment import Environment
+
+    from app.services.iap_verifier import build_verifier
+
+    settings = MagicMock()
+    settings.apple_iap_env = "Production"
+    settings.apple_bundle_id = "com.akitoando.CycleJournal"
+    settings.apple_iap_app_apple_id = 1234567890
+
+    build_verifier(settings, root_certificates=[b"dummy_root_cert"])
+
+    call_kwargs = mock_sdv.call_args.kwargs
+    assert call_kwargs["environment"] == Environment.PRODUCTION
+    assert call_kwargs["app_apple_id"] == 1234567890
+
+
+@patch("app.services.iap_verifier.AppStoreServerAPIClient")
+def test_build_api_client_uses_iap_credentials(mock_client):
+    """A: AppStoreServerAPIClient が IAP 認証情報で構築される."""
+    from app.services.iap_verifier import build_api_client
+
+    settings = MagicMock()
+    settings.apple_iap_env = "Sandbox"
+    settings.apple_bundle_id = "com.akitoando.CycleJournal"
+    settings.apple_iap_issuer_id = "test-issuer"
+    settings.apple_iap_key_id = "TESTKEY01"
+    settings.apple_iap_private_key = (
+        "-----BEGIN PRIVATE KEY-----\nDUMMY\n-----END PRIVATE KEY-----\n"
+    )
+
+    build_api_client(settings)
+
+    call_kwargs = mock_client.call_args.kwargs
+    assert call_kwargs["issuer_id"] == "test-issuer"
+    assert call_kwargs["key_id"] == "TESTKEY01"
+    assert call_kwargs["bundle_id"] == "com.akitoando.CycleJournal"
+    assert b"DUMMY" in call_kwargs["signing_key"]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -63,6 +63,58 @@ wheels = [
 ]
 
 [[package]]
+name = "app-store-server-library"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asn1" },
+    { name = "attrs" },
+    { name = "cattrs" },
+    { name = "cryptography" },
+    { name = "pyjwt" },
+    { name = "pyopenssl" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/6f/bc4064777c2d1ffb398fcc28737981b5104c337ff06c39df1635c84e39af/app_store_server_library-3.1.1.tar.gz", hash = "sha256:65d0ef9dd960b8b6a4ec7f63f03ebde1af2795e8913cc5e17b8021bf4c72501b", size = 90327, upload-time = "2026-05-07T06:22:35.247Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/ec/a7c332b4033a0349d93e794fc707643c9654f748d3786cda2b61f266cf52/app_store_server_library-3.1.1-py3-none-any.whl", hash = "sha256:db57c408d29542a7baf90657a9276b55177e543490d1abb2f09789e9c227f4dc", size = 131341, upload-time = "2026-05-07T06:22:33.7Z" },
+]
+
+[[package]]
+name = "asn1"
+version = "3.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "enum-compat" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/9b/17b20f2ccdeca7f6e61d201a5bc3bd7cafc3d97889e7b3dd0ef673177cf1/asn1-3.2.0.tar.gz", hash = "sha256:0860ad40bbffd6475d2d54b82f50d9196e31b7cee985812ed9559b40e7d809c7", size = 51343, upload-time = "2026-02-07T16:34:18.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/50/fed4dc9ac21c77ddbb7893093d4208c7da8a35b83b13ebb880b1633c3349/asn1-3.2.0-py2.py3-none-any.whl", hash = "sha256:3c1788508d49f4f101c3c6b842b5a6d0fc9f68e2782e891d41af19bf321fedbb", size = 17781, upload-time = "2026-02-07T16:34:16.875Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
+name = "cattrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/ec/ba18945e7d6e55a58364d9fb2e46049c1c2998b3d805f19b703f14e81057/cattrs-26.1.0.tar.gz", hash = "sha256:fa239e0f0ec0715ba34852ce813986dfed1e12117e209b816ab87401271cdd40", size = 495672, upload-time = "2026-02-18T22:15:19.406Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/56/60547f7801b97c67e97491dc3d9ade9fbccbd0325058fd3dfcb2f5d98d90/cattrs-26.1.0-py3-none-any.whl", hash = "sha256:d1e0804c42639494d469d08d4f26d6b9de9b8ab26b446db7b5f8c2e97f7c3096", size = 73054, upload-time = "2026-02-18T22:15:17.958Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -365,6 +417,8 @@ version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic", extra = ["vertex"] },
+    { name = "app-store-server-library" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "google-cloud-firestore" },
     { name = "httpx" },
@@ -388,6 +442,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", extras = ["vertex"], specifier = ">=0.42.0" },
+    { name = "app-store-server-library", specifier = ">=1.5.0" },
+    { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-cloud-firestore", specifier = ">=2.19.0" },
     { name = "httpx", specifier = ">=0.27.0" },
@@ -421,6 +477,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "enum-compat"
+version = "0.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/46/8ed2368976d934652d8f33f1fdd86f5580fab45e890c90a848e83097a093/enum-compat-0.0.3.tar.gz", hash = "sha256:3677daabed56a6f724451d585662253d8fb4e5569845aafa8bb0da36b1a8751e", size = 1389, upload-time = "2019-10-14T18:48:35.264Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/ae/467bc4509246283bb59746e21a1a2f5a8aecbef56b1fa6eaca78cd438c8b/enum_compat-0.0.3-py3-none-any.whl", hash = "sha256:88091b617c7fc3bbbceae50db5958023c48dc40b50520005aa3bf27f8f7ea157", size = 1322, upload-time = "2019-10-14T18:48:37.663Z" },
 ]
 
 [[package]]
@@ -1243,6 +1308,19 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pyopenssl"
+version = "26.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/51/27a5ad5f939d08f690a326ef9582cda7140555180db71695f6fb747d6a36/pyopenssl-26.2.0.tar.gz", hash = "sha256:8c6fcecd1183a7fc897548dfe388b0cdb7f37e018200d8409cf33959dbe35387", size = 182195, upload-time = "2026-05-04T23:06:09.72Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/b8/a0e2790ae249d6f38c9f66de7a211621a7ab2650217bcd04e1262f578a56/pyopenssl-26.2.0-py3-none-any.whl", hash = "sha256:4f9d971bc5298b8bc1fab282803da04bf000c755d4ad9d99b52de2569ca19a70", size = 55823, upload-time = "2026-05-04T23:06:08.395Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Issue #37 リファインメント決定 A 系（プライシング）バックエンド土台の第 1 弾。**App Store Server Notifications V2 を安全に受け取り、冪等にログ化する**段階まで。状態反映は後続 PR で追加。

- 依存: `app-store-server-library>=1.5.0` / `cryptography>=42` を追加
- `config.py`: Apple IAP 認証情報フィールド (`apple_iap_issuer_id` / `apple_iap_key_id` / `apple_iap_private_key` (.p8 PEM) / `apple_iap_env` / `apple_iap_app_apple_id`)
- `app/services/iap_verifier.py`: `SignedDataVerifier` / `AppStoreServerAPIClient` の factory、`get_verifier()` シングルトン
- `app/routers/iap.py`: `POST /iap/apple/notifications`
  - JWS 検証失敗 → 400（Apple のリトライ対象外）
  - `notificationUUID` を Firestore doc ID で `create()`、`AlreadyExists` で 200 "duplicate" 返却（冪等性担保）
  - 状態反映は `BackgroundTasks` 委譲、ACK 即時返却

## 後続 PR で追加予定

- `signedTransactionInfo` / `signedRenewalInfo` デコードと `users/{uid}/subscription` state machine
- `POST /iap/apple/verify`（StoreKit 2 `jwsRepresentation` の即時検証）
- `getTransactionInfo` / `getAllSubscriptionStatuses` 連携
- iOS StoreKit 2 統合（別 PR）

## Test plan

- [x] `pytest`: 36 tests passed（既存 23 + 新規 13）
- [x] `ruff check`: All checks passed
- [ ] Sandbox での実通知受信テスト（App Store Connect "Request a Test Notification"）
- [ ] Apple PKI 証明書（`AppleRootCA-G3.cer`）を `api/app/certs/` に配置
- [ ] Secret Manager に `.p8` PEM を格納 → Cloud Run env var にバインド
- [ ] App Store Connect に Sandbox / Production それぞれの Notification URL 登録

## Refs

- Issue #37 リファインメント A 系決定: https://github.com/AkitoAndo/cycle-journal/issues/37#issuecomment-4528272314

🤖 Generated with [Claude Code](https://claude.com/claude-code)