### PR TITLE
feat: #37 トライアル Day1/3/6/7 ローカル通知スケジューラ

### DIFF
--- a/ios/Cycle/Features/Subscription/Notifications/TrialNotificationPlan.swift
+++ b/ios/Cycle/Features/Subscription/Notifications/TrialNotificationPlan.swift
@@ -1,0 +1,174 @@
+//
+//  TrialNotificationPlan.swift
+//  CycleJournal
+//
+//  Issue #37 C-2 決定: 7 日間トライアル中の Day1/3/6/7 通知計画を生成する純粋関数。
+//
+//  起点は Apple Introductory Offer の purchaseDate(StoreKit2 Transaction)。
+//  すべてローカル通知 (UNTimeIntervalNotificationTrigger / UNCalendarNotificationTrigger
+//  どちらでもよいが、Scheduler 側で UNTimeInterval を採用)。
+//
+
+import Foundation
+
+/// 1 件のトライアル通知 (Scheduler が UNNotificationRequest に変換)
+struct TrialNotification: Equatable {
+    let day: Int           // 1, 3, 6, 7
+    let scheduledAt: Date
+    let title: String
+    let body: String
+    let identifier: String // "trial.day{N}"
+}
+
+enum TrialNotificationPlan {
+    /// Day1/3/6/7 の通知 4 件を生成する.
+    ///
+    /// - parameter purchaseDate: Apple Intro Offer の起点 (StoreKit2 `Transaction.purchaseDate`)
+    /// - parameter goal: オンボーディングで選択したゴール (Day3 文面のパーソナライズに使う)
+    /// - parameter calendar: 時刻計算用カレンダー (TimeZone はユーザーのものを推奨)
+    static func generate(
+        purchaseDate: Date,
+        goal: OnboardingGoal?,
+        calendar: Calendar = .current
+    ) -> [TrialNotification] {
+        return [
+            day1Notification(purchaseDate: purchaseDate, calendar: calendar),
+            day3Notification(purchaseDate: purchaseDate, goal: goal, calendar: calendar),
+            day6Notification(purchaseDate: purchaseDate, calendar: calendar),
+            day7Notification(purchaseDate: purchaseDate, calendar: calendar),
+        ]
+    }
+
+    // MARK: - Day-specific factories
+
+    private static func day1Notification(
+        purchaseDate: Date,
+        calendar: Calendar
+    ) -> TrialNotification {
+        return TrialNotification(
+            day: 1,
+            scheduledAt: nextMorning(after: purchaseDate, hour: 8, minute: 30, calendar: calendar),
+            title: "今日の振り返りを 3 分で",
+            body: "最初のジャーナルから、自分との対話を始めましょう。",
+            identifier: "trial.day1"
+        )
+    }
+
+    private static func day3Notification(
+        purchaseDate: Date,
+        goal: OnboardingGoal?,
+        calendar: Calendar
+    ) -> TrialNotification {
+        let scheduledAt = morningOf(
+            day: 3,
+            from: purchaseDate,
+            hour: 8,
+            minute: 30,
+            calendar: calendar
+        )
+        return TrialNotification(
+            day: 3,
+            scheduledAt: scheduledAt,
+            title: "AI コーチがあなたを待っています",
+            body: day3Body(for: goal),
+            identifier: "trial.day3"
+        )
+    }
+
+    private static func day6Notification(
+        purchaseDate: Date,
+        calendar: Calendar
+    ) -> TrialNotification {
+        return TrialNotification(
+            day: 6,
+            scheduledAt: morningOf(
+                day: 6,
+                from: purchaseDate,
+                hour: 9,
+                minute: 0,
+                calendar: calendar
+            ),
+            title: "まもなくトライアル終了",
+            body: "明日、年額プランへの自動更新が始まります。"
+                + "継続も解約も「設定 → Apple ID → サブスクリプション」から行えます。",
+            identifier: "trial.day6"
+        )
+    }
+
+    private static func day7Notification(
+        purchaseDate: Date,
+        calendar: Calendar
+    ) -> TrialNotification {
+        // 課金 2 時間前 (sunk cost 想起 + 不意打ち回避)
+        let trialEnd = purchaseDate.addingTimeInterval(7 * 86400)
+        let scheduledAt = trialEnd.addingTimeInterval(-2 * 3600)
+        return TrialNotification(
+            day: 7,
+            scheduledAt: scheduledAt,
+            title: "プレミアム継続開始",
+            body: "今日からプレミアムが継続されます。"
+                + "これまでのジャーナルと対話が、あなたの一年を支えます。",
+            identifier: "trial.day7"
+        )
+    }
+
+    // MARK: - Day3 goal-based body
+
+    private static func day3Body(for goal: OnboardingGoal?) -> String {
+        switch goal {
+        case .selfAwareness:
+            return "AI コーチがあなたの自己理解を深めるための問いを準備しています。"
+        case .stressManagement:
+            return "AI コーチがストレスの源を整理するヒントを準備しています。"
+        case .goalAchievement:
+            return "AI コーチが目標達成への次の一歩を一緒に考えます。"
+        case .dailyHabits:
+            return "AI コーチが習慣を続けるためのコツを共有します。"
+        case .personalGrowth:
+            return "AI コーチがあなたの成長の手応えを一緒に振り返ります。"
+        case .none:
+            return "AI コーチとの対話で、Day1-2 の気づきを深掘りしませんか。"
+        }
+    }
+
+    // MARK: - Date helpers
+
+    /// 翌朝の指定時刻 (Day1 で 6h 後より朝のほうが遅ければ朝を採用)
+    private static func nextMorning(
+        after date: Date,
+        hour: Int,
+        minute: Int,
+        calendar: Calendar
+    ) -> Date {
+        var components = calendar.dateComponents(
+            [.year, .month, .day, .hour],
+            from: date
+        )
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        var morning = calendar.date(from: components) ?? date
+
+        // 購入が既に朝の時刻を過ぎていたら翌日朝に
+        if morning <= date.addingTimeInterval(6 * 3600) {
+            morning = calendar.date(byAdding: .day, value: 1, to: morning) ?? morning
+        }
+        return morning
+    }
+
+    /// 購入日から N 日後の指定時刻
+    private static func morningOf(
+        day: Int,
+        from purchaseDate: Date,
+        hour: Int,
+        minute: Int,
+        calendar: Calendar
+    ) -> Date {
+        let target = calendar.date(byAdding: .day, value: day, to: purchaseDate) ?? purchaseDate
+        var components = calendar.dateComponents([.year, .month, .day], from: target)
+        components.hour = hour
+        components.minute = minute
+        components.second = 0
+        return calendar.date(from: components) ?? target
+    }
+}

