### PR TITLE
feat: #37 GA4 Measurement Protocol server-side イベント送信サービス

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -48,6 +48,14 @@ class Settings(BaseSettings):
     apple_iap_env: str = "Sandbox"
     apple_iap_app_apple_id: int | None = None
 
+    # GA4 Measurement Protocol (サーバーサイドからのイベント送信用)
+    # - GA4 Admin → Data Streams → 該当 iOS stream → Measurement Protocol API secrets
+    #   で API secret を発行し Secret Manager 経由で注入する
+    # - measurement_id / api_secret が空のときは send_event は no-op
+    ga4_measurement_id: str = ""
+    ga4_api_secret: str = ""
+    ga4_endpoint: str = "https://www.google-analytics.com/mp/collect"
+
     model_config = {"env_prefix": "", "case_sensitive": False}
 
 

--- a/api/app/services/analytics_service.py
+++ b/api/app/services/analytics_service.py
@@ -1,0 +1,75 @@
+"""GA4 Measurement Protocol — server-side event ingestion.
+
+Apple App Store Server Notifications V2 受信時など、クライアント iOS では
+発火できないサブスクリプション系イベント (trial_converted_to_paid /
+subscription_renewed / subscription_cancelled / subscription_refunded /
+trial_expired_without_conversion) を GA4 にサーバーから送信する。
+
+設計方針:
+- ga4_measurement_id / ga4_api_secret が未設定なら no-op (開発・テスト環境)
+- ネットワーク例外は握り潰す (Apple Webhook の ACK を遅らせない・落とさない)
+- params に event_id を入れることで GA4 側で重複排除可能にする
+  (Apple ASSN の notificationUUID を渡せば再送に強い)
+
+References:
+- https://developers.google.com/analytics/devguides/collection/protocol/ga4
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.config import settings
+
+
+async def send_event(
+    *,
+    client_id: str,
+    event_name: str,
+    params: dict[str, Any],
+    event_id: str | None = None,
+    user_id: str | None = None,
+) -> dict[str, Any] | None:
+    """GA4 にサーバーサイドイベントを 1 件送信する.
+
+    Args:
+        client_id: GA4 の client_id (iOS の Firebase Installations ID と紐付ける)
+        event_name: 例 "trial_converted_to_paid"
+        params: イベントパラメータ (product_id, revenue_jpy, paywall_variant 等)
+        event_id: 冪等性キー (Apple ASSN notificationUUID 等)。GA4 で重複排除に利用
+        user_id: 認証済みユーザー ID (App user_id property として送信)
+
+    Returns:
+        送信成功時はレスポンス JSON (debug endpoint の場合)、no-op / 失敗時は None
+    """
+    if not settings.ga4_measurement_id or not settings.ga4_api_secret:
+        return None
+
+    body_params = dict(params)
+    if event_id is not None:
+        body_params["event_id"] = event_id
+
+    payload: dict[str, Any] = {
+        "client_id": client_id,
+        "events": [{"name": event_name, "params": body_params}],
+    }
+    if user_id is not None:
+        payload["user_id"] = user_id
+
+    url = (
+        f"{settings.ga4_endpoint}"
+        f"?measurement_id={settings.ga4_measurement_id}"
+        f"&api_secret={settings.ga4_api_secret}"
+    )
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            resp = await client.post(url, json=payload)
+            resp.raise_for_status()
+    except (httpx.HTTPError, httpx.NetworkError):
+        # Webhook 処理を止めない: GA4 への送信失敗は ASSN 応答に影響させない
+        return None
+
+    return None

--- a/api/tests/test_analytics_config.py
+++ b/api/tests/test_analytics_config.py
@@ -1,0 +1,35 @@
+"""GA4 Measurement Protocol 設定テスト (C-3 backend)."""
+
+import os
+from unittest.mock import patch
+
+from app.config import Settings
+
+
+def test_ga4_measurement_id_exists():
+    """C-3: GA4 Measurement ID 設定項目."""
+    settings = Settings()
+    assert hasattr(settings, "ga4_measurement_id")
+
+
+def test_ga4_api_secret_exists():
+    """C-3: GA4 Measurement Protocol API Secret 設定項目."""
+    settings = Settings()
+    assert hasattr(settings, "ga4_api_secret")
+
+
+def test_ga4_endpoint_defaults_to_production():
+    """C-3: 既定エンドポイントは https://www.google-analytics.com/mp/collect."""
+    settings = Settings()
+    assert settings.ga4_endpoint.startswith("https://www.google-analytics.com")
+
+
+def test_ga4_overridable_via_env():
+    """C-3: env var で上書き可能(本番/デバッグエンドポイント切替用)."""
+    with patch.dict(
+        os.environ,
+        {"GA4_MEASUREMENT_ID": "G-TEST123", "GA4_API_SECRET": "secret-xyz"},
+    ):
+        settings = Settings()
+        assert settings.ga4_measurement_id == "G-TEST123"
+        assert settings.ga4_api_secret == "secret-xyz"

