### PR TITLE
docs: #37 デプロイメントセットアップ手順書一式

### DIFF
--- a/docs/guides/37-deployment-setup/01-app-store-connect-iap.md
+++ b/docs/guides/37-deployment-setup/01-app-store-connect-iap.md
@@ -1,0 +1,112 @@
+# 01. App Store Connect: サブスクリプション商品設定
+
+## 目的
+
+CycleJournal の課金プラン（月額 ¥1,800 / 年額 ¥14,400 + 7 日無料トライアル）を App Store Connect に登録し、StoreKit 2 経由で購入可能にする。
+
+## 前提条件
+
+- Apple Developer Program に加入済（年 $99）
+- App Store Connect の **Admin** または **App Manager** ロール
+- 対象アプリ（Bundle ID `com.akitoando.CycleJournal`）が App Store Connect に登録済
+- 課金契約（Paid Apps Agreement）に署名済
+  - [App Store Connect](https://appstoreconnect.apple.com/) → **Agreements, Tax, and Banking** で "Active" になっていること
+  - 銀行口座・税情報入力が完了していないと商品が "Waiting for Agreement" になり Sandbox でも取得不可
+
+## 手順
+
+### 1. Subscription Group の作成
+
+1. [App Store Connect](https://appstoreconnect.apple.com/) → 対象アプリ → **Monetization** → **Subscriptions**
+2. **Create Subscription Group** をクリック
+3. **Reference Name**: `CycleJournal Premium`（内部識別用、ユーザーには見えない）
+4. **Save**
+
+> 同じ Group 内のサブスクは「アップグレード／ダウングレード」の関係になる。月額・年額は同一 Group に入れる。
+
+### 2. 月額プランの作成
+
+1. Subscription Group `CycleJournal Premium` を開く
+2. **Create Subscription** をクリック
+3. 入力項目:
+   - **Reference Name**: `Monthly Premium`
+   - **Product ID**: **`com.akitoando.CycleJournal.monthly_1800`**
+     - ⚠️ 必ずこの ID。`ios/Cycle/Features/Subscription/Models/SubscriptionProduct.swift` の `SubscriptionProductID.monthly` と完全一致
+   - **Subscription Duration**: `1 Month`
+4. **Create**
+5. 次画面の Subscription Pricing で **Add Subscription Price**
+   - **Country/Region**: 日本 → **¥1,800**
+   - 他国は Apple の自動換算テンプレートで OK（米国基準: $14.99 相当の Tier を選択）
+6. **Subscription Information**（Localizations）で日本語版を入力
+   - **Subscription Display Name**: `月額プレミアム`
+   - **Description**: `すべての Premium 機能を月額でご利用いただけます。`
+7. **App Review Information**:
+   - **Review Screenshot**: Paywall のスクリーンショット（後述、Sandbox テスト後に撮影）
+   - **Review Notes**: `テスト用 Sandbox アカウントは TestFlight で配布済`
+8. **Save**
+
+### 3. 年額プランの作成（7 日無料トライアル付き）
+
+1. Subscription Group `CycleJournal Premium` で再度 **Create Subscription**
+2. 入力項目:
+   - **Reference Name**: `Yearly Premium`
+   - **Product ID**: **`com.akitoando.CycleJournal.yearly_14400`**
+   - **Subscription Duration**: `1 Year`
+3. **Subscription Pricing**:
+   - 日本 → **¥14,400**
+4. **Subscription Information**:
+   - **Display Name**: `年額プレミアム`
+   - **Description**: `すべての Premium 機能を年額でご利用いただけます。最初の 7 日間は無料。`
+5. **Introductory Offers** セクションへスクロール → **Set Up Introductory Offer**
+6. 入力項目:
+   - **Countries or Regions**: All Countries（or 提供国のみ）
+   - **Offer Type**: **Free Trial**
+   - **Duration**: **1 Week** （= 7 日）
+   - **Start Date**: 即時 / **End Date**: 無期限 or 一定期間
+   - **Eligibility**: `New Subscribers`（新規購読者のみ）
+7. **Save**
+8. App Review Information / Review Screenshot を月額と同様に設定
+
+### 4. Sandbox テスター作成
+
+1. App Store Connect → **Users and Access** → **Sandbox Testers** タブ
+2. **+** → 新規アカウント作成
+   - メールアドレス（実在しないものでよい、`test+sandbox@example.com` 等）
+   - パスワード（強度高）
+   - 国/地域: **Japan**
+3. **Invite**
+4. iOS 実機 / シミュレータの **Settings → Apple Account → Sandbox Account** にこのアカウントでサインイン
+5. アプリ側で課金ダイアログが出たときにこのアカウントで承認
+
+## 検証
+
+### Sandbox での購入フロー
+1. Xcode で実機ビルド & 起動
+2. Paywall に到達するまで操作
+3. 「7 日間無料で始める」タップ
+4. Sandbox アカウントのパスワード入力ダイアログ → 承認
+5. `SubscriptionStore.state` が `.trial(productID: "com.akitoando.CycleJournal.yearly_14400", expiresAt: ...)` になる
+6. `Settings → Apple Account → Subscriptions` に "CycleJournal" が表示される
+
+### App Store Connect 側の状態
+- 商品が `Ready to Submit` になっていればアプリの審査提出に同梱可能
+- `Missing Metadata` の場合は Localizations / Pricing / Review Screenshot の不足を解消
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `Product.products(for:)` が空配列を返す | 商品が "Waiting for Review" or "Waiting for Agreement" | Agreements, Tax, and Banking を完了させる。商品を Submit |
+| `userCancelled` ばかり返る | Sandbox アカウントが地域不一致 | Sandbox アカウントを Japan で作り直す |
+| Trial が `nil` | `isEligibleForIntroOffer` が false（過去にトライアル経験あり） | 別の Sandbox アカウントを作って再テスト |
+| `purchase()` が `unverified` を返す | `.storekit` Configuration が Production 設定 | [05](05-storekit-config-xcode.md) を見直す |
+
+## 公式ドキュメント
+
+- [Setting up Auto-Renewable Subscriptions](https://developer.apple.com/help/app-store-connect/manage-subscriptions/create-auto-renewable-subscriptions/)
+- [Set up introductory offers for auto-renewable subscriptions](https://developer.apple.com/help/app-store-connect/manage-subscriptions/set-up-introductory-offers-for-auto-renewable-subscriptions/)
+- [Creating Sandbox Apple Accounts](https://developer.apple.com/help/app-store-connect/test-in-app-purchases/create-sandbox-apple-accounts/)
+
+## 次のステップ
+
+→ [02. IAP Key (.p8) と Secret Manager](02-iap-key-secret-manager.md)

--- a/docs/guides/37-deployment-setup/02-iap-key-secret-manager.md
+++ b/docs/guides/37-deployment-setup/02-iap-key-secret-manager.md
@@ -1,0 +1,193 @@
+# 02. IAP Key (.p8) と Secret Manager
+
+## 目的
+
+App Store Server API を呼び出すための ES256 署名用 `.p8` 秘密鍵を発行し、Google Cloud Secret Manager 経由で Cloud Run に注入する。
+
+`.p8` は Sign in with Apple 用の鍵とは **別物**。In-App Purchase 専用キー（Users and Access → Integrations → In-App Purchase）が必要。
+
+## 前提条件
+
+- [01](01-app-store-connect-iap.md) 完了
+- App Store Connect の **Admin** ロール
+- GCP プロジェクト `cycle-journal` への `roles/secretmanager.admin` 権限
+- `gcloud` CLI 認証済（`gcloud auth login` + `gcloud config set project cycle-journal`）
+
+## 手順
+
+### 1. In-App Purchase Key の発行
+
+1. [App Store Connect](https://appstoreconnect.apple.com/) → **Users and Access** → **Integrations** タブ
+2. 左サイドバーの **In-App Purchase** を選択
+3. **Generate In-App Purchase Key** ボタン
+4. **Name**: `CycleJournal IAP Server Key`
+5. **Generate**
+6. **`AuthKey_XXXXXXXXXX.p8`** をダウンロード（**一度しかダウンロードできない**ので必ず安全に保管）
+7. 表示される以下の値を控える:
+   - **Key ID** (例: `9ABCDEFGHI`) — 10 文字
+   - **Issuer ID** (アカウント全体で固定、UUID 形式) — `0123abcd-4567-89ef-...`
+   - **Bundle ID**: `com.akitoando.CycleJournal`
+
+### 2. Secret Manager に格納
+
+```bash
+# Issuer ID
+echo -n "0123abcd-4567-89ef-XXXX-XXXXXXXXXXXX" | \
+  gcloud secrets create apple-iap-issuer-id --data-file=-
+
+# Key ID
+echo -n "9ABCDEFGHI" | \
+  gcloud secrets create apple-iap-key-id --data-file=-
+
+# Private Key (.p8 ファイル全体を改行込みで)
+gcloud secrets create apple-iap-private-key \
+  --data-file=./AuthKey_9ABCDEFGHI.p8
+
+# (Production のみ) App Apple ID
+echo -n "1234567890" | \
+  gcloud secrets create apple-iap-app-apple-id --data-file=-
+```
+
+> `.p8` ファイルは Secret Manager に格納したら **ローカルからも安全に削除**（`rm -P ./AuthKey_*.p8`）。再発行不可なので、組織のパスワードマネージャか別途バックアップは保持しておくことを推奨。
+
+### 3. Cloud Run に環境変数として注入
+
+`infra/` ディレクトリの Terraform 構成（または Cloud Run YAML）で以下を追加:
+
+```hcl
+# infra/cloudrun.tf (例)
+resource "google_cloud_run_v2_service" "api" {
+  # ...
+  template {
+    containers {
+      # ...
+      env {
+        name = "APPLE_IAP_ISSUER_ID"
+        value_source {
+          secret_key_ref {
+            secret  = "apple-iap-issuer-id"
+            version = "latest"
+          }
+        }
+      }
+      env {
+        name = "APPLE_IAP_KEY_ID"
+        value_source {
+          secret_key_ref { secret = "apple-iap-key-id", version = "latest" }
+        }
+      }
+      env {
+        name = "APPLE_IAP_PRIVATE_KEY"
+        value_source {
+          secret_key_ref { secret = "apple-iap-private-key", version = "latest" }
+        }
+      }
+      env {
+        name  = "APPLE_IAP_ENV"
+        value = "Sandbox"  # Production デプロイ時は "Production"
+      }
+      env {
+        name = "APPLE_IAP_APP_APPLE_ID"
+        value_source {
+          secret_key_ref { secret = "apple-iap-app-apple-id", version = "latest" }
+        }
+      }
+    }
+  }
+}
+```
+
+`gcloud` で手動デプロイの場合:
+
+```bash
+gcloud run deploy cyclejournal-api \
+  --update-secrets=APPLE_IAP_ISSUER_ID=apple-iap-issuer-id:latest,\
+APPLE_IAP_KEY_ID=apple-iap-key-id:latest,\
+APPLE_IAP_PRIVATE_KEY=apple-iap-private-key:latest,\
+APPLE_IAP_APP_APPLE_ID=apple-iap-app-apple-id:latest \
+  --set-env-vars=APPLE_IAP_ENV=Sandbox
+```
+
+### 4. Cloud Run サービスアカウントに Secret Manager 読取権限を付与
+
+```bash
+SERVICE_ACCOUNT="$(gcloud run services describe cyclejournal-api \
+  --region=asia-northeast1 \
+  --format='value(spec.template.spec.serviceAccountName)')"
+
+for SECRET in apple-iap-issuer-id apple-iap-key-id apple-iap-private-key apple-iap-app-apple-id; do
+  gcloud secrets add-iam-policy-binding "$SECRET" \
+    --member="serviceAccount:${SERVICE_ACCOUNT}" \
+    --role="roles/secretmanager.secretAccessor"
+done
+```
+
+## 検証
+
+### Cloud Run 上で環境変数が読めるか
+
+```bash
+# /health に環境変数のセットだけ確認するデバッグエンドポイントを一時的に追加するか、
+# ログ確認:
+gcloud logging read "resource.type=cloud_run_revision \
+  AND resource.labels.service_name=cyclejournal-api" \
+  --limit 20 --format=json | jq '.[].textPayload' | grep -i "apple_iap"
+```
+
+### App Store Server API への JWT 署名テスト
+
+ローカルで一時的に `.p8` を使い、Python で JWT を生成して `/inApps/v1/transactions/{id}` を叩く:
+
+```python
+# scripts/test_app_store_api.py (動作確認用、コミットしない)
+import jwt, time, os, requests
+
+key_id = "9ABCDEFGHI"
+issuer_id = "0123abcd-...."
+bundle_id = "com.akitoando.CycleJournal"
+private_key = open("./AuthKey_9ABCDEFGHI.p8").read()
+
+token = jwt.encode(
+    {
+        "iss": issuer_id,
+        "iat": int(time.time()),
+        "exp": int(time.time()) + 1500,
+        "aud": "appstoreconnect-v1",
+        "bid": bundle_id,
+    },
+    private_key,
+    algorithm="ES256",
+    headers={"alg": "ES256", "kid": key_id, "typ": "JWT"},
+)
+
+# Sandbox 環境の任意の transactionId で試す
+resp = requests.get(
+    "https://api.storekit-sandbox.itunes.apple.com/inApps/v1/transactions/{tx_id}".format(
+        tx_id="2000000000000001"
+    ),
+    headers={"Authorization": f"Bearer {token}"},
+)
+print(resp.status_code, resp.text[:200])
+```
+
+`200` または `404`（テスト用 ID なので存在しない）が返れば JWT 署名は正常。`401` なら鍵か Issuer ID が誤り。
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `401 Unauthorized` | Issuer ID 誤り or .p8 の改ざん | App Store Connect で再確認、PEM 改行が壊れていないか確認 |
+| `403 Forbidden` | Bundle ID 不一致 | JWT の `bid` クレームが App Store Connect 登録と完全一致しているか |
+| Secret Manager `Permission denied` | Cloud Run SA に IAM 不足 | 上記手順 4 で `roles/secretmanager.secretAccessor` 付与 |
+| `gcloud secrets create` 失敗 | 重複作成 | `versions add` で更新 |
+
+## 公式ドキュメント
+
+- [Creating API Keys to Use With the App Store Server API](https://developer.apple.com/documentation/appstoreserverapi/creating-api-keys-to-use-with-the-app-store-server-api)
+- [Generating JSON Web Tokens for API Requests](https://developer.apple.com/documentation/appstoreserverapi/generating-json-web-tokens-for-api-requests)
+- [Google Cloud Secret Manager](https://cloud.google.com/secret-manager/docs)
+- [Cloud Run: Use secrets](https://cloud.google.com/run/docs/configuring/secrets)
+
+## 次のステップ
+
+→ [03. Apple PKI ルート証明書配置](03-apple-root-certs.md)

--- a/docs/guides/37-deployment-setup/03-apple-root-certs.md
+++ b/docs/guides/37-deployment-setup/03-apple-root-certs.md
@@ -1,0 +1,143 @@
+# 03. Apple PKI ルート証明書配置
+
+## 目的
+
+App Store Server Notifications V2 / Server API のレスポンスは JWS（JSON Web Signature）で署名されている。サーバー側で署名検証するために Apple のルート CA 証明書が必要。
+
+`app-store-server-library` の `SignedDataVerifier` は引数で証明書バイト列を要求する。本プロジェクトでは `api/app/certs/*.cer` を起動時に読み込む実装（PR #43）。
+
+## 前提条件
+
+- リポジトリのクローン
+- Docker イメージビルドができる環境（または `gcloud builds submit` が動く環境）
+
+## 手順
+
+### 1. Apple PKI Repository から証明書を取得
+
+公式ページ: https://www.apple.com/certificateauthority/
+
+ダウンロードする証明書:
+
+| ファイル名 | 用途 | URL |
+|---|---|---|
+| `AppleRootCA-G3.cer` | StoreKit 2 / ASSN V2 / Server API 検証用（ES256） | https://www.apple.com/appleca/AppleRootCA-G3.cer |
+| `AppleIncRootCertificate.cer` | 旧 SHA-1 ルート（後方互換、必須ではないが推奨） | https://www.apple.com/appleca/AppleIncRootCertificate.cer |
+
+```bash
+mkdir -p api/app/certs
+cd api/app/certs
+
+curl -fsSL -o AppleRootCA-G3.cer https://www.apple.com/appleca/AppleRootCA-G3.cer
+curl -fsSL -o AppleIncRootCertificate.cer https://www.apple.com/appleca/AppleIncRootCertificate.cer
+```
+
+### 2. 証明書の検証
+
+ダウンロードした証明書が正しいか SHA-256 で確認:
+
+```bash
+shasum -a 256 AppleRootCA-G3.cer
+# 期待値: 63343abfb89a6a03ebb57e9b3f5fa7be7c4f5c756f3017b3a8c488c3653e9152
+# (公式は時々入れ替えるので最新を https://www.apple.com/certificateauthority/ で確認)
+
+openssl x509 -inform DER -in AppleRootCA-G3.cer -noout -subject -issuer -dates
+# Subject: CN=Apple Root CA - G3, OU=Apple Certification Authority, O=Apple Inc., C=US
+# Issuer:  CN=Apple Root CA - G3, OU=Apple Certification Authority, O=Apple Inc., C=US
+# notBefore=Apr 30 18:19:06 2014 GMT
+# notAfter =Apr 30 18:19:06 2039 GMT
+```
+
+### 3. `.gitignore` 設定の確認
+
+証明書は公開情報なのでコミットして問題ない（Apple Inc. 配布物、再頒布許可あり）。ただし「秘密鍵を誤って同ディレクトリに置いてしまった」事故を防ぐため、`*.p8` だけ ignore する設定にする:
+
+```bash
+# api/app/certs/.gitignore (新規作成)
+*.p8
+*.pem
+*.key
+```
+
+```bash
+cat > api/app/certs/.gitignore <<'EOF'
+# IAP / Sign in with Apple 秘密鍵はここに置かない (Secret Manager で管理)
+*.p8
+*.pem
+*.key
+EOF
+
+# 証明書ファイル自体はコミット対象
+git add api/app/certs/AppleRootCA-G3.cer
+git add api/app/certs/AppleIncRootCertificate.cer
+git add api/app/certs/.gitignore
+```
+
+### 4. Docker イメージに含まれることを確認
+
+`api/Dockerfile` を確認:
+
+```dockerfile
+# 既存 Dockerfile が COPY app/ /app/app/ のように broad copy しているなら、
+# certs ディレクトリも自動的に含まれる。
+# 明示的に確認するなら:
+COPY app/certs/*.cer /app/app/certs/
+```
+
+ビルド & 確認:
+
+```bash
+docker build -t cyclejournal-api:test ./api
+docker run --rm cyclejournal-api:test ls /app/app/certs/
+# AppleIncRootCertificate.cer
+# AppleRootCA-G3.cer
+```
+
+## 検証
+
+### Python で読み込みテスト
+
+```bash
+cd api
+.venv/bin/python -c "
+from app.services.iap_verifier import load_root_certificates
+roots = load_root_certificates()
+print(f'Loaded {len(roots)} certs')
+for r in roots:
+    print(f'  size={len(r)} bytes')
+"
+# Loaded 2 certs
+#   size=NNN bytes
+#   size=NNN bytes
+```
+
+`0 certs` だった場合は配置場所か Dockerfile を見直す。
+
+### SignedDataVerifier の構築
+
+```python
+from app.config import settings
+from app.services.iap_verifier import build_verifier
+
+v = build_verifier(settings)
+print(type(v).__name__)  # SignedDataVerifier
+```
+
+例外なくインスタンス化できれば OK。
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `ValueError: Invalid certificate` | DER フォーマットでない | `.cer` を `openssl x509 -inform DER -in ...` で読めるか確認、PEM の場合は `-inform PEM` か再ダウンロード |
+| `load_root_certificates()` が `[]` | パスが違う | `api/app/certs/` の絶対パスを `_CERTS_DIR` ログで確認 |
+| Docker 内で見つからない | COPY パターンが broad copy していない | Dockerfile に明示的に `COPY app/certs/*.cer` を追加 |
+
+## 公式ドキュメント
+
+- [Apple PKI Repository](https://www.apple.com/certificateauthority/)
+- [App Store Server Library: signed_data_verifier](https://github.com/apple/app-store-server-library-python)
+
+## 次のステップ
+
+→ [04. App Store Server Notifications V2 URL 登録](04-assn-v2-webhook.md)

--- a/docs/guides/37-deployment-setup/04-assn-v2-webhook.md
+++ b/docs/guides/37-deployment-setup/04-assn-v2-webhook.md
@@ -1,0 +1,123 @@
+# 04. App Store Server Notifications V2 URL 登録
+
+## 目的
+
+サブスクリプションの状態変化（購入・更新・解約・払戻し・refund・grace period 等）を Apple から CycleJournal バックエンドにリアルタイム通知する。PR #43 で実装した `POST /iap/apple/notifications` エンドポイントを App Store Connect に登録する。
+
+## 前提条件
+
+- [01](01-app-store-connect-iap.md) / [02](02-iap-key-secret-manager.md) / [03](03-apple-root-certs.md) 完了
+- Cloud Run の `cyclejournal-api` が Sandbox / Production の 2 環境にデプロイ済（または同一サービスを env で切替）
+- 各環境の HTTPS URL が判明している
+  - 例: Sandbox `https://api-sandbox.cycle-journal.example.com/iap/apple/notifications`
+  - 例: Production `https://api.cycle-journal.example.com/iap/apple/notifications`
+- Cloud Run / API Gateway / Load Balancer で **認証不要**でこのパスに到達できる
+  - Cloud Run の場合、`/iap/apple/notifications` だけ unauthenticated にするか、サービス全体を `--allow-unauthenticated` にする
+  - 認証必要にしたい場合は事前共有シークレットを URL クエリに含めて検証する独自実装が必要（推奨はしない）
+
+## 手順
+
+### 1. URL 登録
+
+1. [App Store Connect](https://appstoreconnect.apple.com/) → 対象アプリ → **App Information**
+2. 右下にスクロール → **App Store Server Notifications** セクション
+3. **Production Server URL**: `https://api.cycle-journal.example.com/iap/apple/notifications`
+4. **Sandbox Server URL**: `https://api-sandbox.cycle-journal.example.com/iap/apple/notifications`
+5. **Version**: **Version 2 Notifications** を選択（V1 は廃止予定なので必須で V2）
+6. **Save**
+
+> URL は HTTPS 必須。HTTP は受け付けられない。
+
+### 2. Cloud Run の Ingress / 認証設定
+
+```bash
+# サービス全体を unauthenticated にする (シンプル、推奨)
+gcloud run services add-iam-policy-binding cyclejournal-api \
+  --region=asia-northeast1 \
+  --member="allUsers" \
+  --role="roles/run.invoker"
+
+# Ingress を all に
+gcloud run services update cyclejournal-api \
+  --region=asia-northeast1 \
+  --ingress=all
+```
+
+> 内部の他エンドポイント（`/coach`, `/tasks` 等）は別途 `Authorization: Bearer` JWT で保護されているので unauthenticated 化しても安全。`/iap/apple/notifications` は JWS で署名検証する設計（PR #43）。
+
+### 3. Test Notification の送信
+
+App Store Connect から手動でテスト通知を送って疎通確認:
+
+1. App Store Connect → 対象アプリ → **App Store Server Notifications** セクション
+2. **Request a Test Notification** ボタン
+3. **Sandbox** を選択して **Send**
+4. 数秒以内に Cloud Run のログにリクエストが記録される
+
+```bash
+gcloud logging read "resource.type=cloud_run_revision \
+  AND resource.labels.service_name=cyclejournal-api \
+  AND httpRequest.requestUrl:apple/notifications" \
+  --limit 5 --format=json | jq '.[].httpRequest'
+# 200 OK が返っていれば成功
+```
+
+Firestore の `iap_notifications` コレクションに `notificationType: TEST` のドキュメントが 1 件作成される:
+
+```bash
+gcloud firestore documents read \
+  iap_notifications/<notificationUUID>
+```
+
+### 4. Production 側の有効化（リリース時）
+
+- Production URL を入力したら App Review 提出時に Apple がエンドポイントの疎通を試す
+- レビュー前に「Sandbox はテスト済、Production URL は同等動作」を Review Notes に記載
+
+### 5. リトライ動作の理解
+
+Apple は ACK が 200-206 以外、または 5 秒以内にレスポンスがない場合に **最大 5 回 / 72 時間** リトライする。
+- 同じ `notificationUUID` で複数回届く可能性 → **冪等処理必須**（PR #43 で実装済: `AlreadyExists` で 200 "duplicate"）
+- 4xx を返すと「これ以上送らないで」になる → JWS 検証失敗時は 400 が正解
+
+## 検証
+
+### 疎通確認チェックリスト
+
+- [ ] App Store Connect で Production / Sandbox URL が緑チェック表示
+- [ ] **Request a Test Notification** で 200 が返る
+- [ ] Firestore `iap_notifications` コレクションに `TEST` タイプのドキュメントが作成される
+- [ ] Cloud Run ログに JWS デコード結果（`notificationType: TEST` など）が出る
+- [ ] 同じ `notificationUUID` の再送で 200 "duplicate" 応答（冪等）
+- [ ] 改ざんした payload を送ると 400 InvalidSignature
+
+### 改ざんテスト（手動）
+
+```bash
+# 適当な無効な signedPayload で 400 が返ること
+curl -X POST https://api-sandbox.cycle-journal.example.com/iap/apple/notifications \
+  -H "Content-Type: application/json" \
+  -d '{"signedPayload":"invalid-jws-string"}'
+# {"detail":"invalid signature: ..."}
+```
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `Request a Test Notification` ボタンがグレー | 商品が "Waiting for Review" 状態 | [01](01-app-store-connect-iap.md) で Subscription を Submit |
+| Test 通知が届かない | Cloud Run が unauthenticated でない | `roles/run.invoker` を `allUsers` に付与 |
+| 200 を返したのに Apple がリトライ | 5 秒以内に応答できていない | BackgroundTasks で重い処理を後ろに回す（PR #43 で対応済） |
+| 401 / 403 が返る | Cloud Run の Ingress 制限 | `--ingress=all` で外部到達可能に |
+| JWS 検証が失敗する | Sandbox 通知を Production verifier で検証 | `payload.data.environment` で verifier を切替、または APPLE_IAP_ENV を Sandbox にしてデプロイ分離 |
+
+## 公式ドキュメント
+
+- [App Store Server Notifications V2](https://developer.apple.com/documentation/appstoreservernotifications/app-store-server-notifications-v2)
+- [Enter server URLs for App Store Server Notifications](https://developer.apple.com/help/app-store-connect/configure-in-app-purchase-settings/enter-server-urls-for-app-store-server-notifications/)
+- [responseBodyV2DecodedPayload](https://developer.apple.com/documentation/appstoreservernotifications/responsebodyv2decodedpayload)
+- [Testing notifications: Request a test notification](https://developer.apple.com/documentation/appstoreserverapi/request_a_test_notification)
+
+## 次のステップ
+
+→ [05. .storekit Configuration ファイル作成](05-storekit-config-xcode.md)

--- a/docs/guides/37-deployment-setup/05-storekit-config-xcode.md
+++ b/docs/guides/37-deployment-setup/05-storekit-config-xcode.md
@@ -1,0 +1,111 @@
+# 05. .storekit Configuration ファイル作成（Xcode）
+
+## 目的
+
+シミュレータ / 実機デバッグ時に App Store Connect / Sandbox を経由せずに購入フローをテストできるようにする。Xcode の **StoreKit Configuration** ファイル（`.storekit`）で商品定義をローカルにモック化する。
+
+> 本番リリース時は Scheme から `.storekit` を外す（または "None" にする）こと。残したまま提出すると審査でリジェクトされる可能性は低いが、Sandbox / Production の挙動とは異なるため動作確認は別途必要。
+
+## 前提条件
+
+- Xcode 16+
+- 本プロジェクト（`ios/Cycle.xcodeproj`）が開ける状態
+
+## 手順
+
+### 1. StoreKit Configuration ファイル作成
+
+1. Xcode で `Cycle.xcodeproj` を開く
+2. **File → New → File from Template**
+3. iOS タブ → **StoreKit Configuration File** を選択 → **Next**
+4. Save As: `Configuration.storekit`
+5. Group: `Cycle` ターゲット直下（`ios/Cycle/` 配下）に保存
+6. **Create**
+
+### 2. 商品の追加
+
+`.storekit` ファイルを開くと空のリストが表示される。
+
+#### 月額プラン
+1. **+** → **Add Auto-Renewable Subscription**
+2. **Reference Name**: `Monthly Premium`
+3. **Product ID**: `com.akitoando.CycleJournal.monthly_1800`
+4. **Subscription Group**: `CycleJournal Premium` を新規作成して選択
+5. **Subscription Duration**: 1 month
+6. **Price**: ¥1,800 → 1800.00 / JPY
+7. **Family Sharing**: Off（必要なら On）
+
+#### 年額プラン
+1. **+** → **Add Auto-Renewable Subscription**
+2. **Reference Name**: `Yearly Premium`
+3. **Product ID**: `com.akitoando.CycleJournal.yearly_14400`
+4. **Subscription Group**: 上で作った `CycleJournal Premium` を選択
+5. **Subscription Duration**: 1 year
+6. **Price**: ¥14,400 → 14400.00 / JPY
+
+#### 年額プランに Introductory Offer を追加
+1. 年額プランを選択した状態で **Subscription Group / Introductory Offer** タブ
+2. **+ Add Introductory Offer**
+3. **Offer Type**: `Free Trial`
+4. **Duration**: 1 Week
+5. **Pricing**: 0
+6. **Mode**: `Pay As You Go` / `Pay Up Front` ではなく **`Free Trial`** が選ばれていることを確認
+
+### 3. Scheme への紐付け
+
+1. Xcode 上部の **Cycle スキーム** → **Edit Scheme...**
+2. **Run** → **Options** タブ
+3. **StoreKit Configuration**: ドロップダウンで `Configuration.storekit` を選択
+4. **Close**
+
+### 4. テスト実行
+
+シミュレータで実行（Cmd+R）し、Paywall に到達:
+
+- `Product.products(for: [...])` がローカル定義から商品 2 つを返す
+- 「7日間無料で始める」を押すと **Sandbox アカウント不要**で即購入が走る（パスワードダイアログ出ず）
+- `SubscriptionStore.state` が `.trial(...)` になる
+
+### 5. デバッグ操作（時間操作・取消し）
+
+シミュレータ起動中、Xcode **Debug → StoreKit → Manage Transactions**
+
+- 任意のトランザクションを選択 → **Refund** で払戻しをシミュレート
+- **Resolve Issues** で課金エラーをシミュレート
+- Subscription Group の **Time Rate** で時間進行速度を倍速にできる（1 second = 1 day など → 7日トライアル終了を数秒で確認可能）
+
+## 検証
+
+### 動作確認チェックリスト
+
+- [ ] `Product.products(for:)` がエラーなく 2 商品を返す
+- [ ] 「7日間無料で始める」タップ → ダイアログなし or 簡易確認のみで `state == .trial(...)` になる
+- [ ] **Manage Transactions** で `Refund` → `Transaction.updates` に通知が来て `state == .expired` になる
+- [ ] **Time Rate** を 1s = 1d にして 7 秒待つ → トライアル終了し自動課金 → `state == .active(...)`
+- [ ] Day3 通知（C-2）の `scheduledAt` がローカルで実際に発火するか（`Time Rate` 倍速だと通知も加速）
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `Product.products(for:)` が空配列 | Scheme で `.storekit` 未選択 | Edit Scheme → Run → Options → StoreKit Configuration |
+| Introductory Offer がアクティブにならない | Subscription Group が違う | 月額・年額・Intro Offer が同一 Group に属しているか |
+| 購入後 `state == .unknown` のまま | `refreshEntitlements` 呼び忘れ | `Transaction.updates` リスナーが起動しているか確認、または手動で `await store.refreshEntitlements()` |
+| Time Rate を変えても何も起きない | シミュレータを完全に再起動 | `xcrun simctl shutdown all` → 再起動 |
+
+## 本番リリース前のチェック
+
+- [ ] Scheme から `.storekit` を **外す** または **None** にする
+- [ ] Configuration.storekit はリポジトリに含めて良い（個人情報なし）
+- [ ] Sandbox アカウントで実機テストを完了
+- [ ] App Store Connect の本番商品で動作することを TestFlight ビルドで確認
+
+## 公式ドキュメント
+
+- [Setting up StoreKit testing in Xcode](https://developer.apple.com/documentation/Xcode/setting-up-storekit-testing-in-xcode)
+- [Creating a StoreKit configuration file](https://developer.apple.com/documentation/Xcode/setting-up-storekit-testing-in-xcode#Create-a-StoreKit-configuration-file)
+- [Testing in-app purchases with sandbox](https://developer.apple.com/documentation/storekit/testing-in-app-purchases-with-sandbox)
+
+## 次のステップ
+
+→ [06. Firebase Project / iOS SDK 統合](06-firebase-analytics.md)

--- a/docs/guides/37-deployment-setup/06-firebase-analytics.md
+++ b/docs/guides/37-deployment-setup/06-firebase-analytics.md
@@ -1,0 +1,159 @@
+# 06. Firebase Project / iOS SDK 統合
+
+## 目的
+
+KPI 計測（Trial→Paid 25% / 3ヶ月継続 60% / アクティベーション率）のため Firebase Analytics（GA4）を iOS から起動時にイベント送信できる状態にする。Crashlytics も同パッケージで取れるので併用する。
+
+## 前提条件
+
+- GCP プロジェクト `cycle-journal` が存在
+- 同プロジェクトに Firebase が紐付け可能（請求先アカウント設定済）
+- Xcode 16+
+
+## 手順
+
+### 1. Firebase Project の作成 / 紐付け
+
+1. [Firebase Console](https://console.firebase.google.com/) → **Add project**
+2. プロジェクト名で **既存の GCP プロジェクト `cycle-journal` を選択** することを推奨
+   - 新規作成すると `cycle-journal-XXXXX` の別 GCP プロジェクトになり、Firestore とテナント分離されてしまう
+3. Google Analytics を **有効化**
+   - Analytics account: 既存または新規作成
+   - データの保存場所: **United States** または **Region with similar policies**（GA4 のグローバル設定）
+
+### 2. iOS App の登録
+
+1. Firebase Console → **+ Add app** → iOS アイコン
+2. **iOS bundle ID**: `com.akitoando.CycleJournal`
+3. App nickname: `CycleJournal iOS`
+4. App Store ID: 後で入力可
+5. **Register App**
+6. **Download GoogleService-Info.plist** をクリック
+7. ダウンロードしたファイルを `ios/Cycle/` 配下に配置
+8. Xcode で **左サイドバーにドラッグ&ドロップ** → **Cycle ターゲットを選択 / Copy items if needed: ON**
+
+> File System Synchronized Groups を使っているので、ファイルを `ios/Cycle/` に置くだけで自動的にターゲットに含まれる。
+
+### 3. Firebase SDK の追加（Swift Package Manager）
+
+1. Xcode → **File → Add Package Dependencies...**
+2. 検索: `https://github.com/firebase/firebase-ios-sdk`
+3. Dependency Rule: **Up to Next Major Version** / 11.0.0 以上
+4. **Add Package**
+5. 追加するライブラリを選択（Cycle ターゲットへ）:
+   - **FirebaseAnalytics** （必須）
+   - **FirebaseCrashlytics** （推奨）
+6. **Add Package**
+
+### 4. アプリ起動時の初期化
+
+`ios/Cycle/App/CycleApp.swift` に以下を追加:
+
+```swift
+import FirebaseCore
+import SwiftUI
+
+@main
+struct CycleApp: App {
+    init() {
+        FirebaseApp.configure()
+    }
+    // ... 既存の body / @StateObject 群
+}
+```
+
+### 5. AnalyticsLogger ラッパー作成
+
+`ios/Cycle/Shared/Utilities/AnalyticsLogger.swift` を新規作成（コードは別 PR で実装、本書は配置先のみ指示）:
+
+```swift
+import FirebaseAnalytics
+import Foundation
+
+enum AnalyticsEvent: String {
+    case onboardingStart = "onboarding_start"
+    case onboardingComplete = "onboarding_complete"
+    case journalFirstEntryCreated = "journal_first_entry_created"
+    case journalEntryCreated = "journal_entry_created"
+    case coachFirstMessageSent = "coach_first_message_sent"
+    case coachMessageSent = "coach_message_sent"
+    case paywallViewed = "paywall_viewed"
+    case paywallDismissed = "paywall_dismissed"
+    case trialStarted = "trial_started"  // server-side でも発火
+    // ... 他のイベント
+}
+
+enum AnalyticsLogger {
+    static func log(_ event: AnalyticsEvent, params: [String: Any]? = nil) {
+        Analytics.logEvent(event.rawValue, parameters: params)
+    }
+
+    static func setUserId(_ id: String?) {
+        Analytics.setUserID(id)
+    }
+
+    static func setUserProperty(_ value: String?, forName name: String) {
+        Analytics.setUserProperty(value, forName: name)
+    }
+}
+```
+
+### 6. ATT 不要設定
+
+`Info.plist` に `NSUserTrackingUsageDescription` を **追加しない**。`AdSupport.framework` をリンクしていなければ、Firebase Analytics は IDFA を取得せず、ATT ダイアログも出ない（CVR 維持）。
+
+### 7. Crashlytics の dSYM アップロード設定
+
+1. Xcode → Cycle ターゲット → **Build Phases**
+2. **+ → New Run Script Phase**
+3. Script:
+   ```
+   ${PODS_ROOT:-${BUILD_DIR%/Build/*}/SourcePackages/checkouts}/firebase-ios-sdk/Crashlytics/run
+   ```
+4. **Input Files**:
+   - `$(BUILT_PRODUCTS_DIR)/$(INFOPLIST_PATH)`
+   - `${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}`
+
+### 8. .gitignore の確認
+
+`GoogleService-Info.plist` には API キーが含まれるが、**iOS Firebase の API キーは公開情報扱い**（Bundle ID と紐付いており他アプリから使えない）。コミットして問題ない。
+
+ただし社内ポリシーで `.gitignore` する場合は `ios/Cycle/GoogleService-Info.plist` を追加し、CI で復元する形にする。
+
+## 検証
+
+### 動作確認
+
+1. Xcode で実機ビルド & 起動
+2. アプリを 30 秒程度操作
+3. Firebase Console → **Analytics → DebugView**
+   - シミュレータからのイベントは: Xcode の Run Arguments に `-FIRDebugEnabled` を追加して再起動 → DebugView に即時表示
+   - 実機: `xcrun simctl spawn booted log stream | grep FIRAnalytics` でログ確認
+
+4. Firebase Console → **Crashlytics**
+   - 「Set up Crashlytics」が完了し「Crash-free users」に最初のセッションが反映される（数分かかる）
+
+### Analytics の初期イベント
+
+`first_open` / `session_start` / `screen_view` などは Firebase が自動収集する。カスタムイベントは AnalyticsLogger 経由で送信したものが Console に出る。
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| DebugView にイベントが出ない | `-FIRDebugEnabled` 未設定 | Scheme → Arguments Passed On Launch に追加 |
+| `FirebaseApp.configure()` でクラッシュ | `GoogleService-Info.plist` がターゲットに含まれていない | Project Navigator で plist を選択し Target Membership にチェック |
+| Crashlytics にクラッシュが出ない | dSYM 未アップロード | Run Script Phase を確認、アーカイブ後に dSYM が `~/Library/Developer/Xcode/Archives/...` にあるか |
+| `ATT` ダイアログが出てしまう | `AdSupport.framework` をリンクしている | Build Phases → Link Binary With Libraries から削除 |
+| Firebase と既存 GCP プロジェクトが別になっている | 紐付けミスで Firestore とテナント分離 | Firebase プロジェクトを削除 → 既存 GCP プロジェクトを選択して再作成 |
+
+## 公式ドキュメント
+
+- [Add Firebase to your Apple project](https://firebase.google.com/docs/ios/setup)
+- [Get started with Google Analytics](https://firebase.google.com/docs/analytics/get-started?platform=ios)
+- [Crashlytics for Apple](https://firebase.google.com/docs/crashlytics/get-started?platform=ios)
+- [Apple App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency)
+
+## 次のステップ
+
+→ [07. GA4 Measurement Protocol API secret 発行](07-ga4-measurement-protocol.md)

--- a/docs/guides/37-deployment-setup/07-ga4-measurement-protocol.md
+++ b/docs/guides/37-deployment-setup/07-ga4-measurement-protocol.md
@@ -1,0 +1,155 @@
+# 07. GA4 Measurement Protocol API secret 発行
+
+## 目的
+
+サーバーサイド（FastAPI）から GA4 にイベントを送信できるようにする。
+PR #44 の `app/services/analytics_service.py` が `https://www.google-analytics.com/mp/collect` に POST する際に必要な **Measurement ID** と **API Secret** を発行する。
+
+サーバーサイドで送るイベント:
+- `trial_started` (StoreKit 購入時に iOS でも発火するが server 重複 OK)
+- `trial_converted_to_paid` (ASSN V2 `DID_RENEW` 初回)
+- `trial_expired_without_conversion` (ASSN V2 `EXPIRED`)
+- `subscription_renewed`
+- `subscription_cancelled`
+- `subscription_refunded`
+
+## 前提条件
+
+- [06](06-firebase-analytics.md) 完了（Firebase Analytics が iOS で動作している）
+
+## 手順
+
+### 1. Measurement ID の確認
+
+1. [Firebase Console](https://console.firebase.google.com/) → プロジェクト → **Project Settings**（歯車）
+2. **Integrations** タブ → **Google Analytics → Manage**
+3. [GA4 Admin](https://analytics.google.com/) に遷移
+4. **Admin（歯車）** → **Data Streams** → 該当 iOS stream を選択
+5. **Measurement ID** をコピー（`G-XXXXXXXXXX` 形式）
+
+### 2. API Secret の発行
+
+GA4 Admin の同じ Data Stream 詳細画面下部:
+
+1. **Measurement Protocol API secrets**
+2. **Create**
+3. **Nickname**: `cyclejournal-api-server`
+4. **Create**
+5. **Secret value** をコピー（**一度しか表示されない**）
+
+> Secret は 10 個まで発行可能。古いものは Revoke して入れ替えできる。
+
+### 3. Secret Manager に格納
+
+```bash
+echo -n "G-XXXXXXXXXX" | \
+  gcloud secrets create ga4-measurement-id --data-file=-
+
+echo -n "your-secret-value-here" | \
+  gcloud secrets create ga4-api-secret --data-file=-
+```
+
+### 4. Cloud Run の環境変数に注入
+
+Terraform で:
+
+```hcl
+env {
+  name = "GA4_MEASUREMENT_ID"
+  value_source {
+    secret_key_ref { secret = "ga4-measurement-id", version = "latest" }
+  }
+}
+env {
+  name = "GA4_API_SECRET"
+  value_source {
+    secret_key_ref { secret = "ga4-api-secret", version = "latest" }
+  }
+}
+# GA4_ENDPOINT はデフォルト (Production) でよい。デバッグ時のみ /debug/mp/collect に切替
+```
+
+gcloud で:
+
+```bash
+gcloud run deploy cyclejournal-api \
+  --update-secrets=GA4_MEASUREMENT_ID=ga4-measurement-id:latest,\
+GA4_API_SECRET=ga4-api-secret:latest
+```
+
+### 5. サービスアカウントに権限付与
+
+```bash
+SERVICE_ACCOUNT="$(gcloud run services describe cyclejournal-api \
+  --region=asia-northeast1 \
+  --format='value(spec.template.spec.serviceAccountName)')"
+
+for SECRET in ga4-measurement-id ga4-api-secret; do
+  gcloud secrets add-iam-policy-binding "$SECRET" \
+    --member="serviceAccount:${SERVICE_ACCOUNT}" \
+    --role="roles/secretmanager.secretAccessor"
+done
+```
+
+## 検証
+
+### Debug Endpoint でドライラン
+
+GA4 には Production と同等の検証用エンドポイントがある:
+`https://www.google-analytics.com/debug/mp/collect`
+
+一時的に Cloud Run の `GA4_ENDPOINT` を debug 版に切り替え、Python REPL から呼ぶ:
+
+```bash
+cd api
+.venv/bin/python <<'EOF'
+import asyncio, os
+os.environ["GA4_MEASUREMENT_ID"] = "G-XXXXXXXXXX"
+os.environ["GA4_API_SECRET"] = "your-secret-value"
+os.environ["GA4_ENDPOINT"] = "https://www.google-analytics.com/debug/mp/collect"
+
+from app.services.analytics_service import send_event
+
+async def main():
+    result = await send_event(
+        client_id="test-client-123",
+        event_name="trial_converted_to_paid",
+        params={"product_id": "yearly_14400", "revenue_jpy": 14400},
+        event_id="test-uuid-1",
+    )
+    print(result)
+
+asyncio.run(main())
+EOF
+```
+
+`200` が返り、debug endpoint は `validationMessages: []` を返せば成功。
+
+### Realtime レポート確認
+
+Production endpoint に向けて Cloud Run から実イベントを送り、GA4 Realtime レポートに反映されるか:
+
+1. ASSN V2 webhook を Sandbox で発火させる（[04](04-assn-v2-webhook.md) の Test Notification）
+2. Cloud Run 内で `send_event` が呼ばれる（コード統合は後続 PR で）
+3. GA4 → **Reports → Realtime** に `trial_converted_to_paid` イベントが 30 秒以内に表示
+
+> Production レポート（Realtime 以外）には反映に 24-48 時間かかる。
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `400 Bad Request` | client_id 未設定 or params の型不正 | params の値は文字列・数値・bool のみ。Dict/Array 不可 |
+| `2xx 返るが Realtime に出ない` | Measurement ID が iOS の物と違う | Data Streams で iOS stream の ID を再確認 |
+| `event_id` で重複排除されない | event_id を params に入れていない | `app/services/analytics_service.py` の実装通り、params に同梱必須 |
+| `send_event` が no-op になる | secret 未設定 | `gcloud secrets versions list ga4-api-secret` で確認 |
+
+## 公式ドキュメント
+
+- [GA4 Measurement Protocol](https://developers.google.com/analytics/devguides/collection/protocol/ga4)
+- [Sending events](https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events)
+- [Validating events](https://developers.google.com/analytics/devguides/collection/protocol/ga4/validating-events)
+
+## 次のステップ
+
+→ [08. BigQuery export と Looker Studio ダッシュボード](08-bigquery-looker-studio.md)

--- a/docs/guides/37-deployment-setup/08-bigquery-looker-studio.md
+++ b/docs/guides/37-deployment-setup/08-bigquery-looker-studio.md
@@ -1,0 +1,213 @@
+# 08. BigQuery export と Looker Studio ダッシュボード
+
+## 目的
+
+Firebase Analytics（GA4）で収集したイベントを BigQuery に自動エクスポートし、Looker Studio で「Trial→Paid 転換率」「3ヶ月継続率」「アクティベーション率」を可視化する。
+
+GA4 内蔵レポートでは粒度が浅いため、ASSN V2 から FastAPI が書き込む Firestore の `users/{uid}/subscription` テーブルと **SQL で JOIN** できる BigQuery export を中核に据える。
+
+## 前提条件
+
+- [06](06-firebase-analytics.md) / [07](07-ga4-measurement-protocol.md) 完了
+- GCP 課金アカウントが Firebase プロジェクトに紐付け済（Blaze プラン）
+  - BQ export 自体は無料だが Firebase が Blaze 必須
+
+## 手順
+
+### 1. BigQuery export 有効化
+
+1. [Firebase Console](https://console.firebase.google.com/) → プロジェクト → **Project Settings**（歯車）
+2. **Integrations** タブ
+3. **BigQuery** → **Link**
+4. **iOS app** を選択
+5. **Configure integration**:
+   - **Daily** ✅ チェック（毎日 1 回まとめてエクスポート）
+   - **Streaming** ✅ チェック（リアルタイム、追加コストあり、デバッグ時のみで OK）
+   - **Include advertising identifiers**: OFF（ATT 不要設定維持）
+6. **Link to BigQuery**
+
+24 時間以内に BQ にデータセットが作成される:
+- データセット名: `analytics_<property_id>`
+- テーブル名: `events_YYYYMMDD`（日次）、`events_intraday_YYYYMMDD`（streaming 時）
+
+### 2. Firestore → BigQuery export 設定
+
+サブスクリプション状態（`users/{uid}/subscription`）を BQ に取り込む。
+
+**Option A**: Firebase Extensions の `Stream Firestore to BigQuery`
+1. Firebase Console → **Extensions** → **Stream Firestore to BigQuery**
+2. Install:
+   - **Source Collection Path**: `users/{userId}/subscription`
+   - **Dataset ID**: `firestore_export`
+   - **Table ID**: `subscriptions`
+   - **Backfill existing documents**: Yes
+3. Install Extension
+
+**Option B**: Cloud Functions で手動同期（既存運用がある場合）
+
+### 3. SQL ビュー作成
+
+BigQuery Console で以下のビューを作成。`PROJECT_ID` `analytics_NNNN` `firestore_export` は実値で置換:
+
+#### a) Trial Started ユーザー
+```sql
+CREATE OR REPLACE VIEW `cycle-journal.analytics.trial_started_users` AS
+SELECT
+  user_pseudo_id,
+  TIMESTAMP_MICROS(event_timestamp) AS started_at,
+  (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'product_id') AS product_id,
+  DATE(TIMESTAMP_MICROS(event_timestamp)) AS started_date,
+FROM `cycle-journal.analytics_NNNN.events_*`
+WHERE event_name = 'trial_started';
+```
+
+#### b) Trial → Paid 転換
+```sql
+CREATE OR REPLACE VIEW `cycle-journal.analytics.trial_conversion` AS
+WITH started AS (
+  SELECT user_pseudo_id, started_at, product_id
+  FROM `cycle-journal.analytics.trial_started_users`
+),
+converted AS (
+  SELECT
+    user_pseudo_id,
+    TIMESTAMP_MICROS(event_timestamp) AS converted_at,
+    (SELECT value.string_value FROM UNNEST(event_params) WHERE key = 'product_id') AS product_id,
+  FROM `cycle-journal.analytics_NNNN.events_*`
+  WHERE event_name = 'trial_converted_to_paid'
+)
+SELECT
+  s.user_pseudo_id,
+  s.product_id,
+  s.started_at,
+  c.converted_at,
+  c.converted_at IS NOT NULL AS converted,
+  TIMESTAMP_DIFF(c.converted_at, s.started_at, HOUR) AS hours_to_convert
+FROM started s
+LEFT JOIN converted c USING (user_pseudo_id);
+```
+
+#### c) Trial→Paid 転換率（KPI: 25%）
+```sql
+CREATE OR REPLACE VIEW `cycle-journal.analytics.kpi_trial_conversion_rate` AS
+SELECT
+  DATE_TRUNC(DATE(started_at), WEEK(MONDAY)) AS cohort_week,
+  COUNT(*) AS trials,
+  COUNTIF(converted) AS conversions,
+  SAFE_DIVIDE(COUNTIF(converted), COUNT(*)) AS conversion_rate
+FROM `cycle-journal.analytics.trial_conversion`
+GROUP BY cohort_week
+ORDER BY cohort_week;
+```
+
+#### d) 3 ヶ月継続率（KPI: 60%）
+```sql
+CREATE OR REPLACE VIEW `cycle-journal.analytics.kpi_three_month_retention` AS
+WITH converted AS (
+  SELECT
+    user_pseudo_id,
+    converted_at,
+  FROM `cycle-journal.analytics.trial_conversion`
+  WHERE converted
+    AND converted_at < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 90 DAY)
+),
+still_active AS (
+  SELECT
+    document_id AS user_id,
+    data.status AS status,
+    TIMESTAMP_DIFF(CURRENT_TIMESTAMP(),
+      TIMESTAMP(data.purchasedAt), DAY) AS days_since_purchase,
+  FROM `cycle-journal.firestore_export.subscriptions`
+  WHERE data.status = 'active'
+)
+SELECT
+  DATE_TRUNC(DATE(c.converted_at), WEEK(MONDAY)) AS cohort_week,
+  COUNT(*) AS converted_users,
+  COUNTIF(s.user_id IS NOT NULL) AS still_active_users,
+  SAFE_DIVIDE(COUNTIF(s.user_id IS NOT NULL), COUNT(*)) AS retention_rate
+FROM converted c
+LEFT JOIN still_active s ON c.user_pseudo_id = s.user_id
+GROUP BY cohort_week
+ORDER BY cohort_week;
+```
+
+#### e) アクティベーション率（first journal / signup）
+```sql
+CREATE OR REPLACE VIEW `cycle-journal.analytics.kpi_activation_rate` AS
+WITH signups AS (
+  SELECT
+    user_pseudo_id,
+    MIN(TIMESTAMP_MICROS(event_timestamp)) AS signup_at,
+  FROM `cycle-journal.analytics_NNNN.events_*`
+  WHERE event_name = 'signup_succeeded'
+  GROUP BY user_pseudo_id
+),
+first_journals AS (
+  SELECT
+    user_pseudo_id,
+    MIN(TIMESTAMP_MICROS(event_timestamp)) AS first_journal_at,
+  FROM `cycle-journal.analytics_NNNN.events_*`
+  WHERE event_name = 'journal_first_entry_created'
+  GROUP BY user_pseudo_id
+)
+SELECT
+  DATE_TRUNC(DATE(s.signup_at), WEEK(MONDAY)) AS cohort_week,
+  COUNT(*) AS signups,
+  COUNTIF(f.user_pseudo_id IS NOT NULL) AS activated,
+  SAFE_DIVIDE(COUNTIF(f.user_pseudo_id IS NOT NULL), COUNT(*)) AS activation_rate
+FROM signups s
+LEFT JOIN first_journals f USING (user_pseudo_id)
+GROUP BY cohort_week
+ORDER BY cohort_week;
+```
+
+### 4. Looker Studio ダッシュボード作成
+
+1. [Looker Studio](https://lookerstudio.google.com/) → **Create → Report**
+2. **Add data → BigQuery → cycle-journal → analytics → kpi_trial_conversion_rate**
+3. グラフ:
+   - **Time series chart**: `cohort_week` × `conversion_rate`、目標ライン 25% を Constant に追加
+   - **Scorecard**: 直近 4 週平均の `conversion_rate`
+4. 同様に他 3 ビューも `Add Data` してチャート化:
+   - 3-month retention (target 60%)
+   - Activation rate
+   - DAU / WAU
+5. 共有 → メンバーのメールに **Viewer** 権限で配布
+
+### 5. 自動更新
+
+- Looker Studio はデフォルトで BQ をリアルタイム参照
+- データの鮮度は GA4 BQ export の方式に依存:
+  - Daily export: 翌日 朝
+  - Streaming export: 数分以内
+
+## 検証
+
+### チェックリスト
+
+- [ ] BQ Console で `cycle-journal.analytics_NNNN.events_YYYYMMDD` テーブルが存在
+- [ ] `SELECT COUNT(*) FROM ...events_*` が 0 より大きい
+- [ ] `firestore_export.subscriptions` テーブルにレコードがある
+- [ ] 5 つのビューが SQL エラーなく `SELECT * LIMIT 10` できる
+- [ ] Looker Studio に 5 つのチャートが表示
+- [ ] 共有メンバーが「権限がありません」エラーなくアクセスできる
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| BQ にデータセットが作られない | Firebase Analytics と GCP プロジェクトが分離 | [06](06-firebase-analytics.md) で既存 GCP プロジェクトに Firebase を紐付け |
+| `events_*` テーブルが空 | iOS アプリで Firebase 初期化されていない | `FirebaseApp.configure()` を確認 |
+| `firestore_export.subscriptions` が空 | Extension の Backfill 未実行 / write event なし | Extension の "Run backfill" を実行 |
+| Looker Studio で BQ コネクタが選べない | 課金アカウント未設定 | Firebase Blaze プランに upgrade |
+
+## 公式ドキュメント
+
+- [Export Firebase data to BigQuery](https://firebase.google.com/docs/projects/bigquery-export)
+- [BigQuery Export schema for GA4](https://support.google.com/analytics/answer/7029846?hl=en)
+- [Stream Firestore to BigQuery extension](https://extensions.dev/extensions/firebase/firestore-bigquery-export)
+- [Looker Studio Help](https://support.google.com/looker-studio)
+
+## 次のステップ
+
+→ [09. Vertex AI Model Garden のモデル ID 検証](09-vertex-ai-models.md)

--- a/docs/guides/37-deployment-setup/09-vertex-ai-models.md
+++ b/docs/guides/37-deployment-setup/09-vertex-ai-models.md
@@ -1,0 +1,156 @@
+# 09. Vertex AI Model Garden のモデル ID 検証
+
+## 目的
+
+PR #42 で `config.py` のデフォルトに pin した Claude モデル ID（`claude-sonnet-4-5@20250929` / `claude-haiku-4-5@20251001`）が `asia-northeast1` リージョンで実際に GA 提供されているか確認し、必要なら環境変数で上書きする。
+
+Vertex AI のモデル命名規則は **Anthropic 公式 API とは異なる**:
+- Anthropic 直: `claude-sonnet-4-6`
+- Vertex AI: `claude-sonnet-4-5@20250929`（バージョン日付 サフィックス）
+
+リージョンごとに利用可能なモデルが異なり、特に新リリース直後は東京リージョン（`asia-northeast1`）が遅れることがある。
+
+## 前提条件
+
+- GCP プロジェクト `cycle-journal` の **Vertex AI User** 権限
+- `gcloud` CLI 認証済
+
+## 手順
+
+### 1. Model Garden でモデル確認
+
+1. [GCP Console → Vertex AI → Model Garden](https://console.cloud.google.com/vertex-ai/model-garden)
+2. 検索バーに `claude` と入力
+3. 利用可能なモデル一覧:
+   - Claude Sonnet 4.5
+   - Claude Haiku 4.5
+   - Claude Opus 4.x
+4. 該当モデルをクリック → **MODEL DETAILS**
+5. 以下を確認:
+   - **Regional availability**: `asia-northeast1` が含まれているか
+   - **Model ID**: 正確な ID（`claude-sonnet-4-5@20250929` 等の `@YYYYMMDD` 形式）
+
+### 2. CLI でモデル ID 確認
+
+```bash
+gcloud ai models list \
+  --region=asia-northeast1 \
+  --filter="displayName:claude" \
+  --format="table(displayName,name)"
+```
+
+または `curl` で直接 API を叩いて検証:
+
+```bash
+ACCESS_TOKEN=$(gcloud auth print-access-token)
+PROJECT_ID=cycle-journal
+REGION=asia-northeast1
+MODEL_ID="claude-sonnet-4-5@20250929"
+
+curl -sS -X POST \
+  "https://${REGION}-aiplatform.googleapis.com/v1/projects/${PROJECT_ID}/locations/${REGION}/publishers/anthropic/models/${MODEL_ID}:rawPredict" \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "anthropic_version": "vertex-2023-10-16",
+    "max_tokens": 50,
+    "messages": [{"role": "user", "content": "こんにちは"}]
+  }' | jq '.content[0].text'
+```
+
+`"こんにちは" + 何か応答` が返れば OK。404 / 403 ならモデル ID か権限が誤り。
+
+### 3. 利用申請（必要な場合のみ）
+
+新規モデルは初回利用申請が必要なことがある:
+
+1. Model Garden の該当モデルページ
+2. **REQUEST ACCESS** ボタンがあればクリック
+3. 利用目的を記入して送信
+4. 通常 24 時間以内に承認メールが届く
+
+### 4. config.py の値 vs 実 ID の照合
+
+```bash
+cd api
+.venv/bin/python -c "
+from app.config import settings
+print('Coach:', settings.claude_model_coach)
+print('Quick:', settings.claude_model_quick)
+"
+# Coach: claude-sonnet-4-5@20250929
+# Quick: claude-haiku-4-5@20251001
+```
+
+Model Garden で確認した実際の Model ID と一致していれば変更不要。
+
+### 5. env var で上書き（必要な場合）
+
+`asia-northeast1` で違うバージョン日付の場合や、本番運用時にバージョン固定したい場合:
+
+```bash
+# Secret Manager に格納する場合
+echo -n "claude-sonnet-4-5@20251015" | \
+  gcloud secrets create claude-model-coach --data-file=-
+
+echo -n "claude-haiku-4-5@20251101" | \
+  gcloud secrets create claude-model-quick --data-file=-
+
+# Cloud Run に注入
+gcloud run deploy cyclejournal-api \
+  --update-secrets=CLAUDE_MODEL_COACH=claude-model-coach:latest,\
+CLAUDE_MODEL_QUICK=claude-model-quick:latest
+```
+
+または直接 env var で:
+
+```bash
+gcloud run deploy cyclejournal-api \
+  --set-env-vars=CLAUDE_MODEL_COACH=claude-sonnet-4-5@20251015,\
+CLAUDE_MODEL_QUICK=claude-haiku-4-5@20251101
+```
+
+## 検証
+
+### Cloud Run 上で実呼び出し
+
+デプロイ後、`/coach` エンドポイントを認証付きで叩いて応答が返ること:
+
+```bash
+ACCESS_TOKEN="<アプリ発行の JWT>"
+
+curl -sS -X POST https://api.cycle-journal.example.com/coach \
+  -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"message":"今日は疲れた"}' | jq
+```
+
+### LangGraph 各ノードのモデル切替確認
+
+Cloud Run ログで Haiku 呼び出しが分離されているか:
+
+```bash
+gcloud logging read "resource.type=cloud_run_revision \
+  AND resource.labels.service_name=cyclejournal-api \
+  AND textPayload:claude-haiku" \
+  --limit 10
+```
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|---|---|---|
+| `404 Not Found` | モデル ID が違う / リージョンに無い | Model Garden で正確な ID 確認 |
+| `403 Permission Denied` | Vertex AI User 権限不足 | `roles/aiplatform.user` を Cloud Run SA に付与 |
+| `RESOURCE_EXHAUSTED` | Quota 超過 | Console → IAM & Admin → Quotas で増枠申請 |
+| Prompt caching が効かない | Vertex AI は cache_control サポート最新版でのみ可能 | リージョン・モデルバージョンを確認、SDK バージョンも `anthropic[vertex]>=0.42.0` |
+
+## 公式ドキュメント
+
+- [Use Claude models on Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude)
+- [Anthropic Vertex AI versions](https://docs.anthropic.com/en/api/claude-on-vertex-ai)
+- [Vertex AI Model Garden](https://cloud.google.com/model-garden)
+
+## 次のステップ
+
+→ [10. Terms / Privacy URL の差し替え](10-legal-urls.md)

--- a/docs/guides/37-deployment-setup/10-legal-urls.md
+++ b/docs/guides/37-deployment-setup/10-legal-urls.md
@@ -1,0 +1,76 @@
+# 10. Terms / Privacy URL の差し替え
+
+## 目的
+
+PR #45 で実装した `PaywallView.swift` にプレースホルダで入っている利用規約・プライバシーポリシー URL を、公開済の本番 URL に差し替える。**App Store Review でこれらが本物のページに到達しないとリジェクト対象**。
+
+## 前提条件
+
+- 利用規約・プライバシーポリシーが公開済（HTML / Markdown のホスティング）
+- 推奨ホスティング:
+  - GitHub Pages（`docs/legal/` を public 公開する場合）
+  - Notion → Public Page
+  - 独自ドメイン CMS
+  - App Store Connect の **Privacy Policy URL** フィールドにも同じ URL を入れる
+
+## 手順
+
+### 1. 公開ページの準備
+
+すでに `docs/legal/` 配下にドラフトがある場合はそれを公開化:
+
+```bash
+ls docs/legal/
+# terms.md, privacy.md, ...
+```
+
+GitHub Pages で公開する場合:
+1. **Settings → Pages** → **Source**: `main` ブランチ `/docs` フォルダ
+2. URL 例: `https://akitoando.github.io/cycle-journal/legal/terms`
+
+独自ドメインなら DNS 設定後 `https://cycle-journal.app/legal/terms` 等。
+
+### 2. PaywallView.swift の差し替え
+
+```swift
+// ios/Cycle/Features/Subscription/Views/PaywallView.swift
+let termsURL = URL(string: "https://akitoando.github.io/cycle-journal/legal/terms")!
+let privacyURL = URL(string: "https://akitoando.github.io/cycle-journal/legal/privacy")!
+```
+
+### 3. App Store Connect の Privacy 設定
+
+1. App Store Connect → 対象アプリ → **App Information**
+2. **Privacy Policy URL** に同じプライバシー URL を入力
+3. **App Privacy** タブで収集データを宣言（Firebase Analytics 利用なら "Product Interaction" / "Crash Data" / "Performance Data" 等を選択）
+4. **Save**
+
+### 4. App Store Server Notifications V2 のサブスク利用規約
+
+iOS のサブスク商品には **EULA**（End User License Agreement）が必須。Apple のデフォルト EULA を使う場合は何もしない。独自 EULA を使う場合は `App Information → Custom EULA` に URL 登録。
+
+### 5. 動作確認
+
+- iOS シミュレータで Paywall を表示 → 「利用規約」「プライバシーポリシー」リンクをタップ
+- Safari で実 URL が開く
+- 404 や白画面でないこと
+
+## 検証
+
+### チェックリスト
+
+- [ ] `PaywallView.swift` の `termsURL` / `privacyURL` が本番 URL
+- [ ] 両 URL が 200 OK で実コンテンツを返す
+- [ ] App Store Connect の Privacy Policy URL に同じ URL を登録
+- [ ] App Privacy で収集データを正確に宣言
+- [ ] Paywall からのタップで Safari が立ち上がりページ表示
+
+## 公式ドキュメント
+
+- [App Store Review Guideline 5.1.1 (Data Collection and Storage)](https://developer.apple.com/app-store/review/guidelines/#data-collection-and-storage)
+- [App privacy details on the App Store](https://developer.apple.com/app-store/app-privacy-details/)
+- [Schedule, report, and refund in-app purchases](https://developer.apple.com/help/app-store-connect/manage-subscriptions/offer-a-subscription/)
+
+## 完了
+
+すべてのセットアップが終わったら → [動作確認チェックリスト](verification-checklist.md)

--- a/docs/guides/37-deployment-setup/README.md
+++ b/docs/guides/37-deployment-setup/README.md
@@ -1,0 +1,55 @@
+# #37 デプロイメントセットアップ手順
+
+Issue #37 で実装した B 系（AI モデル分離）／A 系（IAP）／C 系（オンボーディング・通知・Analytics）を **本番稼働させるための手動セットアップ手順** をまとめた索引。
+
+PR #42 〜 #47 のコードはすべて main にマージ済だが、以下の外部システム設定が揃わないと動かない。**順序通りに進めることを推奨**。
+
+## 進行表
+
+| # | ドキュメント | 想定時間 | 担当 | 完了条件 |
+|---|---|---|---|---|
+| 01 | [App Store Connect: サブスクリプション商品設定](01-app-store-connect-iap.md) | 30 分 | 開発者 | `monthly_1800` / `yearly_14400` 商品が "Ready to Submit" 状態 |
+| 02 | [IAP Key (.p8) と Secret Manager](02-iap-key-secret-manager.md) | 20 分 | 開発者 | Cloud Run 環境変数に `APPLE_IAP_PRIVATE_KEY` が注入されている |
+| 03 | [Apple PKI ルート証明書配置](03-apple-root-certs.md) | 10 分 | 開発者 | `api/app/certs/AppleRootCA-G3.cer` が存在し Docker イメージに含まれる |
+| 04 | [App Store Server Notifications V2 URL 登録](04-assn-v2-webhook.md) | 15 分 | 開発者 | Sandbox / Production 両方の URL が登録され、Test Notification が 200 で返る |
+| 05 | [.storekit Configuration ファイル作成](05-storekit-config-xcode.md) | 15 分 | 開発者 | Xcode の Scheme で `Configuration.storekit` が選択され、シミュレータで Sandbox 課金なしに動作 |
+| 06 | [Firebase Project / iOS SDK 統合](06-firebase-analytics.md) | 30 分 | 開発者 | `GoogleService-Info.plist` が `ios/Cycle/` に存在し、Crashlytics ダッシュボードに最初のセッションが届く |
+| 07 | [GA4 Measurement Protocol API secret 発行](07-ga4-measurement-protocol.md) | 10 分 | 開発者 | Secret Manager に `GA4_API_SECRET` が格納され、Cloud Run 環境変数で参照 |
+| 08 | [BigQuery export と Looker Studio ダッシュボード](08-bigquery-looker-studio.md) | 60 分 | 開発者 | Looker Studio に「Trial→Paid 転換率」「3ヶ月継続率」のグラフが出ている |
+| 09 | [Vertex AI Model Garden のモデル ID 検証](09-vertex-ai-models.md) | 10 分 | 開発者 | `claude-sonnet-4-5@...` / `claude-haiku-4-5@...` が `asia-northeast1` で GA 確認済 |
+| 10 | [Terms / Privacy URL の差し替え](10-legal-urls.md) | 10 分 | 開発者 | `PaywallView.swift` の `termsURL` / `privacyURL` が公開 URL に差し替え済 |
+
+合計目安: 約 3 時間。
+
+## 依存関係
+
+```
+01 (App Store Connect 商品)
+  ├──> 04 (ASSN V2 URL 登録)
+  └──> 05 (.storekit Config)
+02 (IAP Key) ──> 04 (ASSN V2 URL 登録: 検証に必要)
+03 (Apple PKI) ──> 04 (検証に必要)
+06 (Firebase Project) ──> 07 (GA4 secret) ──> 08 (BQ export)
+09 (Vertex AI) [独立]
+10 (Legal URL) [独立]
+```
+
+## 完了後の動作確認
+
+すべてのセットアップが完了したら [動作確認チェックリスト](verification-checklist.md) を実施する。
+
+## 公式ドキュメント早見表
+
+| 領域 | 公式 URL |
+|---|---|
+| App Store Connect Help | https://developer.apple.com/help/app-store-connect/ |
+| Apple Developer: Auto-Renewable Subscriptions | https://developer.apple.com/documentation/storekit/in-app_purchase/auto-renewable_subscriptions |
+| App Store Server API | https://developer.apple.com/documentation/appstoreserverapi |
+| App Store Server Notifications V2 | https://developer.apple.com/documentation/appstoreservernotifications |
+| Apple PKI Repository | https://www.apple.com/certificateauthority/ |
+| Firebase iOS SDK | https://firebase.google.com/docs/ios/setup |
+| GA4 Measurement Protocol | https://developers.google.com/analytics/devguides/collection/protocol/ga4 |
+| Firebase → BigQuery export | https://firebase.google.com/docs/projects/bigquery-export |
+| Looker Studio | https://lookerstudio.google.com/ |
+| Vertex AI: Claude models | https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude |
+| App Store Review Guidelines | https://developer.apple.com/app-store/review/guidelines/ |

--- a/docs/guides/37-deployment-setup/verification-checklist.md
+++ b/docs/guides/37-deployment-setup/verification-checklist.md
@@ -1,0 +1,123 @@
+# 動作確認チェックリスト
+
+セットアップ [01](01-app-store-connect-iap.md) 〜 [10](10-legal-urls.md) がすべて完了したあと、エンドツーエンドで動作確認するためのチェックリスト。
+
+## 1. 単体確認
+
+### A backend (IAP webhook)
+
+- [ ] Cloud Run の `cyclejournal-api` がデプロイされている
+- [ ] `gcloud secrets list | grep apple-iap` で 4 つの secret が存在
+- [ ] Cloud Run ログに `Loaded N certs` (N >= 1) が出ている
+- [ ] `curl https://api.../iap/apple/notifications -d '{}'` で `400 missing signedPayload` が返る
+- [ ] App Store Connect の **Request a Test Notification** で 200 が返り、Firestore `iap_notifications` に `TEST` ドキュメントが作成される
+
+### A iOS (StoreKit 2 + Paywall)
+
+- [ ] `Configuration.storekit` がプロジェクトに含まれている
+- [ ] Scheme で `.storekit` が選択されている（local テスト用）/ または None（Sandbox / Production テスト用）
+- [ ] シミュレータ起動 → Paywall 到達 → `Product.products(for:)` が 2 件返る
+- [ ] 「7日間無料で始める」タップ → `state == .trial(...)` になる
+- [ ] **Debug → StoreKit → Manage Transactions** で Refund → `state == .expired` になる
+
+### B (AI モデル分離)
+
+- [ ] `/coach` を認証付きで叩く → 応答が返る
+- [ ] Cloud Run ログに `claude-sonnet-4-5@...` 呼び出し（generate_response）が記録される
+- [ ] LangGraph を有効化（`USE_LANGGRAPH=true`）した場合、`claude-haiku-4-5@...` 呼び出し（analyze_emotion 等）も出る
+- [ ] 同一 system prompt の連続呼び出しで `cache_read_input_tokens > 0`（Vertex AI レスポンスメタで確認、または Anthropic 直 API ログ）
+
+### C-1 (オンボーディングフロー)
+
+- [ ] アプリ初回起動 → Welcome → Cycle 概念 → Goal 選択（必須）→ Sign In → 初ジャーナル（必須）→ 通知 opt-in → Paywall の順に遷移
+- [ ] Goal 未選択で「つぎへ」を押しても進まない
+- [ ] 初ジャーナルテキスト空のままでは進まない
+- [ ] Paywall で購入完了 → ホームに遷移
+
+### C-2 (トライアル通知)
+
+- [ ] `.storekit` の Time Rate を `1s = 1d` にしてシミュレータで購入
+- [ ] Day1/3/6/7 のローカル通知がスケジュールされている
+  ```bash
+  xcrun simctl spawn booted log stream | grep "trial.day"
+  ```
+- [ ] StoreKit Manage Transactions で auto-renew をオフ → 通知が cancel される（解約検知連携 PR が必要）
+
+### C-3 (Analytics)
+
+- [ ] Firebase Analytics DebugView に `app_opened` / `signup_succeeded` / `journal_first_entry_created` が出る
+- [ ] サーバーから送った `trial_converted_to_paid` が GA4 Realtime に出る
+- [ ] BigQuery `analytics_NNNN.events_*` テーブルにデータが流入
+- [ ] Looker Studio で `kpi_trial_conversion_rate` チャートに値が出る
+
+## 2. エンドツーエンド: 7 日間トライアルフル走行
+
+`.storekit` の Time Rate を `1s = 1d` 加速で 1 周回す:
+
+1. シミュレータ起動 → 新規ユーザーで Apple Sign In（Sandbox アカウント）
+2. オンボーディング完了 → 初ジャーナル投稿 → 通知 opt-in → Paywall
+3. 「7日間無料で始める」タップ
+4. **Day 0**:
+   - Firestore `users/{uid}/subscription.status == "trial"`
+   - GA4 で `trial_started`
+   - 4 件のローカル通知（trial.day1〜7）がスケジュール
+5. **Day 1**（1秒待機）: 通知発火「今日の振り返りを 3 分で」
+6. **Day 3**: Goal 別の Day3 通知発火
+7. **Day 6**: 「明日トライアル終了」通知、解約導線含む
+8. **Day 7**: 課金 2h 前通知
+9. **Day 7 終了**: 自動課金成功 → Apple ASSN V2 `DID_RENEW` → Cloud Run 受信
+10. **Firestore**: `subscription.status == "active"`
+11. **GA4**: `trial_converted_to_paid` イベント
+12. **Looker Studio** で当該 cohort の conversion_rate が +1 件分上昇
+
+## 3. ネガティブパス
+
+### 解約パス
+1. Trial 中に **Manage Transactions → auto-renew オフ**
+2. ASSN V2 `DID_CHANGE_RENEWAL_STATUS` を Cloud Run が受信
+3. Firestore `subscription.autoRenewStatus == false`
+4. 解約検知 silent push → iOS が `cancelAllTrialNotifications` を呼ぶ
+5. 予約されていた Day3/6/7 通知が消える
+6. Day 7 で `EXPIRED` 通知 → Firestore `status == "expired"`、GA4 `trial_expired_without_conversion`
+
+### Refund パス
+1. Active sub に対し Manage Transactions → **Refund**
+2. ASSN V2 `REFUND` を受信
+3. Firestore `status == "revoked"`、GA4 `subscription_refunded`
+4. iOS `SubscriptionStore.state` が `.expired` になる
+
+### Receipt 改ざんパス
+1. 改ざんした `jwsRepresentation` を `POST /iap/apple/verify` に送る
+2. 400 invalid signature が返る
+3. ユーザーには「購入の検証に失敗しました」エラー表示
+
+## 4. App Store 提出前最終確認
+
+- [ ] `.storekit` を Scheme から **None** に変更
+- [ ] iOS bundle ID と App Store Connect の Bundle ID 一致
+- [ ] App Store Connect で商品が "Ready to Submit"
+- [ ] Paywall Review Screenshot を撮影 → App Store Connect にアップロード
+- [ ] Privacy Policy URL / Custom EULA URL 設定
+- [ ] App Privacy で収集データ宣言完了
+- [ ] TestFlight で内部テスターが Sandbox 課金を実行
+- [ ] Review Notes に「Sandbox テスト用アカウント不要、Apple のテスター用に通常購入フローをそのまま提供」と記載
+
+## 5. 本番デプロイ後監視
+
+最初の 7-14 日間は毎日確認:
+
+- [ ] Cloud Run エラーレート < 1%
+- [ ] ASSN V2 通知のリトライ率（同じ notificationUUID で 2 回以上届く割合）< 5%
+- [ ] Vertex AI クォータ使用率 < 80%
+- [ ] Firestore 読み書き量が想定範囲内
+- [ ] GA4 Realtime にイベントが定常的に流入
+- [ ] Crashlytics の Crash-free users > 99%
+- [ ] App Store Connect のサブスク tab で課金が発生していることを確認
+
+## トラブルが起きたら
+
+1. Cloud Run ログ → `gcloud logging read ... severity=ERROR`
+2. Firebase Console → Crashlytics
+3. App Store Connect → Sales and Trends（Sandbox は別タブ）
+4. GA4 → DebugView → 該当ユーザーの行動を追跡
+5. Firestore → `users/{uid}/subscription` と `iap_notifications/{uuid}` を直接確認


### PR DESCRIPTION
## Summary

PR #42〜#47 で実装した B/A/C 系を **本番稼働させるための手動セットアップ手順書** を `docs/guides/37-deployment-setup/` に追加。

合計目安 3 時間、依存関係付き 10 ステップ + 動作確認チェックリスト。

### 構成
- **[README.md](docs/guides/37-deployment-setup/README.md)** — 進行表 + 依存関係図 + 公式 URL 早見表
- **01** App Store Connect: サブスクリプション商品設定（Group / 月額 / 年額 + Intro Offer / Sandbox テスター）
- **02** IAP Key (.p8) と Secret Manager
- **03** Apple PKI ルート証明書配置
- **04** App Store Server Notifications V2 URL 登録
- **05** .storekit Configuration ファイル作成（Xcode）
- **06** Firebase Project / iOS SDK 統合
- **07** GA4 Measurement Protocol API secret 発行
- **08** BigQuery export と Looker Studio（KPI SQL ビュー 5 種付き）
- **09** Vertex AI Model Garden のモデル ID 検証
- **10** Terms / Privacy URL の差し替え
- **verification-checklist.md** — 単体確認 / E2E 7 日間フル走行 / ネガティブパス / 本番デプロイ後監視

各手順:
- 目的 / 前提条件
- 番号付き手順（コマンド・スクリーン操作）
- 検証方法
- トラブルシューティング表
- 公式ドキュメント URL

## Test plan

- [x] Markdown プレビュー表示確認
- [ ] 実際にセットアップを進めながら漏れがないか確認（次のアクション）

## Refs

- Issue #37: https://github.com/AkitoAndo/cycle-journal/issues/37
- 実装 PR: #42 (B), #43 (A backend), #44 (C-3 backend), #45 (A iOS), #46 (C-2), #47 (C-1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)