--- a/ios/Cycle/Features/Subscription/Notifications/TrialNotificationScheduler.swift
+++ b/ios/Cycle/Features/Subscription/Notifications/TrialNotificationScheduler.swift
@@ -1,0 +1,67 @@
+//
+//  TrialNotificationScheduler.swift
+//  CycleJournal
+//
+//  Issue #37 C-2: TrialNotificationPlan で生成した通知を
+//  UNUserNotificationCenter にローカル通知として登録する。
+//
+//  - 解約検知時は cancelAllTrialNotifications() で予約取り消し
+//    (ASSN V2 DID_CHANGE_RENEWAL_STATUS を受けたらサーバから silent push、
+//     端末側で本 API を呼ぶ運用を想定)
+//
+
+import Foundation
+import UserNotifications
+
+@MainActor
+final class TrialNotificationScheduler {
+    static let shared = TrialNotificationScheduler()
+
+    private let center: UNUserNotificationCenter
+
+    init(center: UNUserNotificationCenter = .current()) {
+        self.center = center
+    }
+
+    /// purchaseDate を起点に Day1/3/6/7 通知をローカルでスケジュール.
+    ///
+    /// 既存のトライアル通知は全てキャンセルしてから再登録 (購入再開や goal 変更後の更新用)。
+    func scheduleTrialNotifications(
+        purchaseDate: Date,
+        goal: OnboardingGoal?,
+        now: Date = Date()
+    ) async {
+        cancelAllTrialNotifications()
+
+        let plan = TrialNotificationPlan.generate(purchaseDate: purchaseDate, goal: goal)
+        for notification in plan {
+            let interval = notification.scheduledAt.timeIntervalSince(now)
+            // 既に過ぎている、または非常に直近(60s 未満)の通知はスキップ
+            guard interval >= 60 else { continue }
+
+            let content = UNMutableNotificationContent()
+            content.title = notification.title
+            content.body = notification.body
+            content.sound = .default
+
+            let trigger = UNTimeIntervalNotificationTrigger(
+                timeInterval: interval,
+                repeats: false
+            )
+            let request = UNNotificationRequest(
+                identifier: notification.identifier,
+                content: content,
+                trigger: trigger
+            )
+            try? await center.add(request)
+        }
+    }
+
+    /// trial.day1〜day7 の予約通知を全て取り消す.
+    ///
+    /// 解約・refund・期限切れ検知時に呼ぶ。
+    func cancelAllTrialNotifications() {
+        let identifiers = (1...7).map { "trial.day\($0)" }
+        center.removePendingNotificationRequests(withIdentifiers: identifiers)
+    }
+}

