### PR TITLE
feat: #37 iOS StoreKit 2 統合 (SubscriptionStore + Paywall)

### DIFF
--- a/ios/Cycle/Features/Subscription/Models/SubscriptionProduct.swift
+++ b/ios/Cycle/Features/Subscription/Models/SubscriptionProduct.swift
@@ -1,0 +1,38 @@
+//
+//  SubscriptionProduct.swift
+//  CycleJournal
+//
+//  Issue #37 A 系: プロダクト ID とトライアル適用範囲の定義
+//
+
+import Foundation
+
+/// App Store Connect で作成するサブスクリプション商品。
+///
+/// - `monthly_1800`: ¥1,800/月 (Intro Offer なし、Calm 型: 月額は即課金)
+/// - `yearly_14400`: ¥14,400/年 (7-day Free Trial Intro Offer 付き)
+///
+/// 命名は App Store Connect のプロダクト ID と完全一致させること。
+/// 変更時は App Store Connect 側と本 enum の両方を必ずセットで更新。
+enum SubscriptionProductID: String, CaseIterable {
+    case monthly = "com.akitoando.CycleJournal.monthly_1800"
+    case yearly = "com.akitoando.CycleJournal.yearly_14400"
+
+    /// 7-day Free Trial Intro Offer を持つか。
+    ///
+    /// Issue #37 A-1 決定: yearly のみトライアル付き (LTV の高い年額に集中)。
+    var supportsIntroductoryOffer: Bool {
+        switch self {
+        case .yearly: return true
+        case .monthly: return false
+        }
+    }
+
+    /// 表示順 (Paywall で年額を上位に出す)。
+    var displayOrder: Int {
+        switch self {
+        case .yearly: return 0
+        case .monthly: return 1
+        }
+    }
+}

--- a/ios/Cycle/Features/Subscription/Models/SubscriptionState.swift
+++ b/ios/Cycle/Features/Subscription/Models/SubscriptionState.swift
@@ -1,0 +1,47 @@
+//
+//  SubscriptionState.swift
+//  CycleJournal
+//
+//  Issue #37 A 系: ユーザーのサブスクリプション状態を一元管理する値型。
+//
+
+import Foundation
+
+/// StoreKit 2 `Transaction.currentEntitlements` から導出される状態。
+///
+/// `hasEntitlement` がプロダクト機能解放の判定に使われ、
+/// `trialDay(purchaseDate:now:)` で Day1/3/6/7 通知 (#37 C-2) の起点判定に使う。
+enum SubscriptionState: Equatable {
+    /// 初期状態 (StoreKit 復元処理が完了する前)。
+    case unknown
+
+    /// 未契約 (トライアル経験なし or トライアル済みで未復帰)。
+    case notSubscribed
+
+    /// トライアル中。`expiresAt` は Apple が決めるトライアル終了時刻 (purchaseDate + 7日)。
+    case trial(productID: String, expiresAt: Date)
+
+    /// 有料アクティブ (トライアル後の課金成功 or 即時課金プラン)。
+    case active(productID: String, expiresAt: Date)
+
+    /// 期限切れ (契約完了後、解約 or 払戻し or 自動更新失敗)。
+    case expired
+
+    /// 有料機能を解放するか。
+    var hasEntitlement: Bool {
+        switch self {
+        case .trial, .active: return true
+        case .unknown, .notSubscribed, .expired: return false
+        }
+    }
+
+    /// トライアル開始からの経過日数 (0 起点)。
+    ///
+    /// 1 日 = 86400 秒 で割って int 化。同日内は 0、24 時間経過で 1、72 時間で 3。
+    /// `now` を引数化することでテスト時に時間を固定できる。
+    static func trialDay(purchaseDate: Date, now: Date = Date()) -> Int {
+        let elapsed = now.timeIntervalSince(purchaseDate)
+        guard elapsed >= 0 else { return 0 }
+        return Int(elapsed / 86400.0)
+    }
+}