--- a/api/tests/test_analytics_service.py
+++ b/api/tests/test_analytics_service.py
@@ -1,0 +1,113 @@
+"""GA4 Measurement Protocol sender tests (C-3 backend).
+
+サーバーサイドで `trial_converted_to_paid` / `subscription_renewed` 等の
+サブスクイベントを GA4 に送信するサービスのテスト。httpx は完全にモック化。
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_send_event_posts_to_measurement_protocol():
+    """C-3: send_event は GA4 Measurement Protocol に POST する."""
+    from app.services import analytics_service
+    from app.services.analytics_service import send_event
+
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+    mock_response.raise_for_status = MagicMock()
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(analytics_service.settings, "ga4_measurement_id", "G-TEST123"),
+        patch.object(analytics_service.settings, "ga4_api_secret", "secret-xyz"),
+        patch(
+            "app.services.analytics_service.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        await send_event(
+            client_id="user-abc",
+            event_name="trial_converted_to_paid",
+            params={"product_id": "yearly_14400", "revenue_jpy": 14400},
+            event_id="notif-uuid-1",
+        )
+
+    mock_client.post.assert_awaited_once()
+    call = mock_client.post.call_args
+    url = call.args[0]
+    assert "/mp/collect" in url
+    assert "measurement_id=" in url
+    assert "api_secret=" in url
+    body = call.kwargs["json"]
+    assert body["client_id"] == "user-abc"
+    assert len(body["events"]) == 1
+    event = body["events"][0]
+    assert event["name"] == "trial_converted_to_paid"
+    assert event["params"]["product_id"] == "yearly_14400"
+    assert event["params"]["revenue_jpy"] == 14400
+    # 冪等化キー (Apple ASSN の notificationUUID 等) は event params に含める
+    assert event["params"]["event_id"] == "notif-uuid-1"
+
+
+@pytest.mark.asyncio
+async def test_send_event_skips_when_not_configured():
+    """C-3: ga4_measurement_id / ga4_api_secret 未設定なら何もしない(no-op)."""
+    from app.services import analytics_service
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(analytics_service.settings, "ga4_measurement_id", ""),
+        patch.object(analytics_service.settings, "ga4_api_secret", ""),
+        patch(
+            "app.services.analytics_service.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        await analytics_service.send_event(
+            client_id="user-x",
+            event_name="trial_started",
+            params={},
+        )
+
+    mock_client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_event_swallows_network_errors():
+    """C-3: ネットワークエラーで Webhook 処理を止めないため例外を握り潰す."""
+    import httpx
+
+    from app.services import analytics_service
+    from app.services.analytics_service import send_event
+
+    mock_client = MagicMock()
+    mock_client.post = AsyncMock(side_effect=httpx.NetworkError("boom"))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch.object(analytics_service.settings, "ga4_measurement_id", "G-TEST"),
+        patch.object(analytics_service.settings, "ga4_api_secret", "secret"),
+        patch(
+            "app.services.analytics_service.httpx.AsyncClient",
+            return_value=mock_client,
+        ),
+    ):
+        # 例外が再送出されず None で返ることを確認
+        result = await send_event(
+            client_id="user-x",
+            event_name="trial_started",
+            params={},
+        )
+
+    assert result is None


### PR DESCRIPTION
## Summary

Issue #37 C-3（Analytics）バックエンド土台。**Apple ASSN V2 受信時に GA4 へサーバーサイドでサブスクイベントを送る基盤**。

- `config.py`: `ga4_measurement_id` / `ga4_api_secret` / `ga4_endpoint`
- `app/services/analytics_service.py`: 非同期 `send_event(client_id, event_name, params, event_id, user_id)`
  - 未設定時 no-op、ネットワーク例外は握り潰し（ASSN ACK を止めない）
  - `event_id` を params 同梱で GA4 重複排除（Apple `notificationUUID` 等）

## 用途
PR #43（IAP webhook）の続編で `DID_RENEW` / `EXPIRED` / `REVOKE` 等の受信時に呼び、以下を送信:
- `trial_converted_to_paid` / `trial_expired_without_conversion`
- `subscription_renewed` / `subscription_cancelled` / `subscription_refunded`

## Test plan

- [x] `pytest`: 30 passed（新規 7 + 既存 23）
- [x] `ruff check`: All checks passed（変更ファイル）
- [ ] GA4 Admin で Measurement Protocol API secret 発行 → Secret Manager
- [ ] iOS Firebase SDK 統合（別 PR）で client_id 紐付け
- [ ] BigQuery export 有効化 → Looker Studio ダッシュボード

## Refs
- Issue #37 C 系決定: https://github.com/AkitoAndo/cycle-journal/issues/37#issuecomment-4528348152

🤖 Generated with [Claude Code](https://claude.com/claude-code)