### PR TITLE
chore: #37 IAP 用 Secret と Cloud Run env を Terraform に追加

### DIFF
--- a/infra/cloud_run.tf
+++ b/infra/cloud_run.tf
@@ -64,6 +64,32 @@ resource "google_cloud_run_v2_service" "api" {
         }
       }
 
+      # IAP (App Store Server API / ASSN V2)
+      env {
+        name  = "APPLE_IAP_ISSUER_ID"
+        value = var.apple_iap_issuer_id
+      }
+
+      env {
+        name  = "APPLE_IAP_KEY_ID"
+        value = var.apple_iap_key_id
+      }
+
+      env {
+        name = "APPLE_IAP_PRIVATE_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.apple_iap_private_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "APPLE_IAP_ENV"
+        value = var.apple_iap_env
+      }
+
       env {
         name  = "USE_LANGGRAPH"
         value = var.use_langgraph ? "true" : "false"
@@ -90,6 +116,7 @@ resource "google_cloud_run_v2_service" "api" {
     google_project_service.apis,
     google_secret_manager_secret_version.jwt_secret,
     google_secret_manager_secret.apple_auth,
+    google_secret_manager_secret.apple_iap_private_key,
   ]
 }
 

--- a/infra/prod.tfvars
+++ b/infra/prod.tfvars
@@ -3,3 +3,8 @@ region        = "asia-northeast1"
 environment   = "prod"
 apple_team_id = "AXSR25N22T"
 apple_key_id  = "TXTX42VXG4"
+
+# IAP 専用キー (Sign in with Apple とは別物。issuer/key id は環境共通)
+apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
+apple_iap_key_id    = "7W562GZ399"
+apple_iap_env       = "Sandbox" # テスト完了後 "Production" に変更

--- a/infra/secret_manager.tf
+++ b/infra/secret_manager.tf
@@ -9,6 +9,20 @@ resource "google_secret_manager_secret" "apple_auth" {
   depends_on = [google_project_service.apis]
 }
 
+# IAP (App Store Server API / ASSN V2 JWS 検証) 用 .p8 秘密鍵。
+# 値 (version) は TF state に秘密を残さないため手動投入する:
+#   gcloud secrets versions add apple-iap-private-key-<env> --data-file=./SubscriptionKey_XXX.p8 --project=cycle-journal
+resource "google_secret_manager_secret" "apple_iap_private_key" {
+  secret_id = "apple-iap-private-key-${var.environment}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
 # JWT署名鍵（サーバー発行アクセストークン用）
 resource "google_secret_manager_secret" "jwt_secret" {
   secret_id = "jwt-secret-${var.environment}"

--- a/infra/terraform.tfvars
+++ b/infra/terraform.tfvars
@@ -3,3 +3,7 @@ region        = "asia-northeast1"
 environment   = "dev"
 apple_team_id = "AXSR25N22T"
 apple_key_id  = "TXTX42VXG4"
+
+# IAP 専用キー (Sign in with Apple とは別物)
+apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
+apple_iap_key_id    = "7W562GZ399"

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -36,3 +36,19 @@ variable "apple_key_id" {
   description = "Apple Sign in with Apple Key ID (.p8 と対になる)"
   type        = string
 }
+
+variable "apple_iap_issuer_id" {
+  description = "App Store Connect IAP Key Issuer ID (UUID, アカウント全体で固定)"
+  type        = string
+}
+
+variable "apple_iap_key_id" {
+  description = "App Store Connect IAP Key ID (10 文字、IAP 専用キー。Sign in with Apple の key_id とは別物)"
+  type        = string
+}
+
+variable "apple_iap_env" {
+  description = "IAP 検証先の Apple 環境。Sandbox / Production。deploy 環境(environment)とは独立。テスト中は Sandbox。"
+  type        = string
+  default     = "Sandbox"
+}


### PR DESCRIPTION
## 概要

手順02（IAP Key / Secret Manager）を IaC で実装。App Store Server API・ASSN V2 の JWS 検証に必要な IAP 認証情報を Cloud Run に結線した。**既に prod へ apply 済み**。

## 背景

- IAP 用 `.p8` キーを App Store Connect で発行（Key ID `7W562GZ399` / Issuer ID `c7bb6896-…`）
- 既存インフラは Terraform 管理（workspace: `default`/`prod`、稼働中は `prod`）
- Sign in with Apple の鍵（`TXTX42VXG4`）とは**別系統**。既存パターン（`.p8` のみ Secret、ID 類は平文 env）を踏襲

## 変更内容

- **secret_manager.tf**: `apple-iap-private-key-${env}` を宣言（値=`.p8` は TF state に残さず gcloud で手動 version 投入）
- **cloud_run.tf**: `APPLE_IAP_ISSUER_ID` / `_KEY_ID` / `_PRIVATE_KEY`(secret) / `_ENV` を env 注入、`depends_on` に新 secret 追加
- **variables.tf**: `apple_iap_issuer_id` / `apple_iap_key_id` / `apple_iap_env`（Sandbox 既定、deploy 環境とは独立）
- **tfvars(dev/prod)**: issuer/key **ID** を設定（識別子。秘密は `.p8` のみで repo 非格納）。prod は当面 `Sandbox` 検証

## apply 結果（prod workspace, prod.tfvars）

- Plan: **1 add / 1 change / 0 destroy**
- secret `apple-iap-private-key-prod` 作成 → `.p8` を version 1 (enabled) 投入
- `cycle-api-prod` 更新、リビジョン `cycle-api-prod-00007-8dp` **Ready=True**
- env 反映確認済み（`APPLE_IAP_ENV=Sandbox`）

## 残（別タスク）

- 本番課金開始時に `apple_iap_env` を `Production` へ
- Production 時は `APPLE_IAP_APP_APPLE_ID`（数値 App ID）を追加結線
- サーバー側ロジック B1（`/iap/apple/verify`）/ B2（ASSN state machine）は未実装

🤖 Generated with [Claude Code](https://claude.com/claude-code)