### PR TITLE
refactor: #37 Paywall/オンボの配色をブランドトークンに統一

### DIFF
--- a/ios/Cycle/Features/Onboarding/Views/OnboardingFirstJournalView.swift
+++ b/ios/Cycle/Features/Onboarding/Views/OnboardingFirstJournalView.swift
@@ -38,7 +38,7 @@ struct OnboardingFirstJournalView: View {
                 .focused($isEditorFocused)
                 .padding(8)
                 .frame(minHeight: 180)
-                .background(Color(.secondarySystemBackground))
+                .background(DesignSystem.Colors.surface)
                 .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
             }
 
@@ -56,9 +56,9 @@ struct OnboardingFirstJournalView: View {
                     .font(.system(size: 17, weight: .semibold))
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
-                    .background(flow.canAdvance ? Color.green : Color.gray)
+                    .background(flow.canAdvance ? DesignSystem.Colors.accent : DesignSystem.Colors.grey)
                     .foregroundStyle(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
             }
             .disabled(!flow.canAdvance)
         }

--- a/ios/Cycle/Features/Onboarding/Views/OnboardingNotificationPermissionView.swift
+++ b/ios/Cycle/Features/Onboarding/Views/OnboardingNotificationPermissionView.swift
@@ -16,7 +16,7 @@ struct OnboardingNotificationPermissionView: View {
             VStack(spacing: 16) {
                 Image(systemName: "bell.badge.fill")
                     .font(.system(size: 56))
-                    .foregroundStyle(.green)
+                    .foregroundStyle(DesignSystem.Colors.accent)
                 Text("そっと背中を押させてください")
                     .font(.system(size: 24, weight: .bold))
                     .multilineTextAlignment(.center)
@@ -40,9 +40,9 @@ struct OnboardingNotificationPermissionView: View {
                     }
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
-                    .background(Color.green)
+                    .background(DesignSystem.Colors.accent)
                     .foregroundStyle(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
                 }
                 .disabled(isRequesting)
 

--- a/ios/Cycle/Features/Subscription/Views/PaywallView.swift
+++ b/ios/Cycle/Features/Subscription/Views/PaywallView.swift
@@ -41,7 +41,7 @@ struct PaywallView: View {
             .padding(.horizontal, 24)
             .padding(.vertical, 32)
         }
-        .background(Color(.systemBackground))
+        .background(DesignSystem.Colors.background)
         .task {
             await store.loadProducts()
             await store.refreshEntitlements()
@@ -54,7 +54,7 @@ struct PaywallView: View {
         VStack(spacing: 12) {
             Image(systemName: "tree.fill")
                 .font(.system(size: 48))
-                .foregroundStyle(.green)
+                .foregroundStyle(DesignSystem.Colors.accent)
             Text("Cycle Premium")
                 .font(.system(size: 28, weight: .bold))
             Text("自分と向き合う時間を、もっと深く。")
@@ -68,7 +68,7 @@ struct PaywallView: View {
         VStack(alignment: .leading, spacing: 16) {
             timelineRow(
                 icon: "checkmark.circle.fill",
-                color: .green,
+                color: DesignSystem.Colors.accent,
                 title: "今すぐ",
                 subtitle: "Premium 機能をすべて開放"
             )
@@ -86,7 +86,7 @@ struct PaywallView: View {
             )
         }
         .padding(20)
-        .background(Color(.secondarySystemBackground))
+        .background(DesignSystem.Colors.surface)
         .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
     }
 
@@ -131,7 +131,7 @@ struct PaywallView: View {
             HStack(alignment: .center, spacing: 16) {
                 Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
                     .font(.system(size: 22))
-                    .foregroundStyle(isSelected ? .green : .secondary)
+                    .foregroundStyle(isSelected ? DesignSystem.Colors.accent : .secondary)
 
                 VStack(alignment: .leading, spacing: 4) {
                     HStack(spacing: 8) {
@@ -142,8 +142,8 @@ struct PaywallView: View {
                                 .font(.caption2.bold())
                                 .padding(.horizontal, 8)
                                 .padding(.vertical, 2)
-                                .background(Color.green.opacity(0.15))
-                                .foregroundStyle(.green)
+                                .background(DesignSystem.Colors.accent.opacity(0.15))
+                                .foregroundStyle(DesignSystem.Colors.accent)
                                 .clipShape(Capsule())
                         }
                     }
@@ -160,7 +160,7 @@ struct PaywallView: View {
             .padding(16)
             .background(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(isSelected ? Color.green : Color(.separator), lineWidth: isSelected ? 2 : 1)
+                    .stroke(isSelected ? DesignSystem.Colors.accent : Color(.separator), lineWidth: isSelected ? 2 : 1)
             )
         }
         .buttonStyle(.plain)
@@ -177,9 +177,9 @@ struct PaywallView: View {
             }
             .frame(maxWidth: .infinity)
             .padding(.vertical, 16)
-            .background(Color.green)
+            .background(DesignSystem.Colors.accent)
             .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
         }
         .disabled(isPurchasing || store.products.isEmpty)
     }


### PR DESCRIPTION
## 概要

課金系UI（PaywallView）とオンボーディング2画面が **生 `.green` + iOS システム色**で実装されており、アプリ本体の **茶系ブランド（`DesignSystem.Colors.accent`）と乖離**していた。デザイントークン参照に統一し、見た目の一貫性を回復する。

## 背景（デザイン整合チェックの結果）

| 観点 | 修正前 Paywall | アプリ標準 |
|---|---|---|
| アクセント | `.green`（生） | `Colors.accent`（茶） |
| 背景 | `Color(.systemBackground)` | `Colors.background` |
| CTA | 自前 `.green` | 茶 |
| 角丸 | 14pt | 12pt (`Spacing.md`) |

メイン画面（Journal一覧）は茶系トークンを使用しており、Paywall/オンボだけ「緑ゾーン」を形成していた。

## 変更内容

- 生 `.green` → `DesignSystem.Colors.accent`（tree アイコン / 選択状態 / おすすめバッジ / CTA / 通知ボタン / 保存ボタン）
- `Color(.systemBackground)` → `DesignSystem.Colors.background`
- `Color(.secondarySystemBackground)` → `DesignSystem.Colors.surface`
- ボタン角丸 14pt → `DesignSystem.Spacing.md`（12pt）
- 無効状態 `Color.gray` → `DesignSystem.Colors.grey`
- タイムラインの `orange`/`blue` は手順区別の意味色として**意図的に保持**

## 対象ファイル

- `ios/Cycle/Features/Subscription/Views/PaywallView.swift`
- `ios/Cycle/Features/Onboarding/Views/OnboardingFirstJournalView.swift`
- `ios/Cycle/Features/Onboarding/Views/OnboardingNotificationPermissionView.swift`

## 検証

- `xcodebuild` **BUILD SUCCEEDED**
- シミュレータで Paywall を描画し、茶系ブランド反映を**目視確認**（tree/選択/CTA すべて茶、背景は温かいオフホワイト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)