--- a/ios/CycleTests/TrialNotificationPlanTests.swift
+++ b/ios/CycleTests/TrialNotificationPlanTests.swift
@@ -1,0 +1,121 @@
+//
+//  TrialNotificationPlanTests.swift
+//  CycleTests
+//
+//  Issue #37 C-2: トライアル中の Day1/3/6/7 通知計画(純粋関数)の単体テスト
+//
+
+import Foundation
+import Testing
+
+@testable import Cycle
+
+struct TrialNotificationPlanTests {
+    // 固定 purchaseDate (UTC 2026-01-01 00:00:00)
+    private static let purchaseDate = Date(timeIntervalSince1970: 1_767_225_600)
+    private static let calendar: Calendar = {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "Asia/Tokyo") ?? .current
+        return c
+    }()
+
+    @Test func generatesFourNotifications() {
+        let plan = TrialNotificationPlan.generate(
+            purchaseDate: Self.purchaseDate,
+            goal: nil,
+            calendar: Self.calendar
+        )
+        #expect(plan.count == 4)
+    }
+
+    @Test func includesDay1Day3Day6Day7() {
+        let plan = TrialNotificationPlan.generate(
+            purchaseDate: Self.purchaseDate,
+            goal: nil,
+            calendar: Self.calendar
+        )
+        let days = plan.map(\.day).sorted()
+        #expect(days == [1, 3, 6, 7])
+    }
+
+    @Test func identifiersAreUniqueAndFollowConvention() {
+        let plan = TrialNotificationPlan.generate(
+            purchaseDate: Self.purchaseDate,
+            goal: nil,
+            calendar: Self.calendar
+        )
+        let ids = plan.map(\.identifier)
+        #expect(Set(ids).count == ids.count) // unique
+        for n in plan {
+            #expect(n.identifier == "trial.day\(n.day)")
+        }
+    }
+
+    @Test func day6BodyIncludesCancellationGuidance() {
+        // EU DSA / Digital Fairness Act 対応: 解約導線を併記
+        let plan = TrialNotificationPlan.generate(
+            purchaseDate: Self.purchaseDate,
+            goal: nil,
+            calendar: Self.calendar
+        )
+        let day6 = plan.first { $0.day == 6 }
+        #expect(day6 != nil)
+        #expect(day6!.body.contains("解約") || day6!.body.contains("サブスクリプション"))
+    }
+
+    @Test func day3BodyVariesByGoal() {
+        let withSelfAwareness = TrialNotificationPlan.generate(
+            purchaseDate: Self.purchaseDate,
+            goal: .selfAwareness,
+            calendar: Self.calendar
+        ).first { $0.day == 3 }!
+
+        let withStressManagement = TrialNotificationPlan.generate(
+            purchaseDate: Self.purchaseDate,
+            goal: .stressManagement,
+            calendar: Self.calendar
+        ).first { $0.day == 3 }!
+
+        // Goal 別に Day3 文面が変わる (#37 C-2 決定)
+        #expect(withSelfAwareness.body != withStressManagement.body)
+    }
+
+    @Test func day7ScheduledBeforeAutoCharge() {
+        // Day7 通知は課金 2 時間前 (sunk cost 想起) なので
+        // purchaseDate + 7 日 より少し早い時刻
+        let plan = TrialNotificationPlan.generate(
+            purchaseDate: Self.purchaseDate,
+            goal: nil,
+            calendar: Self.calendar
+        )
+        let day7 = plan.first { $0.day == 7 }!
+        let trialEnd = Self.purchaseDate.addingTimeInterval(7 * 86400)
+        #expect(day7.scheduledAt < trialEnd)
+    }
+
+    @Test func day1ScheduledMorningOrSixHoursAfterPurchase() {
+        // Day1 は購入 6h 後 or 翌朝 8:30 (どちらか早い方の妥当範囲)
+        let plan = TrialNotificationPlan.generate(
+            purchaseDate: Self.purchaseDate,
+            goal: nil,
+            calendar: Self.calendar
+        )
+        let day1 = plan.first { $0.day == 1 }!
+        let elapsed = day1.scheduledAt.timeIntervalSince(Self.purchaseDate)
+        // 6h <= elapsed <= 36h の範囲に収まる
+        #expect(elapsed >= 6 * 3600)
+        #expect(elapsed <= 36 * 3600)
+    }
+
+    @Test func futureSchedulesOnly() {
+        // すべての通知が purchaseDate より後
+        let plan = TrialNotificationPlan.generate(
+            purchaseDate: Self.purchaseDate,
+            goal: nil,
+            calendar: Self.calendar
+        )
+        for n in plan {
+            #expect(n.scheduledAt > Self.purchaseDate)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Issue #37 C-2 決定の実装。Apple Introductory Offer の `Transaction.purchaseDate` を起点に Day1/3/6/7 をローカル通知でスケジュール。

- `TrialNotificationPlan`（純粋関数）: 4 件の通知を生成
  - **Day1** 翌朝 8:30「今日の振り返りを 3 分で」
  - **Day3** 朝 8:30 / **Goal 別 5 種文面**（selfAwareness / stressManagement / goalAchievement / dailyHabits / personalGrowth）
  - **Day6** 朝 9:00 / 解約導線併記（EU DSA / Digital Fairness Act 対応）
  - **Day7** 課金 2h 前 / sunk cost 想起
- `TrialNotificationScheduler` (@MainActor): UNUserNotificationCenter ラッパー
  - `scheduleTrialNotifications` / `cancelAllTrialNotifications`
  - 解約検知時（ASSN V2 `DID_CHANGE_RENEWAL_STATUS` → silent push → 本 API 呼び出し）に予約取消

## Test plan

- [x] CycleTests/TrialNotificationPlanTests: 8 件 pass
- [x] `xcodebuild`: BUILD SUCCEEDED
- [ ] Transaction.updates 受信時に Scheduler を呼ぶ統合（別 PR）
- [ ] オンボーディング opt-in 後に呼ぶ統合（C-1 別 PR）

## Refs

- Issue #37 C 系決定: https://github.com/AkitoAndo/cycle-journal/issues/37#issuecomment-4528348152

🤖 Generated with [Claude Code](https://claude.com/claude-code)