### PR TITLE
feat: UI調整・Liquid Glass対応・瞑想モード追加・ヘッダー統一

### DIFF
--- a/CHANGES_1.txt
+++ b/CHANGES_1.txt
@@ -1,0 +1,196 @@
+# AuthStore.swift 変更点
+
+## 変更日: 2026-05-18
+
+### 変更内容
+`checkAuthState()` に `#if DEBUG` ブロックを追加。
+
+DEBUGビルド時は認証処理をスキップし、モックユーザーで即座に認証済み状態にする。
+
+### 変更箇所
+- ファイル: AuthStore.swift
+- メソッド: `checkAuthState()`
+
+### 追加コード
+```swift
+#if DEBUG
+let mockUser = AuthUser(userId: "debug-user", email: "debug@test.com", fullName: "Debug User", createdAt: Date(), provider: .apple)
+currentUser = mockUser
+state = .authenticated(userId: "debug-user")
+return
+#endif
+```
+
+### 目的
+試験運転時にSign in with Apple / Google認証をスキップしてメイン画面に直接アクセスできるようにする。
+RELEASEビルドでは従来通りの認証フローが動作する。
+
+### 注意
+- APIコールはモックユーザーID（"debug-user"）で飛ぶため、バックエンドが必要な機能はエラーになる場合がある。
+- `No such module 'GoogleSignIn'` エラーはこの変更とは無関係。SPM/CocoaPodsの依存関係が未解決の可能性がある。
+
+---
+
+# JournalListView.swift / TaskListView.swift 変更点
+
+## 変更日: 2026-05-18
+
+### 変更内容
+＋ボタン（FloatingActionButton）のbottom paddingを `fabBottomPadding` から固定値に変更。
+
+### 変更箇所
+- `Features/Journal/Views/JournalListView.swift`
+- `Features/Tasks/Views/TaskListView.swift`
+
+### 変更前
+```swift
+.padding(.bottom, fabBottomPadding)
+
+private var fabBottomPadding: CGFloat {
+    if #available(iOS 26.0, *) {
+        return 80
+    } else {
+        return DesignSystem.Spacing.xl - 2
+    }
+}
+```
+
+### 変更後
+```swift
+.padding(.bottom, DesignSystem.Spacing.xl - 2)
+```
+
+### 目的
+デスクトップの参照版Cycleに合わせて＋ボタンの位置を統一。
+iOS 26で80ptに変わっていた挙動を元に戻す。
+
+---
+
+# FloatingActionButton.swift 変更点
+
+## 変更日: 2026-05-18
+
+### 変更内容
+iOS 26での `glassEffect` を廃止し、全OSで茶色（`DesignSystem.Colors.accent`）の背景に統一。
+
+### 変更前
+- iOS 26+: `glassEffect` + アクセントカラーのアイコン
+- iOS 17-25: アクセントカラー背景 + 白アイコン
+
+### 変更後
+- 全OS: アクセントカラー（茶色）背景 + 白アイコン + シャドウ
+
+---
+
+# JournalHeader.swift 変更点
+
+## 変更日: 2026-05-18
+
+### 変更内容
+「May 2026」ヘッダー欄を参照版Cycleの仕様に合わせた。
+
+### 変更箇所と内容
+1. 背景: `.modifier(GlassHeaderModifier())` → `.background(DesignSystem.Colors.background)`
+2. 月年フォント: `DesignSystem.Fonts.screenTitle` → `.system(size: 28, weight: .bold)`
+3. メニューアイコンフォント: `DesignSystem.Fonts.headerIcon` → `.system(size: 26)`
+4. `.accessibilityIdentifier("journal_menu")` を削除
+
+---
+
+# JournalHeader.swift 追加変更
+
+## 変更日: 2026-05-18
+
+### 変更内容
+月年表示を日本語ロケールに変更。「May 2026」→「2026年5月」
+
+### 変更箇所
+```swift
+// 変更前
+.formatted(.dateTime.year().month(.wide))
+// 変更後
+.formatted(.dateTime.year().month(.wide).locale(Locale(identifier: "ja_JP")))
+
+---
+
+# WeekCalendarView.swift 変更点
+
+## 変更日: 2026-05-18
+
+### 変更内容
+曜日表示を日本語（日月火水木金土）に変更。
+
+### 変更箇所
+```swift
+// 変更前
+Text(date, format: .dateTime.weekday(.abbreviated))
+    .textCase(.uppercase)
+
+// 変更後（配列から直接取得。ロケール依存なし）
+Text(["日", "月", "火", "水", "木", "金", "土"][Calendar.current.component(.weekday, from: date) - 1])
+
+---
+
+# ContentView.swift 変更点
+
+## 変更日: 2026-05-18
+
+### 変更内容
+DEBUGビルド時のサインイン画面スキップをAuthStore側からContentView側に移動。
+
+### 変更箇所
+```swift
+// 変更前
+switch authStore.state {
+case .unknown: splashView
+case .unauthenticated: SignInView()
+case .authenticated: mainContent
+}
+
+// 変更後
+#if DEBUG
+mainContent
+#else
+switch authStore.state {
+case .unknown: splashView
+case .unauthenticated: SignInView()
+case .authenticated: mainContent
+}
+#endif
+```
+
+### 目的
+AuthStore.checkAuthState()のTaskによる非同期処理タイミングの問題を回避し、
+確実にサインイン画面をスキップする。旧版Cycleと同じアプローチ。
+
+---
+
+# TaskHeader.swift 変更点
+
+## 変更日: 2026-05-18
+
+### 変更内容
+「Today's Focus」ヘッダーを旧Cycleの仕様に合わせた。
+
+### 変更箇所
+0. タイトルテキスト: `"Today's Focus"` → `"今日やること"`
+1. タイトルフォント: `DesignSystem.Fonts.screenTitle` → `.system(size: 28, weight: .bold)`
+2. メニューアイコンフォント: `DesignSystem.Fonts.headerIcon` → `.system(size: 26)`
+3. 背景: `.modifier(GlassHeaderModifier())` → `.background(DesignSystem.Colors.background)`
+4. `.accessibilityIdentifier("task_menu")` を削除
+
+---
+
+# WeekCalendarView.swift 追加変更
+
+## 変更日: 2026-05-18
+
+### 変更内容
+曜日の文字色を日付と同じ色（`textPrimary`）に統一。
+
+### 変更箇所
+```swift
+// 変更前
+.foregroundStyle(DesignSystem.Colors.textTertiary)
+// 変更後
+.foregroundStyle(DesignSystem.Colors.textPrimary)

--- a/CHANGES_2.txt
+++ b/CHANGES_2.txt
@@ -1,0 +1,306 @@
+================================================================================
+CHANGES.txt - Cycle Journal 開発記録
+================================================================================
+
+[2026-05-24] コードベース全体レビュー実施
+--------------------------------------------------------------------------------
+対象: Backend API / iOS Swift / Infrastructure / Documentation
+実施者: Claude Opus 4.6 によるコードレビュー
+ステータス: レビュー完了・改善提案のみ（実装なし）
+詳細: ~/Desktop/CycleJournal_CodeReview_20260524.pdf
+
+[2026-05-24] アプリ全体をライトモード固定
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/App/CycleApp.swift
+内容: ContentViewに.preferredColorScheme(.light)を追加。システム設定に関係なく
+      常にライトモードで表示されるよう変更。Liquid Glassもライト表示になる。
+
+[2026-05-24] ジャーナル・タスクリスト上部グラデーション追加
+--------------------------------------------------------------------------------
+変更ファイル:
+  - ios/Cycle/Features/Journal/Views/JournalListView.swift
+  - ios/Cycle/Features/Tasks/Views/TaskListView.swift
+内容: VStack構造を維持したまま、リスト上部にLinearGradientオーバーレイ（12pt）を追加。
+      背景色→透明のグラデーションにより、カードとヘッダーの境界が自然にフェードする。
+
+[2026-05-24] タスクカードの上下パディング追加
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Tasks/Views/Components/TaskRow.swift
+内容: タスクカード内のHStackに.padding(.vertical, 2.5)を追加。カードの高さを上下2.5ptずつ拡大。
+
+[2026-05-24] ジャーナル検索画面にLiquid Glass適用
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Journal/Views/JournalSearchView.swift
+内容: 検索バー、検索結果カード、タグチップにiOS 26+ Liquid Glass分岐を追加。
+      検索バー: iOS 26+でglassEffect適用
+      検索結果カード: iOS 26+でglassEffect適用
+      タグチップ: 選択時のみLiquid Glass+アクセント色、未選択時はgreyLight背景（ガラスなし）
+      iOS 17-25: 従来のsurface背景+角丸+ボーダー+シャドウ（変更なし）
+      タブ名変更: 「検索」→「テキスト」
+      検索結果リスト上部にグラデーションオーバーレイ（12pt）を追加（テキスト・タグ共通）。
+      検索結果カードの日付表示を「2026年5月24日(日) 00:56」形式に統合（年月日+曜日+時刻を1行に）。
+
+[2026-05-24] 日付選択シートのサイズ固定
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Journal/Views/DatePickerSheet.swift
+内容: presentationDetentsを[.medium]のみに変更。日付選択時のシートサイズ変動を解消。
+      カレンダーのlocaleをja_JPに設定し、日本語表記に変更。
+
+[2026-05-24] 週カレンダー曜日の文字色変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Journal/Views/WeekCalendarView.swift
+内容: 曜日の文字色をtextPrimary→textSecondaryに変更。カレンダーの曜日表記と統一。
+
+[2026-05-24] タグ管理画面のDivider削除
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Journal/Views/TagManagementView.swift
+内容: 入力エリアとタグリスト間のDivider（棒線）を削除。
+      入力欄とタグカードにiOS 26+ Liquid Glass分岐を追加。
+
+[2026-05-24] 最近削除した項目の日付表示形式変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Journal/Views/JournalDeletedView.swift
+内容: 日付表示を「2026年5月24日(日) 00:56」形式に変更。検索結果と統一。
+
+[2026-05-24] タブバーのラベルを日本語に変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/App/ContentView.swift
+内容: Journal→ジャーナル、Coach→セッション、Tasks→やること、Settings→設定に変更。
+      選択時にアイコンをfillバージョンに切り替え（leaf.fill, bubble.fill, checklist.checked, gearshape.fill）。
+
+[2026-05-24] セッションホームから「最近の会話」セクション削除
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Views/CoachHomeView.swift
+内容: 最近の会話セクションを削除。右上の履歴ボタンと重複するため、
+      ホーム画面は「話しかける」「日記から話す」のCTAに集中させた。
+      アクションボタンを画面下部に固定配置。アイコンと挨拶は中央に配置。
+      ボタン間のスペーシングをmd(12pt)→lg(16pt)に拡大。
+      ナビゲーションタイトル「Cycle」を削除。
+
+[2026-05-24] 日記選択カードのデザイン変更（検索カードと統一）
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Views/Components/DiaryPickerView.swift
+内容: 「日記から話す」の選択カードをジャーナル検索結果カードと同じデザインに変更。
+      ScrollView+SurfaceCard → List+個別カードスタイルに構造変更。
+      日付表示を「2026年5月24日(日) 00:56」形式に統一。
+      iOS 26+ Liquid Glass対応のDiaryPickerCardStyle ViewModifierを追加。
+      iOS 17-25: surface背景+角丸+ボーダー+シャドウのフォールバック。
+
+[2026-05-24] タスク画面ヘッダーのタイトル変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Tasks/Views/Components/TaskHeader.swift
+内容: 「今日やること」→「やること」に変更。
+
+[2026-05-24] 会話履歴カードの日付位置変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Views/Components/SessionRowView.swift
+内容: 日付表示をカード上部から下部に移動。表示順: テキスト→感情ラベル→日付。
+
+[2026-05-24] 空状態アイコンの点滅アニメーション削除
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Shared/Components/EmptyStateView.swift
+内容: .symbolEffect(.pulse.byLayer, options: .repeat(3))を削除。
+      全画面の空状態アイコン（アーカイブ等）が点滅しなくなる。
+
+[2026-05-24] アーカイブ空状態のサブタイトル削除
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Tasks/Views/TaskArchiveView.swift
+内容: 「完了したタスクをアーカイブするとここに表示されます」のサブタイトルを削除。
+
+[2026-05-24] タスクのアーカイブスワイプボタンの色変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Tasks/Views/Components/TaskRow.swift
+内容: アーカイブボタンの色をDesignSystem.Colors.accent→.blueに変更。
+
+[2026-05-24] 瞑想モード機能追加
+--------------------------------------------------------------------------------
+新規ファイル:
+  - ios/Cycle/Features/Coach/Models/MeditationLog.swift
+  - ios/Cycle/Features/Coach/Store/MeditationStore.swift
+  - ios/Cycle/Features/Coach/Views/MeditationView.swift
+変更ファイル:
+  - ios/Cycle/App/CycleApp.swift（MeditationStore注入）
+  - ios/Cycle/Features/Coach/Views/CoachHomeView.swift（「瞑想する」ボタン追加）
+  - ios/Cycle/Features/Coach/Views/Components/SessionHistoryView.swift（会話/瞑想タブ追加）
+内容:
+  セッションホームに「瞑想する」ボタンを追加。
+  タイマー式の瞑想画面（1/3/5/10/15/20分選択、円形プログレス表示）。
+  完了時にHapticフィードバック、画面スリープ防止対応。
+  瞑想ログをUserDefaultsに保存。
+  履歴画面を「会話」「瞑想」のセグメントタブに分割。
+  瞑想ログは日付と時間を表示。
+
+[2026-05-24] 履歴画面のタブをジャーナル検索と同じスタイルに変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Views/Components/SessionHistoryView.swift
+内容: セグメントコントロール（Picker）をジャーナル検索画面と同じ
+      カスタムタブ（テキスト+アンダーライン）に変更。
+      選択中: semibold+textPrimary+アクセント色の2ptライン。
+      未選択: regular+textSecondary+grey 0.5ptライン。
+
+[2026-05-24] 瞑想タイマーをiPhone標準タイマー風の時・分・秒ピッカーに変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Views/MeditationView.swift
+内容: 時間選択をカプセルボタンからiPhoneタイマー風の3列ホイールピッカーに変更。
+      UIPickerViewをUIViewRepresentableでラップし、3コンポーネントを1つのピッカーに統合。
+      選択行のグレー背景が3列で一連になるよう実装。
+      数字+単位ラベル（「時間」「分」「秒」）を属性付き文字列で表示。
+      時間選択画面のリーフアイコンを削除。
+      「はじめる」ボタンの再生アイコン(play.fill)を削除。
+      タイマー表示・完了メッセージも時・分・秒対応に変更。
+      合計0秒の場合はタイマー開始不可。
+
+[2026-05-24] 検索タグの未選択時もLiquid Glassを適用
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Journal/Views/JournalSearchView.swift
+内容: SearchTagStyleのiOS 26+分岐を変更。選択時のみglassEffect適用、未選択時はガラスなし。
+      タグ間のグレー隙間を解消。
+
+[2026-05-24] タグ選択ボタン(TagSelector)にLiquid Glass適用
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Journal/Views/TagSelector.swift
+内容: TagButtonStyle ViewModifierを追加しiOS 26+分岐を実装。
+      iOS 26+: 選択時のみglassEffect(.regular.interactive(), in: .capsule)を適用。
+      未選択時はLiquid Glassなし（greyLight背景のみ）でタグ間のグレー隙間を解消。
+      iOS 17-25: 従来のソリッド背景+Capsule（変更なし）。
+
+[2026-05-24] TagChipコンポーネントにLiquid Glass適用
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Shared/Components/TagChip.swift
+内容: TagChipBackgroundStyle ViewModifierを追加しiOS 26+分岐を実装。
+      iOS 26+: 背景色をgrey→backgroundに変更し、glassEffect(.regular, in: .capsule)を適用。
+      タグ間のグレー隙間を解消し、カード背景と馴染むように。
+      iOS 17-25: 従来のgrey背景+Capsule（変更なし）。
+      共通コンポーネントのため、ジャーナルエントリ行のタグ等すべてのTagChipに反映。
+
+[2026-05-24] フローティングアクションボタン(FAB)にLiquid Glass適用
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Shared/Components/FloatingActionButton.swift
+内容: FABBackgroundStyleにiOS 26+分岐を追加。
+      iOS 26+: glassEffect(.regular.interactive(), in: .circle)を適用、シャドウ削除。
+      iOS 17-25: 従来のソリッド背景+シャドウを維持（変更なし）。
+      ジャーナル・タスクの+ボタンがLiquid Glass仕様になる。
+
+[2026-05-24] セッション履歴に左スワイプ削除ボタンを追加
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Views/Components/SessionHistoryView.swift
+内容: 対話履歴・瞑想履歴の両方に左スワイプで削除ボタンを追加。
+      ScrollView+VStack構造をList構造に変更し、swipeActionsを実装。
+      ジャーナルと同じ形式（trashアイコン、iconOnly、allowsFullSwipe: false、customListRowStyle）。
+      対話: coachStore.deleteSession()、瞑想: meditationStore.deleteLog()を呼び出し。
+
+[2026-05-24] 瞑想モードの起動方法を変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Views/CoachHomeView.swift
+内容: 下部の「瞑想する」ボタンを削除。
+      中央のCycleIconアイコンをButtonでラップし、タップで瞑想画面を開くよう変更。
+      アクションボタンは「話しかける」「日記から話す」の2つに整理。
+
+[2026-05-24] 会話履歴タップで過去の会話を閲覧可能に
+--------------------------------------------------------------------------------
+新規ファイル: ios/Cycle/Features/Coach/Views/Components/SessionDetailView.swift
+変更ファイル: ios/Cycle/Features/Coach/Views/Components/SessionHistoryView.swift
+内容: 会話履歴カードをタップすると過去の会話を閲覧できるSessionDetailViewを追加。
+      読み取り専用（入力欄なし）。サーバーにメッセージがある場合は自動取得。
+      チャット画面と同じバブルデザインで表示。
+
+[2026-05-24] Xcode エディタ上の Combine エラー対処
+--------------------------------------------------------------------------------
+対処: DerivedData削除（Cycle-gmxcdiqdjvwxwjflemrqwzmtoojb）
+内容: Xcodeエディタ上で「Static subscript is not available due to missing import
+      of defining module 'Combine'」エラーが表示されていた。
+      コマンドラインビルドはエラーなしで成功しており、インデックスキャッシュが原因。
+      DerivedDataを削除し、Xcode再起動で解消。
+
+[2026-05-24] アプリ起動時のブレークポイント停止問題を修正
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Store/MeditationStore.swift
+内容: Xcodeが23行目のブレークポイントを繰り返し復元し、アプリ起動時に停止する問題。
+      initでloadLogs()を呼ぶ代わりに直接デコード処理をinit内に記述し、
+      コードの行位置をずらすことでブレークポイントを無効化。
+      DerivedData削除、UserInterfaceState.xcuserstate削除、
+      シミュレータリセット、SPMパッケージ再解決も実施。
+
+[2026-05-24] 瞑想モード「やめる」「完了」ボタンのアイコン削除
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Views/MeditationView.swift
+内容: 「完了」ボタンからcheckmarkアイコン、「やめる」ボタンからstop.fillアイコンを削除。
+      テキストのみのボタン表示に変更。
+
+[2026-05-24] ジャーナルヘッダーの右上メニューボタンにLiquid Glass適用
+--------------------------------------------------------------------------------
+変更ファイル:
+  - ios/Cycle/Features/Journal/Views/Components/JournalHeader.swift
+  - ios/Cycle/Shared/Components/GlassHeaderModifier.swift
+内容: メニューボタン(ellipsis.circle)にGlassIconModifierを適用。
+      GlassIconModifier（新規）: アイコンボタン用の汎用Liquid Glassモディファイア。
+      iOS 26+: padding(8) + glassEffect(.regular.interactive(), in: .circle)で円形ガラス。
+      iOS 17-25: そのまま表示（変更なし）。
+
+[2026-05-24] ジャーナル・タスクヘッダーのメニューアイコンを三本線に変更＋タスクにもLiquid Glass適用
+--------------------------------------------------------------------------------
+変更ファイル:
+  - ios/Cycle/Features/Journal/Views/Components/JournalHeader.swift
+  - ios/Cycle/Features/Tasks/Views/Components/TaskHeader.swift
+内容: 両ヘッダーのメニューアイコンをellipsis.circle→line.3.horizontalに変更。
+      TaskHeaderにもGlassIconModifierを適用し、iOS 26+で円形Liquid Glassボタンに。
+
+[2026-05-24] GlassIconModifierのサイズ拡大
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Shared/Components/GlassHeaderModifier.swift
+内容: GlassIconModifierのpadding(8)→padding(12)に変更。ボタンの円形ガラス領域を拡大。
+
+[2026-05-24] タブラベル・タスクヘッダーのタイトル変更
+--------------------------------------------------------------------------------
+変更ファイル:
+  - ios/Cycle/App/ContentView.swift
+  - ios/Cycle/Features/Tasks/Views/Components/TaskHeader.swift
+内容: タブバーのラベルを「やること」→「タスクリスト」に変更。
+      TaskHeaderのタイトルテキスト「やること」を削除（メニューボタンのみに）。
+
+[2026-05-24] タスクヘッダーとリスト間の余白をジャーナルと統一
+--------------------------------------------------------------------------------
+変更ファイル:
+  - ios/Cycle/Features/Tasks/Views/Components/TaskHeader.swift
+  - ios/Cycle/Features/Tasks/Views/TaskListView.swift
+内容: TaskListViewのVStack spacingをsm(8)→0に変更。
+      TaskHeaderのpadding(.vertical, md)をtop md(12) + bottom md+sm(20)に分割。
+      ジャーナルのヘッダー〜曜日間の余白と同じ間隔に統一。
+
+[2026-05-24] ジャーナル検索タブ名・プレースホルダー変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Journal/Views/JournalSearchView.swift
+内容: 検索タブ名「テキスト」→「ワード」に変更。
+      検索欄プレースホルダー「テキストで検索」→「ワードで検索」に変更。
+
+[2026-05-24] セッション履歴の空状態テキスト変更
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Coach/Views/Components/SessionHistoryView.swift
+内容: 対話の空状態「会話履歴がありません」→「対話履歴がありません」に変更。
+      サブタイトル「コーチと会話を始めると〜」を削除。
+      瞑想の空状態「瞑想の記録がありません」→「瞑想履歴がありません」に変更。
+      瞑想の空状態アイコンをleaf→timerに変更。
+
+[2026-05-24] タスクプレビューに締切日時セクション追加
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Tasks/Views/TaskPreviewView.swift
+内容: タスクプレビューに締切日時セクションを追加（dueDate設定時のみ表示）。
+      日本語ロケールで「2026年5月24日(土) 14:30」形式で表示。
+      表示順: タイトル → 詳細 → 締切日時 → 意図 → 完了イメージ → 注意点 → 事実 → 気づき → 次の一手。
+
+[2026-05-25] タスクヘッダーにタイトル「タスクリスト」復活
+--------------------------------------------------------------------------------
+変更ファイル: ios/Cycle/Features/Tasks/Views/Components/TaskHeader.swift
+内容: 削除していたタイトルテキストを「タスクリスト」として復活。
+      ジャーナルと同じ.system(size: 28, weight: .bold)スタイル。
+
+[2026-05-25] セッション画面にカスタムヘッダー追加・レイアウト統一
+--------------------------------------------------------------------------------
+変更ファイル:
+  - ios/Cycle/Features/Coach/Views/CoachHomeView.swift
+  - ios/Cycle/App/ContentView.swift
+内容: CoachHomeView内のNavigationStackを削除し、ContentView側でNavigationStackにラップ。
+      ジャーナル・タスクと同じ構造に統一。
+      カスタムヘッダーを追加: 左に「セッション」タイトル(size 28, bold)、
+      右に履歴ボタン(clock.arrow.circlepath, size 22 + GlassIconModifier)。
+      ナビバーを非表示にしてタイトル・ボタンの位置をジャーナル・タスクと揃えた。

--- a/ios/Cycle/App/ContentView.swift
+++ b/ios/Cycle/App/ContentView.swift
@@ -17,6 +17,9 @@ struct ContentView: View {
 
     var body: some View {
         Group {
+            #if DEBUG
+            mainContent
+            #else
             switch authStore.state {
             case .unknown:
                 splashView
@@ -25,6 +28,7 @@ struct ContentView: View {
             case .authenticated:
                 mainContent
             }
+            #endif
         }
     }
 
@@ -44,7 +48,9 @@ struct ContentView: View {
                         JournalListView()
                     }
                 case 1:
-                    CoachHomeView()
+                    NavigationStack {
+                        CoachHomeView()
+                    }
                 case 2:
                     NavigationStack {
                         TaskListView()
@@ -84,28 +90,32 @@ struct CustomTabBar: View {
         HStack(spacing: 0) {
             TabBarButton(
                 icon: "leaf",
-                label: "Journal",
+                selectedIcon: "leaf.fill",
+                label: "ジャーナル",
                 isSelected: selectedTab == 0,
                 action: { selectedTab = 0 }
             )
 
             TabBarButton(
                 icon: "bubble.left.and.bubble.right",
-                label: "Coach",
+                selectedIcon: "bubble.left.and.bubble.right.fill",
+                label: "セッション",
                 isSelected: selectedTab == 1,
                 action: { selectedTab = 1 }
             )
 
             TabBarButton(
                 icon: "checklist",
-                label: "Tasks",
+                selectedIcon: "checklist.checked",
+                label: "タスクリスト",
                 isSelected: selectedTab == 2,
                 action: { selectedTab = 2 }
             )
 
             TabBarButton(
                 icon: "gearshape",
-                label: "Settings",
+                selectedIcon: "gearshape.fill",
+                label: "設定",
                 isSelected: selectedTab == 3,
                 action: { selectedTab = 3 }
             )
@@ -117,6 +127,7 @@ struct CustomTabBar: View {
 
 struct TabBarButton: View {
     let icon: String
+    let selectedIcon: String
     let label: String
     let isSelected: Bool
     let action: () -> Void
@@ -124,7 +135,7 @@ struct TabBarButton: View {
     var body: some View {
         Button(action: action) {
             VStack(spacing: 4) {
-                Image(systemName: icon)
+                Image(systemName: isSelected ? selectedIcon : icon)
                     .font(.system(size: DesignSystem.FontSize.title3))
 
                 Text(label)

--- a/ios/Cycle/App/CycleApp.swift
+++ b/ios/Cycle/App/CycleApp.swift
@@ -79,6 +79,7 @@ struct CycleApp: App {
     @StateObject private var journalViewModel = JournalViewModel()
     @StateObject private var taskViewModel = TaskViewModel()
     @StateObject private var coachStore = CoachStore()
+    @StateObject private var meditationStore = MeditationStore()
     @StateObject private var authStore = AuthStore()
 
     var body: some Scene {
@@ -89,9 +90,11 @@ struct CycleApp: App {
                 }
             } else {
                 ContentView()
+                    .preferredColorScheme(.light)
                     .environmentObject(journalViewModel)
                     .environmentObject(taskViewModel)
                     .environmentObject(coachStore)
+                    .environmentObject(meditationStore)
                     .environmentObject(authStore)
                     .onOpenURL { url in
                         GIDSignIn.sharedInstance.handle(url)

--- a/ios/Cycle/Features/Auth/Store/AuthStore.swift
+++ b/ios/Cycle/Features/Auth/Store/AuthStore.swift
@@ -245,6 +245,13 @@ class AuthStore: NSObject, ObservableObject {
 
     /// 認証状態を確認
     func checkAuthState() async {
+        #if DEBUG
+        let mockUser = AuthUser(userId: "debug-user", email: "debug@test.com", fullName: "Debug User", createdAt: Date(), provider: .apple)
+        currentUser = mockUser
+        state = .authenticated(userId: "debug-user")
+        return
+        #endif
+
         // 旧バージョンからアップデートしたユーザー: identityToken のみ → 再サインイン要求
         if loadFromKeychain(key: accessTokenKey) == nil, loadFromKeychain(key: legacyTokenKey) != nil {
             clearLocalAuth()

--- a/ios/Cycle/Features/Coach/Models/MeditationLog.swift
+++ b/ios/Cycle/Features/Coach/Models/MeditationLog.swift
@@ -1,0 +1,32 @@
+//
+//  MeditationLog.swift
+//  CycleJournal
+//
+
+import Foundation
+
+/// 瞑想ログ
+struct MeditationLog: Identifiable, Codable {
+    let id: UUID
+    let date: Date
+    let duration: Int // 秒数
+
+    init(id: UUID = UUID(), date: Date = Date(), duration: Int) {
+        self.id = id
+        self.date = date
+        self.duration = duration
+    }
+
+    /// 表示用の時間文字列（例: "5分"、"1分30秒"）
+    var durationText: String {
+        let minutes = duration / 60
+        let seconds = duration % 60
+        if seconds == 0 {
+            return "\(minutes)分"
+        } else if minutes == 0 {
+            return "\(seconds)秒"
+        } else {
+            return "\(minutes)分\(seconds)秒"
+        }
+    }
+}

--- a/ios/Cycle/Features/Coach/Store/MeditationStore.swift
+++ b/ios/Cycle/Features/Coach/Store/MeditationStore.swift
@@ -1,0 +1,47 @@
+//
+//  MeditationStore.swift
+//  CycleJournal
+//
+
+import Combine
+import Foundation
+
+class MeditationStore: ObservableObject {
+    @Published var logs: [MeditationLog] = []
+
+    private let userDefaults = UserDefaults.standard
+    private let logsKey = "MeditationLogs"
+
+    init() {
+        let stored = userDefaults.data(forKey: logsKey)
+        if let data = stored,
+           let decoded = try? JSONDecoder().decode([MeditationLog].self, from: data) {
+            logs = decoded.sorted { $0.date > $1.date }
+        }
+    }
+
+    func loadLogs() {
+        let stored = userDefaults.data(forKey: logsKey)
+        if let data = stored,
+           let decoded = try? JSONDecoder().decode([MeditationLog].self, from: data) {
+            logs = decoded.sorted { $0.date > $1.date }
+        }
+    }
+
+    func saveLogs() {
+        if let encoded = try? JSONEncoder().encode(logs) {
+            userDefaults.set(encoded, forKey: logsKey)
+        }
+    }
+
+    func addLog(duration: Int) {
+        let log = MeditationLog(duration: duration)
+        logs.insert(log, at: 0)
+        saveLogs()
+    }
+
+    func deleteLog(_ log: MeditationLog) {
+        logs.removeAll { $0.id == log.id }
+        saveLogs()
+    }
+}

--- a/ios/Cycle/Features/Coach/Views/CoachHomeView.swift
+++ b/ios/Cycle/Features/Coach/Views/CoachHomeView.swift
@@ -9,92 +9,60 @@ struct CoachHomeView: View {
     @EnvironmentObject var coachStore: CoachStore
     @EnvironmentObject var journalViewModel: JournalViewModel
     @EnvironmentObject var authStore: AuthStore
+    @EnvironmentObject var meditationStore: MeditationStore
 
     @State private var showingChat = false
     @State private var showingHistory = false
     @State private var showingDiaryPicker = false
+    @State private var showingMeditation = false
 
     var body: some View {
-        NavigationStack {
-            ScrollView {
-                VStack(spacing: DesignSystem.Spacing.xxl) {
-                    // コーチのビジュアル（アプリアイコン）
+        VStack(spacing: 0) {
+                sessionHeader
+                Spacer()
+
+                // コーチのビジュアル（アプリアイコン）→タップで瞑想開始
+                Button(action: { showingMeditation = true }) {
                     Image("CycleIcon")
                         .resizable()
                         .aspectRatio(contentMode: .fit)
                         .frame(width: 120, height: 120)
                         .clipShape(Circle())
-                        .padding(.top, DesignSystem.Spacing.xl)
+                }
 
-                    // 挨拶メッセージ
-                    VStack(spacing: DesignSystem.Spacing.sm) {
-                        Text(greetingMessage)
-                            .font(DesignSystem.Fonts.sectionTitle)
-                            .foregroundStyle(DesignSystem.Colors.textPrimary)
-                            .multilineTextAlignment(.center)
+                Spacer().frame(height: DesignSystem.Spacing.xxl)
 
-                        Text("今日はどんな一日だった？")
-                            .font(DesignSystem.Fonts.body)
-                            .foregroundStyle(DesignSystem.Colors.textSecondary)
-                            .multilineTextAlignment(.center)
+                // 挨拶メッセージ
+                VStack(spacing: DesignSystem.Spacing.sm) {
+                    Text(greetingMessage)
+                        .font(DesignSystem.Fonts.sectionTitle)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                        .multilineTextAlignment(.center)
+
+                    Text("今日はどんな一日だった？")
+                        .font(DesignSystem.Fonts.body)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                        .multilineTextAlignment(.center)
+                }
+                .padding(.horizontal, DesignSystem.Spacing.lg)
+
+                Spacer()
+
+                // アクションボタン
+                VStack(spacing: DesignSystem.Spacing.lg) {
+                    PrimaryButton("話しかける", icon: "bubble.left") {
+                        startNewChat()
                     }
-                    .padding(.horizontal, DesignSystem.Spacing.lg)
 
-                    // アクションボタン
-                    VStack(spacing: DesignSystem.Spacing.md) {
-                        PrimaryButton("話しかける", icon: "bubble.left") {
-                            startNewChat()
-                        }
-
-                        SecondaryButton("日記から話す", icon: "book") {
-                            showingDiaryPicker = true
-                        }
-                    }
-                    .padding(.horizontal, DesignSystem.Spacing.lg)
-
-                    // 最近の会話
-                    if !coachStore.recentSessions.isEmpty {
-                        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
-                            SectionLabel("最近の会話", icon: "clock")
-                                .padding(.horizontal, DesignSystem.Spacing.lg)
-
-                            VStack(spacing: DesignSystem.Spacing.sm) {
-                                ForEach(coachStore.recentSessions) { session in
-                                    SessionRowView(session: session)
-                                        .onTapGesture {
-                                            Task {
-                                                if session.messages.isEmpty, session.serverId != nil {
-                                                    if let fullSession = await coachStore.fetchSessionDetail(session) {
-                                                        coachStore.currentSession = fullSession
-                                                    } else {
-                                                        coachStore.currentSession = session
-                                                    }
-                                                } else {
-                                                    coachStore.currentSession = session
-                                                }
-                                                showingChat = true
-                                            }
-                                        }
-                                }
-                            }
-                            .padding(.horizontal, DesignSystem.Spacing.lg)
-                        }
+                    SecondaryButton("日記から話す", icon: "book") {
+                        showingDiaryPicker = true
                     }
                 }
-                .padding(.bottom, DesignSystem.Spacing.xxl)
+                .padding(.horizontal, DesignSystem.Spacing.lg)
+                .padding(.bottom, DesignSystem.Spacing.xxl * 2)
             }
             .background(DesignSystem.Colors.background)
-            .navigationTitle("Cycle")
-            .navigationBarTitleDisplayMode(.inline)
-            .modifier(GlassNavBarModifier())
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button(action: { showingHistory = true }) {
-                        Image(systemName: "clock.arrow.circlepath")
-                            .foregroundStyle(DesignSystem.Colors.accent)
-                    }
-                }
-            }
+            .navigationBarHidden(true)
             .fullScreenCover(isPresented: $showingChat) {
                 CoachChatView()
                     .environmentObject(coachStore)
@@ -109,6 +77,11 @@ struct CoachHomeView: View {
             .sheet(isPresented: $showingHistory) {
                 SessionHistoryView()
                     .environmentObject(coachStore)
+                    .environmentObject(meditationStore)
+            }
+            .sheet(isPresented: $showingMeditation) {
+                MeditationView()
+                    .environmentObject(meditationStore)
             }
             .sheet(isPresented: $showingDiaryPicker) {
                 DiaryPickerView(onSelect: { entry in
@@ -124,7 +97,28 @@ struct CoachHomeView: View {
                 })
                 .environmentObject(journalViewModel)
             }
+    }
+
+    // MARK: - Header
+
+    private var sessionHeader: some View {
+        HStack(alignment: .center) {
+            Text("セッション")
+                .font(.system(size: 28, weight: .bold))
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+            Spacer()
+
+            Button(action: { showingHistory = true }) {
+                Image(systemName: "clock.arrow.circlepath")
+                    .font(.system(size: 22))
+                    .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .modifier(GlassIconModifier())
+            }
         }
+        .padding(.horizontal, DesignSystem.Spacing.lg)
+        .padding(.vertical, DesignSystem.Spacing.md)
+        .background(DesignSystem.Colors.background)
     }
 
     // MARK: - Helpers
@@ -151,4 +145,5 @@ struct CoachHomeView: View {
     CoachHomeView()
         .environmentObject(CoachStore())
         .environmentObject(JournalViewModel())
+        .environmentObject(MeditationStore())
 }

--- a/ios/Cycle/Features/Coach/Views/Components/DiaryPickerView.swift
+++ b/ios/Cycle/Features/Coach/Views/Components/DiaryPickerView.swift
@@ -11,13 +11,6 @@ struct DiaryPickerView: View {
 
     let onSelect: (JournalEntry) -> Void
 
-    private let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "M月d日(E) HH:mm"
-        formatter.locale = Locale(identifier: "ja_JP")
-        return formatter
-    }()
-
     var body: some View {
         NavigationStack {
             Group {
@@ -28,37 +21,57 @@ struct DiaryPickerView: View {
                         subtitle: "日記を書くと、ここから選んでコーチに話せます"
                     )
                 } else {
-                    ScrollView {
-                        VStack(spacing: DesignSystem.Spacing.sm) {
-                            ForEach(journalViewModel.allEntries.prefix(20)) { entry in
-                                Button(action: { onSelect(entry) }) {
-                                    SurfaceCard {
-                                        VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
-                                            Text(dateFormatter.string(from: entry.date))
-                                                .font(DesignSystem.Fonts.caption)
-                                                .foregroundStyle(DesignSystem.Colors.textTertiary)
+                    List {
+                        ForEach(journalViewModel.allEntries.prefix(20)) { entry in
+                            Button(action: { onSelect(entry) }) {
+                                VStack(alignment: .leading, spacing: DesignSystem.Spacing.sm) {
+                                    Text(entry.text)
+                                        .font(DesignSystem.Fonts.body)
+                                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+                                        .lineSpacing(4)
+                                        .lineLimit(3)
+                                        .multilineTextAlignment(.leading)
 
-                                            Text(entry.text)
-                                                .font(DesignSystem.Fonts.body)
-                                                .foregroundStyle(DesignSystem.Colors.textPrimary)
-                                                .lineLimit(2)
-                                                .multilineTextAlignment(.leading)
+                                    HStack(spacing: DesignSystem.Spacing.sm) {
+                                        Text(entry.date.formatted(
+                                            .dateTime
+                                                .year()
+                                                .month()
+                                                .day()
+                                                .weekday(.abbreviated)
+                                                .hour(.twoDigits(amPM: .omitted))
+                                                .minute(.twoDigits)
+                                                .locale(Locale(identifier: "ja_JP"))
+                                        ))
+                                            .font(DesignSystem.Fonts.caption)
+                                            .foregroundStyle(DesignSystem.Colors.textSecondary)
 
-                                            if !entry.tags.isEmpty {
-                                                HStack(spacing: DesignSystem.Spacing.xs) {
-                                                    ForEach(entry.tags.prefix(3), id: \.self) { tag in
-                                                        TagChip(text: tag)
-                                                    }
-                                                }
+                                        if !entry.tags.isEmpty {
+                                            ForEach(entry.tags, id: \.self) { tag in
+                                                TagChip(text: tag)
                                             }
                                         }
                                     }
                                 }
-                                .buttonStyle(.plain)
+                                .padding(DesignSystem.Spacing.lg)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .modifier(DiaryPickerCardStyle())
                             }
+                            .buttonStyle(.plain)
+                            .listRowInsets(
+                                EdgeInsets(
+                                    top: DesignSystem.Spacing.xs,
+                                    leading: DesignSystem.Spacing.lg,
+                                    bottom: DesignSystem.Spacing.xs,
+                                    trailing: DesignSystem.Spacing.lg
+                                )
+                            )
+                            .listRowSeparator(.hidden)
+                            .listRowBackground(Color.clear)
                         }
-                        .padding(DesignSystem.Spacing.lg)
                     }
+                    .listStyle(.plain)
+                    .scrollContentBackground(.hidden)
                 }
             }
             .background(DesignSystem.Colors.background)
@@ -73,6 +86,26 @@ struct DiaryPickerView: View {
                     .foregroundStyle(DesignSystem.Colors.accent)
                 }
             }
+        }
+    }
+}
+
+// MARK: - Card Style
+
+private struct DiaryPickerCardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .rect(cornerRadius: DesignSystem.Spacing.md))
+        } else {
+            content
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous)
+                        .stroke(DesignSystem.Colors.grey.opacity(0.6), lineWidth: 0.5)
+                )
+                .shadow(color: DesignSystem.Colors.brownDark.opacity(0.08), radius: 4, x: 0, y: 2)
         }
     }
 }

--- a/ios/Cycle/Features/Coach/Views/Components/SessionDetailView.swift
+++ b/ios/Cycle/Features/Coach/Views/Components/SessionDetailView.swift
@@ -1,0 +1,120 @@
+//
+//  SessionDetailView.swift
+//  CycleJournal
+//
+
+import SwiftUI
+
+/// 過去の会話セッションを閲覧するビュー（読み取り専用）
+struct SessionDetailView: View {
+    @EnvironmentObject var coachStore: CoachStore
+    @Environment(\.dismiss) var dismiss
+
+    let session: CoachSession
+    @State private var loadedSession: CoachSession?
+    @State private var isLoading = false
+
+    private var messages: [CoachMessage] {
+        (loadedSession ?? session).messages
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                if isLoading {
+                    Spacer()
+                    ProgressView()
+                    Spacer()
+                } else if messages.isEmpty {
+                    Spacer()
+                    Text("メッセージがありません")
+                        .font(DesignSystem.Fonts.body)
+                        .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    Spacer()
+                } else {
+                    messageList
+                }
+            }
+            .background(DesignSystem.Colors.background)
+            .navigationTitle(session.summary ?? "会話")
+            .navigationBarTitleDisplayMode(.inline)
+            .modifier(GlassNavBarModifier())
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("閉じる") {
+                        dismiss()
+                    }
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                }
+            }
+            .task {
+                if messages.isEmpty, session.serverId != nil {
+                    isLoading = true
+                    loadedSession = await coachStore.fetchSessionDetail(session)
+                    isLoading = false
+                }
+            }
+        }
+    }
+
+    // MARK: - Message List
+
+    private var messageList: some View {
+        ScrollView {
+            LazyVStack(spacing: DesignSystem.Spacing.md) {
+                ForEach(messages) { message in
+                    messageBubble(message)
+                }
+            }
+            .padding(DesignSystem.Spacing.lg)
+        }
+    }
+
+    // MARK: - Message Bubble
+
+    private let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "HH:mm"
+        return formatter
+    }()
+
+    private func messageBubble(_ message: CoachMessage) -> some View {
+        HStack(alignment: .bottom, spacing: DesignSystem.Spacing.sm) {
+            if message.role == .user {
+                Spacer(minLength: 60)
+            } else {
+                coachAvatar
+            }
+
+            VStack(alignment: message.role == .user ? .trailing : .leading, spacing: DesignSystem.Spacing.xs) {
+                Text(message.content)
+                    .font(DesignSystem.Fonts.body)
+                    .foregroundStyle(message.role == .user ? .white : DesignSystem.Colors.textPrimary)
+                    .padding(.horizontal, DesignSystem.Spacing.mlg)
+                    .padding(.vertical, DesignSystem.Spacing.md)
+                    .background(
+                        message.role == .user
+                            ? DesignSystem.Colors.accent
+                            : DesignSystem.Colors.surface
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.lg, style: .continuous))
+
+                Text(timeFormatter.string(from: message.createdAt))
+                    .font(DesignSystem.Fonts.caption2)
+                    .foregroundStyle(DesignSystem.Colors.textTertiary)
+            }
+
+            if message.role == .coach {
+                Spacer(minLength: 60)
+            }
+        }
+    }
+
+    private var coachAvatar: some View {
+        Image("CycleIcon")
+            .resizable()
+            .aspectRatio(contentMode: .fit)
+            .frame(width: 32, height: 32)
+            .clipShape(Circle())
+    }
+}

--- a/ios/Cycle/Features/Coach/Views/Components/SessionHistoryView.swift
+++ b/ios/Cycle/Features/Coach/Views/Components/SessionHistoryView.swift
@@ -7,38 +7,58 @@ import SwiftUI
 
 struct SessionHistoryView: View {
     @EnvironmentObject var coachStore: CoachStore
+    @EnvironmentObject var meditationStore: MeditationStore
     @Environment(\.dismiss) var dismiss
 
-    private let dateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "M月d日(E)"
-        formatter.locale = Locale(identifier: "ja_JP")
-        return formatter
-    }()
+    @State private var selectedTab = 0
+    @State private var selectedSession: CoachSession?
 
     var body: some View {
         NavigationStack {
-            Group {
-                if coachStore.sessions.isEmpty {
-                    EmptyStateView(
-                        icon: "bubble.left.and.bubble.right",
-                        title: "会話履歴がありません",
-                        subtitle: "コーチと会話を始めると、ここに履歴が表示されます"
-                    )
-                } else {
-                    ScrollView {
-                        VStack(spacing: DesignSystem.Spacing.sm) {
-                            ForEach(coachStore.sessions) { session in
-                                SessionRowView(session: session)
-                            }
+            VStack(spacing: 0) {
+                VStack(spacing: 0) {
+                    HStack(spacing: 0) {
+                        Button(action: { selectedTab = 0 }) {
+                            Text("対話")
+                                .font(.system(size: DesignSystem.FontSize.body, weight: selectedTab == 0 ? .semibold : .regular))
+                                .foregroundStyle(selectedTab == 0 ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, DesignSystem.Spacing.md)
                         }
-                        .padding(DesignSystem.Spacing.lg)
+
+                        Button(action: { selectedTab = 1 }) {
+                            Text("瞑想")
+                                .font(.system(size: DesignSystem.FontSize.body, weight: selectedTab == 1 ? .semibold : .regular))
+                                .foregroundStyle(selectedTab == 1 ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, DesignSystem.Spacing.md)
+                        }
                     }
+
+                    GeometryReader { geometry in
+                        HStack(spacing: 0) {
+                            Rectangle()
+                                .fill(selectedTab == 0 ? DesignSystem.Colors.accent : DesignSystem.Colors.grey)
+                                .frame(width: geometry.size.width / 2, height: selectedTab == 0 ? 2 : 0.5)
+
+                            Rectangle()
+                                .fill(selectedTab == 1 ? DesignSystem.Colors.accent : DesignSystem.Colors.grey)
+                                .frame(width: geometry.size.width / 2, height: selectedTab == 1 ? 2 : 0.5)
+                        }
+                    }
+                    .frame(height: 2)
+                }
+
+                if selectedTab == 0 {
+                    conversationList
+                } else {
+                    meditationList
                 }
             }
             .background(DesignSystem.Colors.background)
-            .navigationTitle("会話履歴")
+            .navigationTitle("履歴")
             .navigationBarTitleDisplayMode(.inline)
+            .modifier(GlassNavBarModifier())
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button("完了") {
@@ -49,6 +69,100 @@ struct SessionHistoryView: View {
             }
             .task {
                 await coachStore.fetchServerSessions()
+            }
+            .sheet(item: $selectedSession) { session in
+                SessionDetailView(session: session)
+                    .environmentObject(coachStore)
+            }
+        }
+    }
+
+    // MARK: - Conversation List
+
+    @ViewBuilder
+    private var conversationList: some View {
+        if coachStore.sessions.isEmpty {
+            EmptyStateView(
+                icon: "bubble.left.and.bubble.right",
+                title: "対話履歴がありません"
+            )
+        } else {
+            List {
+                ForEach(coachStore.sessions) { session in
+                    Button(action: { selectedSession = session }) {
+                        SessionRowView(session: session)
+                    }
+                    .buttonStyle(.plain)
+                    .customListRowStyle()
+                    .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                        Button(role: .destructive) {
+                            coachStore.deleteSession(session)
+                        } label: {
+                            Label("削除", systemImage: "trash")
+                                .labelStyle(.iconOnly)
+                        }
+                    }
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+
+    // MARK: - Meditation List
+
+    @ViewBuilder
+    private var meditationList: some View {
+        if meditationStore.logs.isEmpty {
+            EmptyStateView(
+                icon: "timer",
+                title: "瞑想履歴がありません"
+            )
+        } else {
+            List {
+                ForEach(meditationStore.logs) { log in
+                    MeditationRowView(log: log)
+                        .customListRowStyle()
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                meditationStore.deleteLog(log)
+                            } label: {
+                                Label("削除", systemImage: "trash")
+                                    .labelStyle(.iconOnly)
+                            }
+                        }
+                }
+            }
+            .listStyle(.plain)
+        }
+    }
+}
+
+// MARK: - Meditation Row
+
+struct MeditationRowView: View {
+    let log: MeditationLog
+
+    private let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "M月d日(E)"
+        formatter.locale = Locale(identifier: "ja_JP")
+        return formatter
+    }()
+
+    var body: some View {
+        SurfaceCard {
+            HStack {
+                VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
+                    Text("\(log.durationText)の瞑想")
+                        .font(DesignSystem.Fonts.body)
+                        .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+                    Text(dateFormatter.string(from: log.date))
+                        .font(DesignSystem.Fonts.caption)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
+                }
+
+                Spacer()
             }
         }
     }

--- a/ios/Cycle/Features/Coach/Views/Components/SessionRowView.swift
+++ b/ios/Cycle/Features/Coach/Views/Components/SessionRowView.swift
@@ -19,10 +19,6 @@ struct SessionRowView: View {
         SurfaceCard {
             HStack {
                 VStack(alignment: .leading, spacing: DesignSystem.Spacing.xs) {
-                    Text(dateFormatter.string(from: session.createdAt))
-                        .font(DesignSystem.Fonts.caption)
-                        .foregroundStyle(DesignSystem.Colors.textTertiary)
-
                     Text(session.summary ?? session.firstUserMessage ?? "会話")
                         .font(DesignSystem.Fonts.body)
                         .foregroundStyle(DesignSystem.Colors.textPrimary)
@@ -33,6 +29,10 @@ struct SessionRowView: View {
                             .font(DesignSystem.Fonts.caption)
                             .foregroundStyle(DesignSystem.Colors.accent)
                     }
+
+                    Text(dateFormatter.string(from: session.createdAt))
+                        .font(DesignSystem.Fonts.caption)
+                        .foregroundStyle(DesignSystem.Colors.textTertiary)
                 }
 
                 Spacer()

--- a/ios/Cycle/Features/Coach/Views/MeditationView.swift
+++ b/ios/Cycle/Features/Coach/Views/MeditationView.swift
@@ -1,0 +1,291 @@
+//
+//  MeditationView.swift
+//  CycleJournal
+//
+
+import SwiftUI
+import UIKit
+
+struct MeditationView: View {
+    @EnvironmentObject var meditationStore: MeditationStore
+    @Environment(\.dismiss) var dismiss
+
+    @State private var selectedHours = 0
+    @State private var selectedMinutes = 5
+    @State private var selectedSeconds = 0
+    @State private var isRunning = false
+    @State private var remainingSeconds = 0
+    @State private var timer: Timer?
+    @State private var totalSeconds = 0
+    @State private var isCompleted = false
+
+    private let hourRange = 0...23
+    private let minuteRange = 0...59
+    private let secondRange = 0...59
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                Spacer()
+
+                if isCompleted {
+                    completedView
+                } else if isRunning {
+                    timerView
+                } else {
+                    selectionView
+                }
+
+                Spacer()
+
+                actionButton
+                    .padding(.horizontal, DesignSystem.Spacing.lg)
+                    .padding(.bottom, DesignSystem.Spacing.xxl * 2)
+            }
+            .background(DesignSystem.Colors.background)
+            .navigationBarTitleDisplayMode(.inline)
+            .modifier(GlassNavBarModifier())
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if !isRunning {
+                        Button("閉じる") {
+                            dismiss()
+                        }
+                        .foregroundStyle(DesignSystem.Colors.accent)
+                    }
+                }
+            }
+            .onAppear {
+                UIApplication.shared.isIdleTimerDisabled = false
+            }
+            .onDisappear {
+                UIApplication.shared.isIdleTimerDisabled = false
+            }
+            .onChange(of: isRunning) { _, running in
+                UIApplication.shared.isIdleTimerDisabled = running
+            }
+        }
+    }
+
+    // MARK: - Selection
+
+    private var selectionView: some View {
+        VStack(spacing: 0) {
+            TimerPickerView(
+                hours: $selectedHours,
+                minutes: $selectedMinutes,
+                seconds: $selectedSeconds
+            )
+            .frame(height: 180)
+        }
+    }
+
+    // MARK: - Timer
+
+    private var timerView: some View {
+        VStack(spacing: DesignSystem.Spacing.xxl) {
+            ZStack {
+                Circle()
+                    .stroke(DesignSystem.Colors.greyLight, lineWidth: 4)
+                    .frame(width: 200, height: 200)
+
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(DesignSystem.Colors.accent, style: StrokeStyle(lineWidth: 4, lineCap: .round))
+                    .frame(width: 200, height: 200)
+                    .rotationEffect(.degrees(-90))
+                    .animation(.linear(duration: 1), value: progress)
+
+                Text(timeString)
+                    .font(.system(size: 44, weight: .light, design: .rounded))
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .monospacedDigit()
+            }
+        }
+    }
+
+    // MARK: - Completed
+
+    private var completedView: some View {
+        VStack(spacing: DesignSystem.Spacing.xl) {
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 48))
+                .foregroundStyle(DesignSystem.Colors.accent)
+
+            Text("\(completedTimeString)の瞑想を完了しました")
+                .font(DesignSystem.Fonts.sectionTitle)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+                .multilineTextAlignment(.center)
+        }
+    }
+
+    // MARK: - Action Button
+
+    @ViewBuilder
+    private var actionButton: some View {
+        if isCompleted {
+            PrimaryButton("完了") {
+                dismiss()
+            }
+        } else if isRunning {
+            SecondaryButton("やめる") {
+                stopTimer()
+                saveAndComplete()
+            }
+        } else {
+            PrimaryButton("はじめる") {
+                if selectedTotalSeconds > 0 {
+                    startTimer()
+                }
+            }
+        }
+    }
+
+    // MARK: - Timer Logic
+
+    private var progress: CGFloat {
+        guard totalSeconds > 0 else { return 1.0 }
+        return CGFloat(totalSeconds - remainingSeconds) / CGFloat(totalSeconds)
+    }
+
+    private var selectedTotalSeconds: Int {
+        selectedHours * 3600 + selectedMinutes * 60 + selectedSeconds
+    }
+
+    private var timeString: String {
+        let h = remainingSeconds / 3600
+        let m = (remainingSeconds % 3600) / 60
+        let s = remainingSeconds % 60
+        if h > 0 {
+            return String(format: "%d:%02d:%02d", h, m, s)
+        }
+        return String(format: "%d:%02d", m, s)
+    }
+
+    private var completedTimeString: String {
+        let elapsed = totalSeconds - remainingSeconds
+        let h = elapsed / 3600
+        let m = (elapsed % 3600) / 60
+        let s = elapsed % 60
+        var parts: [String] = []
+        if h > 0 { parts.append("\(h)時間") }
+        if m > 0 { parts.append("\(m)分") }
+        if s > 0 || parts.isEmpty { parts.append("\(s)秒") }
+        return parts.joined()
+    }
+
+    private func startTimer() {
+        totalSeconds = selectedTotalSeconds
+        remainingSeconds = totalSeconds
+        isRunning = true
+
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { _ in
+            if remainingSeconds > 0 {
+                remainingSeconds -= 1
+            } else {
+                stopTimer()
+                hapticFeedback()
+                saveAndComplete()
+            }
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+        isRunning = false
+    }
+
+    private func saveAndComplete() {
+        let elapsed = totalSeconds - remainingSeconds
+        if elapsed > 0 {
+            meditationStore.addLog(duration: elapsed)
+        }
+        isCompleted = true
+    }
+
+    private func hapticFeedback() {
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+    }
+}
+
+// MARK: - UIPickerView Wrapper (時・分・秒を1つのピッカーで統合)
+
+private struct TimerPickerView: UIViewRepresentable {
+    @Binding var hours: Int
+    @Binding var minutes: Int
+    @Binding var seconds: Int
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(self)
+    }
+
+    func makeUIView(context: Context) -> UIPickerView {
+        let picker = UIPickerView()
+        picker.dataSource = context.coordinator
+        picker.delegate = context.coordinator
+        picker.selectRow(hours, inComponent: 0, animated: false)
+        picker.selectRow(minutes, inComponent: 1, animated: false)
+        picker.selectRow(seconds, inComponent: 2, animated: false)
+        return picker
+    }
+
+    func updateUIView(_ picker: UIPickerView, context: Context) {
+        if picker.selectedRow(inComponent: 0) != hours {
+            picker.selectRow(hours, inComponent: 0, animated: false)
+        }
+        if picker.selectedRow(inComponent: 1) != minutes {
+            picker.selectRow(minutes, inComponent: 1, animated: false)
+        }
+        if picker.selectedRow(inComponent: 2) != seconds {
+            picker.selectRow(seconds, inComponent: 2, animated: false)
+        }
+    }
+
+    class Coordinator: NSObject, UIPickerViewDataSource, UIPickerViewDelegate {
+        let parent: TimerPickerView
+        private let labels = ["時間", "分", "秒"]
+        private let counts = [24, 60, 60]
+
+        init(_ parent: TimerPickerView) {
+            self.parent = parent
+        }
+
+        func numberOfComponents(in pickerView: UIPickerView) -> Int { 3 }
+
+        func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int {
+            counts[component]
+        }
+
+        func pickerView(_ pickerView: UIPickerView, widthForComponent component: Int) -> CGFloat {
+            component == 0 ? 95 : 75
+        }
+
+        func pickerView(_ pickerView: UIPickerView, viewForRow row: Int, forComponent component: Int, reusing view: UIView?) -> UIView {
+            let label = (view as? UILabel) ?? UILabel()
+            label.textAlignment = .center
+            label.font = .systemFont(ofSize: 20)
+
+            let value = "\(row)"
+            let unit = labels[component]
+            let full = "\(value) \(unit)"
+
+            let attr = NSMutableAttributedString(string: full)
+            attr.addAttribute(.font, value: UIFont.systemFont(ofSize: 20), range: NSRange(location: 0, length: value.count))
+            attr.addAttribute(.font, value: UIFont.systemFont(ofSize: 14), range: NSRange(location: value.count + 1, length: unit.count))
+            label.attributedText = attr
+
+            return label
+        }
+
+        func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+            switch component {
+            case 0: parent.hours = row
+            case 1: parent.minutes = row
+            case 2: parent.seconds = row
+            default: break
+            }
+        }
+    }
+}

--- a/ios/Cycle/Features/Journal/Views/Components/JournalHeader.swift
+++ b/ios/Cycle/Features/Journal/Views/Components/JournalHeader.swift
@@ -24,14 +24,14 @@ struct JournalHeader: View {
         }
         .padding(.horizontal, DesignSystem.Spacing.lg)
         .padding(.vertical, DesignSystem.Spacing.md)
-        .modifier(GlassHeaderModifier())
+        .background(DesignSystem.Colors.background)
     }
 
     // MARK: - Components
 
     private var monthYearTitle: some View {
-        Text(selectedDate.formatted(.dateTime.year().month(.wide)))
-            .font(DesignSystem.Fonts.screenTitle)
+        Text(selectedDate.formatted(.dateTime.year().month(.wide).locale(Locale(identifier: "ja_JP"))))
+            .font(.system(size: 28, weight: .bold))
             .foregroundStyle(DesignSystem.Colors.textPrimary)
     }
 
@@ -53,10 +53,10 @@ struct JournalHeader: View {
                 Label("最近削除した項目", systemImage: "trash")
             }
         } label: {
-            Image(systemName: "ellipsis.circle")
-                .font(DesignSystem.Fonts.headerIcon)
+            Image(systemName: "line.3.horizontal")
+                .font(.system(size: 26))
                 .foregroundStyle(DesignSystem.Colors.textSecondary)
+                .modifier(GlassIconModifier())
         }
-        .accessibilityIdentifier("journal_menu")
     }
 }

--- a/ios/Cycle/Features/Journal/Views/DatePickerSheet.swift
+++ b/ios/Cycle/Features/Journal/Views/DatePickerSheet.swift
@@ -24,6 +24,7 @@ struct DatePickerSheet: View {
                 .datePickerStyle(.graphical)
                 .tint(DesignSystem.Colors.accent)
                 .colorScheme(.light)
+                .environment(\.locale, Locale(identifier: "ja_JP"))
                 .padding()
 
                 Spacer()
@@ -45,7 +46,7 @@ struct DatePickerSheet: View {
                 }
             }
         }
-        .presentationDetents([.medium, .large])
+        .presentationDetents([.medium])
         .presentationBackground(DesignSystem.Colors.background)
         .onAppear {
             selectedDate = vm.selectedDate

--- a/ios/Cycle/Features/Journal/Views/JournalDeletedView.swift
+++ b/ios/Cycle/Features/Journal/Views/JournalDeletedView.swift
@@ -107,7 +107,16 @@ struct JournalDeletedRow: View {
     }
 
     private var dateText: some View {
-        Text(entry.date.formatted(.dateTime.year().month().day().hour().minute()))
+        Text(entry.date.formatted(
+            .dateTime
+                .year()
+                .month()
+                .day()
+                .weekday(.abbreviated)
+                .hour(.twoDigits(amPM: .omitted))
+                .minute(.twoDigits)
+                .locale(Locale(identifier: "ja_JP"))
+        ))
             .font(DesignSystem.Fonts.caption)
             .foregroundStyle(DesignSystem.Colors.textSecondary)
     }

--- a/ios/Cycle/Features/Journal/Views/JournalListView.swift
+++ b/ios/Cycle/Features/Journal/Views/JournalListView.swift
@@ -92,15 +92,25 @@ struct JournalListView: View {
     }
 
     private var entriesList: some View {
-        JournalEntriesList(
-            entries: vm.todays,
-            onEdit: { entry in
-                editingEntry = entry
-            },
-            onDelete: { entry in
-                vm.deleteEntry(entry)
-            }
-        )
+        ZStack(alignment: .top) {
+            JournalEntriesList(
+                entries: vm.todays,
+                onEdit: { entry in
+                    editingEntry = entry
+                },
+                onDelete: { entry in
+                    vm.deleteEntry(entry)
+                }
+            )
+
+            LinearGradient(
+                colors: [DesignSystem.Colors.background, DesignSystem.Colors.background.opacity(0)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: 12)
+            .allowsHitTesting(false)
+        }
     }
 
     private var floatingActionButton: some View {
@@ -108,14 +118,6 @@ struct JournalListView: View {
             showNewEntry = true
         }
         .padding(.trailing, DesignSystem.Spacing.xl + 2)
-        .padding(.bottom, fabBottomPadding)
-    }
-
-    private var fabBottomPadding: CGFloat {
-        if #available(iOS 26.0, *) {
-            return 80
-        } else {
-            return DesignSystem.Spacing.xl - 2
-        }
+        .padding(.bottom, DesignSystem.Spacing.xl - 2)
     }
 }

--- a/ios/Cycle/Features/Journal/Views/JournalSearchView.swift
+++ b/ios/Cycle/Features/Journal/Views/JournalSearchView.swift
@@ -36,7 +36,7 @@ struct JournalSearchView: View {
                         Button(action: {
                             vm.searchViewTab = 0
                         }) {
-                            Text("検索")
+                            Text("ワード")
                                 .font(.system(size: DesignSystem.FontSize.body, weight: vm.searchViewTab == 0 ? .semibold : .regular))
                                 .foregroundStyle(vm.searchViewTab == 0 ? DesignSystem.Colors.textPrimary : DesignSystem.Colors.textSecondary)
                                 .frame(maxWidth: .infinity)
@@ -75,7 +75,7 @@ struct JournalSearchView: View {
                         HStack {
                             Image(systemName: "magnifyingglass")
                                 .foregroundStyle(DesignSystem.Colors.textSecondary)
-                            TextField("テキストで検索", text: $vm.searchText)
+                            TextField("ワードで検索", text: $vm.searchText)
                                 .textFieldStyle(.plain)
                                 .foregroundStyle(DesignSystem.Colors.textPrimary)
                                 .tint(DesignSystem.Colors.accent)
@@ -87,8 +87,7 @@ struct JournalSearchView: View {
                             }
                         }
                         .padding(DesignSystem.Spacing.md)
-                        .background(DesignSystem.Colors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md))
+                        .modifier(SearchBarStyle())
                     }
 
                     if vm.searchViewTab == 1 && !vm.allTags.isEmpty {
@@ -107,9 +106,8 @@ struct JournalSearchView: View {
                                                 .font(DesignSystem.Fonts.caption)
                                                 .padding(.horizontal, DesignSystem.Spacing.md)
                                                 .padding(.vertical, DesignSystem.Spacing.xs + 2)
-                                                .background(vm.selectedSearchTags.contains(tag) ? DesignSystem.Colors.accent : DesignSystem.Colors.greyLight)
                                                 .foregroundStyle(vm.selectedSearchTags.contains(tag) ? DesignSystem.Colors.background : DesignSystem.Colors.textPrimary)
-                                                .clipShape(Capsule())
+                                                .modifier(SearchTagStyle(isSelected: vm.selectedSearchTags.contains(tag)))
                                         }
                                     }
                                 }
@@ -205,6 +203,7 @@ struct JournalSearchView: View {
 
     @ViewBuilder
     private func entryList(entries: [JournalEntry], showEmptyMessage: String) -> some View {
+        ZStack(alignment: .top) {
         List {
             if entries.isEmpty {
                 EmptyStateView(icon: "magnifyingglass", title: "見つかりませんでした")
@@ -220,11 +219,16 @@ struct JournalSearchView: View {
                                 .lineSpacing(4)
 
                             HStack(spacing: DesignSystem.Spacing.sm) {
-                                Text(entry.date, format: .dateTime.year().month().day())
-                                    .font(DesignSystem.Fonts.caption)
-                                    .foregroundStyle(DesignSystem.Colors.textSecondary)
-
-                                Text(entry.date.timeHM)
+                                Text(entry.date.formatted(
+                                    .dateTime
+                                        .year()
+                                        .month()
+                                        .day()
+                                        .weekday(.abbreviated)
+                                        .hour(.twoDigits(amPM: .omitted))
+                                        .minute(.twoDigits)
+                                        .locale(Locale(identifier: "ja_JP"))
+                                ))
                                     .font(DesignSystem.Fonts.caption)
                                     .foregroundStyle(DesignSystem.Colors.textSecondary)
 
@@ -237,18 +241,7 @@ struct JournalSearchView: View {
                         }
                         .padding(DesignSystem.Spacing.lg)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(DesignSystem.Colors.surface)
-                        .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous)
-                                .stroke(DesignSystem.Colors.grey.opacity(0.6), lineWidth: 0.5)
-                        )
-                        .shadow(
-                            color: DesignSystem.Colors.brownDark.opacity(0.08),
-                            radius: 4,
-                            x: 0,
-                            y: 2
-                        )
+                        .modifier(SearchCardStyle())
                         .listRowInsets(
                             EdgeInsets(
                                 top: DesignSystem.Spacing.xs,
@@ -266,5 +259,73 @@ struct JournalSearchView: View {
         .listStyle(.plain)
         .scrollContentBackground(.hidden)
         .background(DesignSystem.Colors.background)
+
+            LinearGradient(
+                colors: [DesignSystem.Colors.background, DesignSystem.Colors.background.opacity(0)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: 12)
+            .allowsHitTesting(false)
+        }
+    }
+}
+
+private struct SearchTagStyle: ViewModifier {
+    let isSelected: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            if isSelected {
+                content
+                    .background { Capsule().fill(DesignSystem.Colors.accent) }
+                    .clipShape(Capsule())
+                    .glassEffect(.regular.interactive(), in: .capsule)
+            } else {
+                content
+                    .background { Capsule().fill(DesignSystem.Colors.greyLight) }
+                    .clipShape(Capsule())
+            }
+        } else {
+            content
+                .background(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.greyLight)
+                .clipShape(Capsule())
+        }
+    }
+}
+
+private struct SearchBarStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(.regular, in: .rect(cornerRadius: DesignSystem.Spacing.md))
+        } else {
+            content
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md))
+        }
+    }
+}
+
+private struct SearchCardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .rect(cornerRadius: DesignSystem.Spacing.md))
+        } else {
+            content
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
+                .overlay(
+                    RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous)
+                        .stroke(DesignSystem.Colors.grey.opacity(0.6), lineWidth: 0.5)
+                )
+                .shadow(
+                    color: DesignSystem.Colors.brownDark.opacity(0.08),
+                    radius: 4,
+                    x: 0,
+                    y: 2
+                )
+        }
     }
 }

--- a/ios/Cycle/Features/Journal/Views/TagManagementView.swift
+++ b/ios/Cycle/Features/Journal/Views/TagManagementView.swift
@@ -45,15 +45,10 @@ struct TagManagementView: View {
                     }
                 }
                 .padding(DesignSystem.Spacing.lg)
-                .background(DesignSystem.Colors.surface)
-                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
+                .modifier(TagManagementCardStyle())
                 .padding(.horizontal, DesignSystem.Spacing.lg)
                 .padding(.top, DesignSystem.Spacing.lg)
                 .padding(.bottom, DesignSystem.Spacing.md)
-
-                Divider()
-                    .background(DesignSystem.Colors.grey)
-                    .padding(.horizontal, DesignSystem.Spacing.lg)
 
                 // Tags list
                 if vm.allTags.isEmpty {
@@ -68,8 +63,7 @@ struct TagManagementView: View {
                                 Spacer()
                             }
                             .padding(DesignSystem.Spacing.lg)
-                            .background(DesignSystem.Colors.surface)
-                            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
+                            .modifier(TagManagementCardStyle())
                             .listRowBackground(Color.clear)
                             .listRowSeparator(.hidden)
                             .listRowInsets(EdgeInsets(
@@ -156,5 +150,18 @@ struct TagManagementView: View {
 
     private func deleteTag(_ tag: String) {
         vm.removeTag(tag)
+    }
+}
+
+private struct TagManagementCardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .glassEffect(.regular.interactive(), in: .rect(cornerRadius: DesignSystem.Spacing.md))
+        } else {
+            content
+                .background(DesignSystem.Colors.surface)
+                .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
+        }
     }
 }

--- a/ios/Cycle/Features/Journal/Views/TagSelector.swift
+++ b/ios/Cycle/Features/Journal/Views/TagSelector.swift
@@ -61,10 +61,34 @@ private struct TagButton: View {
                 .font(DesignSystem.Fonts.caption)
                 .padding(.horizontal, DesignSystem.Spacing.md)
                 .padding(.vertical, DesignSystem.Spacing.xs + 2)
+                .modifier(TagButtonStyle(isSelected: isSelected))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+private struct TagButtonStyle: ViewModifier {
+    let isSelected: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            if isSelected {
+                content
+                    .background(DesignSystem.Colors.accent)
+                    .foregroundStyle(DesignSystem.Colors.background)
+                    .clipShape(Capsule())
+                    .glassEffect(.regular.interactive(), in: .capsule)
+            } else {
+                content
+                    .background(DesignSystem.Colors.greyLight)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+                    .clipShape(Capsule())
+            }
+        } else {
+            content
                 .background(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.greyLight)
                 .foregroundStyle(isSelected ? DesignSystem.Colors.background : DesignSystem.Colors.textPrimary)
                 .clipShape(Capsule())
         }
-        .buttonStyle(.plain)
     }
 }

--- a/ios/Cycle/Features/Journal/Views/WeekCalendarView.swift
+++ b/ios/Cycle/Features/Journal/Views/WeekCalendarView.swift
@@ -44,10 +44,9 @@ struct WeekCalendarView: View {
 
         return VStack(spacing: DesignSystem.Spacing.sm) {
             // 曜日
-            Text(date, format: .dateTime.weekday(.abbreviated))
+            Text(["日", "月", "火", "水", "木", "金", "土"][Calendar.current.component(.weekday, from: date) - 1])
                 .font(.system(size: DesignSystem.FontSize.caption - 1))
-                .foregroundStyle(DesignSystem.Colors.textTertiary)
-                .textCase(.uppercase)
+                .foregroundStyle(DesignSystem.Colors.textSecondary)
 
             // 日付
             Text(date, format: .dateTime.day())

--- a/ios/Cycle/Features/Tasks/Views/Components/TaskHeader.swift
+++ b/ios/Cycle/Features/Tasks/Views/Components/TaskHeader.swift
@@ -17,8 +17,8 @@ struct TaskHeader: View {
 
     var body: some View {
         HStack(alignment: .center) {
-            Text("Today's Focus")
-                .font(DesignSystem.Fonts.screenTitle)
+            Text("タスクリスト")
+                .font(.system(size: 28, weight: .bold))
                 .foregroundStyle(DesignSystem.Colors.textPrimary)
 
             Spacer()
@@ -39,14 +39,15 @@ struct TaskHeader: View {
                     Label("最近削除した項目", systemImage: "trash")
                 }
             } label: {
-                Image(systemName: "ellipsis.circle")
-                    .font(DesignSystem.Fonts.headerIcon)
+                Image(systemName: "line.3.horizontal")
+                    .font(.system(size: 26))
                     .foregroundStyle(DesignSystem.Colors.textSecondary)
+                    .modifier(GlassIconModifier())
             }
-            .accessibilityIdentifier("task_menu")
         }
         .padding(.horizontal, DesignSystem.Spacing.lg)
-        .padding(.vertical, DesignSystem.Spacing.md)
-        .modifier(GlassHeaderModifier())
+        .padding(.top, DesignSystem.Spacing.md)
+        .padding(.bottom, DesignSystem.Spacing.md + DesignSystem.Spacing.sm)
+        .background(DesignSystem.Colors.background)
     }
 }

--- a/ios/Cycle/Features/Tasks/Views/Components/TaskRow.swift
+++ b/ios/Cycle/Features/Tasks/Views/Components/TaskRow.swift
@@ -42,6 +42,7 @@ struct TaskRow: View {
                 taskTitle
                 Spacer()
             }
+            .padding(.vertical, 2.5)
         }
     }
 
@@ -98,6 +99,6 @@ struct TaskRow: View {
             Label("アーカイブ", systemImage: "archivebox")
                 .labelStyle(.iconOnly)
         }
-        .tint(DesignSystem.Colors.accent)
+        .tint(.blue)
     }
 }

--- a/ios/Cycle/Features/Tasks/Views/TaskArchiveView.swift
+++ b/ios/Cycle/Features/Tasks/Views/TaskArchiveView.swift
@@ -48,7 +48,7 @@ struct TaskArchiveView: View {
     }
 
     private var emptyState: some View {
-        EmptyStateView(icon: "archivebox", title: "アーカイブはまだありません", subtitle: "完了したタスクをアーカイブするとここに表示されます")
+        EmptyStateView(icon: "archivebox", title: "アーカイブはまだありません")
             .background(DesignSystem.Colors.background)
     }
 

--- a/ios/Cycle/Features/Tasks/Views/TaskListView.swift
+++ b/ios/Cycle/Features/Tasks/Views/TaskListView.swift
@@ -56,7 +56,7 @@ struct TaskListView: View {
     }
 
     private var mainContent: some View {
-        VStack(spacing: DesignSystem.Spacing.sm) {
+        VStack(spacing: 0) {
             header
 
             NetworkStatusBanner()
@@ -109,29 +109,39 @@ struct TaskListView: View {
         if vm.tasks.isEmpty {
             EmptyStateView(icon: "checkmark.circle", title: "タスクがまだありません", subtitle: "＋ボタンから新しいタスクを追加しましょう")
         } else {
-            TaskList(
-                incompleteTasks: vm.incompleteTasks,
-                completedTasks: vm.completedTasks,
-                isReorderMode: isReorderMode,
-                onMove: { source, destination in
-                    vm.moveIncompleteTasks(from: source, to: destination)
-                },
-                onToggleCompletion: { task in
-                    vm.toggleCompletion(task)
-                },
-                onEdit: { task in
-                    editingTask = task
-                },
-                onDelete: { task in
-                    vm.deleteTask(task)
-                },
-                onPreview: { task in
-                    previewingTask = task
-                },
-                onArchive: { task in
-                    vm.archiveTask(task)
-                }
-            )
+            ZStack(alignment: .top) {
+                TaskList(
+                    incompleteTasks: vm.incompleteTasks,
+                    completedTasks: vm.completedTasks,
+                    isReorderMode: isReorderMode,
+                    onMove: { source, destination in
+                        vm.moveIncompleteTasks(from: source, to: destination)
+                    },
+                    onToggleCompletion: { task in
+                        vm.toggleCompletion(task)
+                    },
+                    onEdit: { task in
+                        editingTask = task
+                    },
+                    onDelete: { task in
+                        vm.deleteTask(task)
+                    },
+                    onPreview: { task in
+                        previewingTask = task
+                    },
+                    onArchive: { task in
+                        vm.archiveTask(task)
+                    }
+                )
+
+                LinearGradient(
+                    colors: [DesignSystem.Colors.background, DesignSystem.Colors.background.opacity(0)],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+                .frame(height: 12)
+                .allowsHitTesting(false)
+            }
         }
     }
 
@@ -140,14 +150,6 @@ struct TaskListView: View {
             showNewTask = true
         }
         .padding(.trailing, DesignSystem.Spacing.xl + 2)
-        .padding(.bottom, fabBottomPadding)
-    }
-
-    private var fabBottomPadding: CGFloat {
-        if #available(iOS 26.0, *) {
-            return 80
-        } else {
-            return DesignSystem.Spacing.xl - 2
-        }
+        .padding(.bottom, DesignSystem.Spacing.xl - 2)
     }
 }

--- a/ios/Cycle/Features/Tasks/Views/TaskPreviewView.swift
+++ b/ios/Cycle/Features/Tasks/Views/TaskPreviewView.swift
@@ -23,6 +23,10 @@ struct TaskPreviewView: View {
                         descriptionSection
                     }
 
+                    if let dueDate = task.dueDate {
+                        deadlineSection(date: dueDate)
+                    }
+
                     if !task.intent.isEmpty {
                         fieldSection(title: "意図", content: task.intent)
                     }
@@ -84,6 +88,21 @@ struct TaskPreviewView: View {
 
     private var descriptionSection: some View {
         fieldSection(title: "詳細", content: task.description)
+    }
+
+    private func deadlineSection(date: Date) -> some View {
+        VStack(alignment: .leading, spacing: DesignSystem.Spacing.md) {
+            Text("締切日時")
+                .font(DesignSystem.Fonts.headline)
+                .foregroundStyle(DesignSystem.Colors.textPrimary)
+
+            SurfaceCard {
+                Text(date.formatted(.dateTime.year().month().day().weekday(.abbreviated).hour().minute().locale(Locale(identifier: "ja_JP"))))
+                    .font(DesignSystem.Fonts.body)
+                    .foregroundStyle(DesignSystem.Colors.textPrimary)
+            }
+        }
+        .padding(.horizontal, DesignSystem.Spacing.lg)
     }
 
     private func fieldSection(title: String, content: String) -> some View {

--- a/ios/Cycle/Shared/Components/EmptyStateView.swift
+++ b/ios/Cycle/Shared/Components/EmptyStateView.swift
@@ -26,7 +26,6 @@ struct EmptyStateView: View {
             Image(systemName: icon)
                 .font(DesignSystem.Fonts.largeIcon)
                 .foregroundStyle(DesignSystem.Colors.textTertiary)
-                .symbolEffect(.pulse.byLayer, options: .repeat(3))
 
             VStack(spacing: DesignSystem.Spacing.sm) {
                 Text(title)

--- a/ios/Cycle/Shared/Components/FloatingActionButton.swift
+++ b/ios/Cycle/Shared/Components/FloatingActionButton.swift
@@ -34,11 +34,7 @@ struct FloatingActionButton: View {
     }
 
     private var fabForeground: Color {
-        if #available(iOS 26.0, *) {
-            return DesignSystem.Colors.accent
-        } else {
-            return DesignSystem.Colors.background
-        }
+        DesignSystem.Colors.background
     }
 }
 
@@ -48,6 +44,8 @@ private struct FABBackgroundStyle: ViewModifier {
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *) {
             content
+                .background(DesignSystem.Colors.accent)
+                .clipShape(Circle())
                 .glassEffect(.regular.interactive(), in: .circle)
         } else {
             content

--- a/ios/Cycle/Shared/Components/GlassHeaderModifier.swift
+++ b/ios/Cycle/Shared/Components/GlassHeaderModifier.swift
@@ -24,6 +24,21 @@ struct GlassHeaderModifier: ViewModifier {
     }
 }
 
+/// アイコンボタン用 Liquid Glass
+/// iOS 26+: 円形のglassEffectを適用
+/// iOS 25以下: そのまま表示
+struct GlassIconModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .padding(12)
+                .glassEffect(.regular.interactive(), in: .circle)
+        } else {
+            content
+        }
+    }
+}
+
 /// システムNavigationBar用（Coach, Settings）
 /// iOS 26+ではナビバー背景を透過してLiquid Glass感を出す
 struct GlassNavBarModifier: ViewModifier {

--- a/ios/Cycle/Shared/Components/TagChip.swift
+++ b/ios/Cycle/Shared/Components/TagChip.swift
@@ -32,7 +32,21 @@ struct TagChip: View {
             .foregroundStyle(DesignSystem.Colors.textSecondary)
             .padding(.horizontal, DesignSystem.Spacing.sm)
             .padding(.vertical, DesignSystem.Spacing.xs)
-            .background(DesignSystem.Colors.grey)
-            .clipShape(Capsule())
+            .modifier(TagChipBackgroundStyle())
+    }
+}
+
+private struct TagChipBackgroundStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 26.0, *) {
+            content
+                .background(DesignSystem.Colors.grey)
+                .clipShape(Capsule())
+                .glassEffect(.regular, in: .capsule)
+        } else {
+            content
+                .background(DesignSystem.Colors.grey)
+                .clipShape(Capsule())
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Liquid Glass対応（ヘッダーボタン、FAB、TagChip、検索タグ等）
- 瞑想モード追加（タイマー式、ホイールピッカー、履歴管理）
- ジャーナル・タスク・セッションのヘッダーレイアウト統一（カスタムヘッダー + GlassIconModifier）
- UI調整（日本語化、アイコン変更、余白統一、日付表示形式統一）
- タスクプレビューに締切日時セクション追加
- 会話履歴タップで過去の会話閲覧機能追加

## 変更ファイル数
- 変更: 24ファイル
- 新規: 6ファイル（MeditationLog, MeditationStore, MeditationView, SessionDetailView, CHANGES_1, CHANGES_2）

## Test plan
- [ ] ジャーナル画面: ヘッダーの三本線ボタンがLiquid Glassで表示されること
- [ ] タスク画面: ヘッダーの三本線ボタンがLiquid Glassで表示されること
- [ ] セッション画面: ヘッダーのタイトル・ボタン位置がジャーナル・タスクと揃っていること
- [ ] 瞑想モード: タイマー選択・開始・完了・履歴が正常に動作すること
- [ ] 検索画面: タブ名「ワード」、プレースホルダー「ワードで検索」で表示されること
- [ ] タスクプレビュー: 締切日時が正しく表示されること
- [ ] iOS 17-25: Liquid Glassなしのフォールバックが正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)