--- a/ios/Cycle/Features/Subscription/Store/SubscriptionStore.swift
+++ b/ios/Cycle/Features/Subscription/Store/SubscriptionStore.swift
@@ -1,0 +1,123 @@
+//
+//  SubscriptionStore.swift
+//  CycleJournal
+//
+//  Issue #37 A 系 (iOS StoreKit 2 統合)
+//
+//  - Transaction.currentEntitlements で起動時にエンタイトルメント復元
+//  - Transaction.updates リスナーで自動更新 / Family Sharing / refund 反映
+//  - 購入 → jwsRepresentation をバックエンドに渡して即時検証 (TODO 後続 PR)
+//
+
+import Combine
+import Foundation
+import StoreKit
+
+@MainActor
+final class SubscriptionStore: ObservableObject {
+    @Published private(set) var state: SubscriptionState = .unknown
+    @Published private(set) var products: [Product] = []
+    @Published private(set) var isLoading: Bool = false
+    @Published var error: String?
+
+    private var updatesTask: Task<Void, Never>?
+
+    init() {
+        updatesTask = Task { [weak self] in
+            await self?.listenForTransactionUpdates()
+        }
+    }
+
+    deinit {
+        updatesTask?.cancel()
+    }
+
+    // MARK: - Product loading
+
+    /// App Store からプロダクト情報を取得する。
+    func loadProducts() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        let ids = SubscriptionProductID.allCases.map(\.rawValue)
+        do {
+            let fetched = try await Product.products(for: Set(ids))
+            products = fetched.sorted { lhs, rhs in
+                let li = SubscriptionProductID(rawValue: lhs.id)?.displayOrder ?? .max
+                let ri = SubscriptionProductID(rawValue: rhs.id)?.displayOrder ?? .max
+                return li < ri
+            }
+        } catch {
+            self.error = "プロダクト情報の取得に失敗しました: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - Entitlement refresh
+
+    /// 現在のエンタイトルメントを `state` に反映する。
+    func refreshEntitlements() async {
+        var latest: SubscriptionState = .notSubscribed
+        for await result in Transaction.currentEntitlements {
+            guard case .verified(let transaction) = result else { continue }
+            if let expires = transaction.expirationDate, expires < Date() {
+                continue
+            }
+            // iOS 17.0+ で offerType を見る (paymentMode 直接アクセスは 17.2+)
+            let isTrial = transaction.offerType == .introductory
+            let expiresAt = transaction.expirationDate ?? Date.distantFuture
+            latest = isTrial
+                ? .trial(productID: transaction.productID, expiresAt: expiresAt)
+                : .active(productID: transaction.productID, expiresAt: expiresAt)
+        }
+        state = latest
+    }
+
+    // MARK: - Purchase
+
+    /// プロダクトを購入。成功時にエンタイトルメント反映、jwsRepresentation を返す
+    /// (バックエンド検証用; 呼び出し側で API 送信)。
+    @discardableResult
+    func purchase(_ product: Product) async throws -> String? {
+        let result = try await product.purchase()
+        switch result {
+        case .success(let verification):
+            switch verification {
+            case .verified(let transaction):
+                await refreshEntitlements()
+                await transaction.finish()
+                return verification.jwsRepresentation
+            case .unverified:
+                throw SubscriptionError.unverifiedTransaction
+            }
+        case .userCancelled:
+            return nil
+        case .pending:
+            return nil
+        @unknown default:
+            return nil
+        }
+    }
+
+    // MARK: - Transaction.updates listener
+
+    private func listenForTransactionUpdates() async {
+        for await result in Transaction.updates {
+            guard case .verified(let transaction) = result else { continue }
+            await refreshEntitlements()
+            await transaction.finish()
+        }
+    }
+}
+
+// MARK: - Errors
+
+enum SubscriptionError: LocalizedError {
+    case unverifiedTransaction
+
+    var errorDescription: String? {
+        switch self {
+        case .unverifiedTransaction:
+            return "購入の検証に失敗しました。サポートまでお問い合わせください。"
+        }
+    }
+}

--- a/ios/Cycle/Features/Subscription/Views/PaywallView.swift
+++ b/ios/Cycle/Features/Subscription/Views/PaywallView.swift
@@ -1,0 +1,229 @@
+//
+//  PaywallView.swift
+//  CycleJournal
+//
+//  Issue #37 A-1 / C-1 決定: Apple Introductory Offer (yearly 7日無料) を提示する
+//  Timeline 型 Paywall。
+//
+//  - Day 0「今すぐ全機能」
+//  - Day 5「リマインド」
+//  - Day 7「自動課金」
+//
+//  Review Guideline 2026 強化下の必須要件:
+//  - 価格・課金周期 16pt 以上
+//  - "first 7 days free, then ¥14,400/year" を価格直下
+//  - Restore Purchases / Terms / Privacy リンク
+//  - Toggle UI は使わない
+//
+
+import StoreKit
+import SwiftUI
+
+struct PaywallView: View {
+    @StateObject private var store = SubscriptionStore()
+    @Environment(\.dismiss) private var dismiss
+    @State private var selectedProductID: String = SubscriptionProductID.yearly.rawValue
+    @State private var isPurchasing = false
+
+    /// 規約・プライバシーポリシー URL (App Store Connect と同一の URL を入れること)
+    let termsURL = URL(string: "https://cycle-journal.example.com/terms")!
+    let privacyURL = URL(string: "https://cycle-journal.example.com/privacy")!
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 28) {
+                header
+                trialTimeline
+                planList
+                primaryCTA
+                footer
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 32)
+        }
+        .background(Color(.systemBackground))
+        .task {
+            await store.loadProducts()
+            await store.refreshEntitlements()
+        }
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "tree.fill")
+                .font(.system(size: 48))
+                .foregroundStyle(.green)
+            Text("Cycle Premium")
+                .font(.system(size: 28, weight: .bold))
+            Text("自分と向き合う時間を、もっと深く。")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    private var trialTimeline: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            timelineRow(
+                icon: "checkmark.circle.fill",
+                color: .green,
+                title: "今すぐ",
+                subtitle: "Premium 機能をすべて開放"
+            )
+            timelineRow(
+                icon: "bell.fill",
+                color: .orange,
+                title: "Day 5",
+                subtitle: "トライアル終了 2 日前にお知らせ"
+            )
+            timelineRow(
+                icon: "creditcard.fill",
+                color: .blue,
+                title: "Day 7",
+                subtitle: "¥14,400 自動課金 (いつでも解約可)"
+            )
+        }
+        .padding(20)
+        .background(Color(.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func timelineRow(icon: String, color: Color, title: String, subtitle: String) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: icon)
+                .font(.system(size: 22))
+                .foregroundStyle(color)
+                .frame(width: 28)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).font(.headline)
+                Text(subtitle).font(.subheadline).foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var planList: some View {
+        if store.isLoading {
+            ProgressView().padding(.vertical, 24)
+        } else if store.products.isEmpty {
+            Text("プロダクト情報を取得できませんでした")
+                .foregroundStyle(.secondary)
+                .padding(.vertical, 24)
+        } else {
+            VStack(spacing: 12) {
+                ForEach(store.products, id: \.id) { product in
+                    planRow(product)
+                }
+            }
+        }
+    }
+
+    private func planRow(_ product: Product) -> some View {
+        let id = SubscriptionProductID(rawValue: product.id)
+        let isSelected = product.id == selectedProductID
+        let isYearly = id == .yearly
+
+        return Button {
+            selectedProductID = product.id
+        } label: {
+            HStack(alignment: .center, spacing: 16) {
+                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+                    .font(.system(size: 22))
+                    .foregroundStyle(isSelected ? .green : .secondary)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(spacing: 8) {
+                        Text(isYearly ? "年額プラン" : "月額プラン")
+                            .font(.system(size: 18, weight: .semibold))
+                        if isYearly {
+                            Text("おすすめ")
+                                .font(.caption2.bold())
+                                .padding(.horizontal, 8)
+                                .padding(.vertical, 2)
+                                .background(Color.green.opacity(0.15))
+                                .foregroundStyle(.green)
+                                .clipShape(Capsule())
+                        }
+                    }
+                    Text(product.displayPrice + (isYearly ? "/年" : "/月"))
+                        .font(.system(size: 16, weight: .semibold))
+                    if isYearly {
+                        Text("最初の 7 日間無料、その後 \(product.displayPrice)/年")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                Spacer()
+            }
+            .padding(16)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(isSelected ? Color.green : Color(.separator), lineWidth: isSelected ? 2 : 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var primaryCTA: some View {
+        Button {
+            Task { await beginPurchase() }
+        } label: {
+            HStack {
+                if isPurchasing { ProgressView().tint(.white).padding(.trailing, 8) }
+                Text(selectedProductID == SubscriptionProductID.yearly.rawValue ? "7日間無料で始める" : "購入する")
+                    .font(.system(size: 18, weight: .semibold))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 16)
+            .background(Color.green)
+            .foregroundStyle(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .disabled(isPurchasing || store.products.isEmpty)
+    }
+
+    private var footer: some View {
+        VStack(spacing: 8) {
+            Button("購入を復元") {
+                Task {
+                    await store.refreshEntitlements()
+                }
+            }
+            .font(.footnote)
+
+            HStack(spacing: 16) {
+                Link("利用規約", destination: termsURL).font(.footnote)
+                Link("プライバシーポリシー", destination: privacyURL).font(.footnote)
+            }
+            .foregroundStyle(.secondary)
+
+            Text("サブスクリプションは自動更新されます。解約は設定アプリ → Apple ID → サブスクリプションから行えます。")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.top, 8)
+    }
+
+    // MARK: - Purchase
+
+    private func beginPurchase() async {
+        guard let product = store.products.first(where: { $0.id == selectedProductID }) else { return }
+        isPurchasing = true
+        defer { isPurchasing = false }
+        do {
+            if let _ = try await store.purchase(product) {
+                // 購入成功 → エンタイトルメント反映済、ここで Paywall を閉じる
+                dismiss()
+            }
+        } catch {
+            store.error = error.localizedDescription
+        }
+    }
+}
+
+#Preview {
+    PaywallView()
+}

--- a/ios/CycleTests/SubscriptionTests.swift
+++ b/ios/CycleTests/SubscriptionTests.swift
@@ -1,0 +1,83 @@
+//
+//  SubscriptionTests.swift
+//  CycleTests
+//
+//  Issue #37 A 系 (iOS StoreKit2) - SubscriptionState / Product ID 周りの単体テスト
+//
+
+import Foundation
+import Testing
+
+@testable import Cycle
+
+// MARK: - SubscriptionProduct
+
+struct SubscriptionProductTests {
+    @Test func monthlyProductIdMatchesAppStoreConnect() {
+        #expect(SubscriptionProductID.monthly.rawValue == "com.akitoando.CycleJournal.monthly_1800")
+    }
+
+    @Test func yearlyProductIdMatchesAppStoreConnect() {
+        #expect(SubscriptionProductID.yearly.rawValue == "com.akitoando.CycleJournal.yearly_14400")
+    }
+
+    @Test func allProductIdsAreEnumerated() {
+        // 価格・トライアル設計の決定箇所(issue #37 A-1)に追従しているか
+        let all = SubscriptionProductID.allCases.map(\.rawValue)
+        #expect(all.contains("com.akitoando.CycleJournal.monthly_1800"))
+        #expect(all.contains("com.akitoando.CycleJournal.yearly_14400"))
+        #expect(all.count == 2)
+    }
+
+    @Test func yearlyIsTrialEligible() {
+        // A-1 決定: yearly のみ 7-day Free Trial Intro Offer を設定
+        #expect(SubscriptionProductID.yearly.supportsIntroductoryOffer == true)
+        #expect(SubscriptionProductID.monthly.supportsIntroductoryOffer == false)
+    }
+}
+
+// MARK: - SubscriptionState
+
+struct SubscriptionStateTests {
+    @Test func unknownHasNoEntitlement() {
+        #expect(SubscriptionState.unknown.hasEntitlement == false)
+    }
+
+    @Test func notSubscribedHasNoEntitlement() {
+        #expect(SubscriptionState.notSubscribed.hasEntitlement == false)
+    }
+
+    @Test func expiredHasNoEntitlement() {
+        #expect(SubscriptionState.expired.hasEntitlement == false)
+    }
+
+    @Test func trialHasEntitlement() {
+        let s = SubscriptionState.trial(
+            productID: "com.akitoando.CycleJournal.yearly_14400",
+            expiresAt: Date().addingTimeInterval(86400 * 7)
+        )
+        #expect(s.hasEntitlement == true)
+    }
+
+    @Test func activeHasEntitlement() {
+        let s = SubscriptionState.active(
+            productID: "com.akitoando.CycleJournal.yearly_14400",
+            expiresAt: Date().addingTimeInterval(86400 * 365)
+        )
+        #expect(s.hasEntitlement == true)
+    }
+
+    @Test func trialReportsDayCountFromPurchase() {
+        // Day1/Day3/Day6/Day7 通知 (#37 C-2) の起点判定に使う
+        let purchaseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let now = purchaseDate.addingTimeInterval(86400 * 3 + 3600) // Day 3 + 1h
+        let day = SubscriptionState.trialDay(purchaseDate: purchaseDate, now: now)
+        #expect(day == 3)
+    }
+
+    @Test func trialDayZeroOnPurchaseDay() {
+        let purchaseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        let now = purchaseDate.addingTimeInterval(3600) // 1h 後
+        #expect(SubscriptionState.trialDay(purchaseDate: purchaseDate, now: now) == 0)
+    }
+}


### PR DESCRIPTION
## Summary

Issue #37 リファインメント決定 A 系の iOS 実装。

- `SubscriptionProductID`: `monthly_1800` / `yearly_14400`、yearly のみ Intro Offer 適格
- `SubscriptionState`: unknown / notSubscribed / trial / active / expired + `hasEntitlement` + `trialDay(purchaseDate:now:)`
- `SubscriptionStore` (@MainActor):
  - `Transaction.currentEntitlements` 起動時復元
  - `Transaction.updates` リスナー（自動更新・refund・Family Sharing）
  - `purchase` 成功時に `jwsRepresentation` 返却（バックエンド検証用）
- `PaywallView`: Apple Review 2026 準拠、Timeline 型、年額デフォルト、Restore/Terms/Privacy

## Test plan

- [x] `xcodebuild`: BUILD SUCCEEDED
- [x] SubscriptionTests 11 件 pass
- [ ] App Store Connect で Subscription Group・商品・Intro Offer 設定
- [ ] `.storekit` Configuration ファイルを Xcode で作成、Scheme に紐付け
- [ ] termsURL / privacyURL を本番 URL に差し替え
- [ ] Sandbox 購入テスト

## Refs

- Issue #37 A 系決定: https://github.com/AkitoAndo/cycle-journal/issues/37#issuecomment-4528272314

🤖 Generated with [Claude Code](https://claude.com/claude-code)