### PR TITLE
Introduce Pow motion effects to SwiftUI components

### DIFF
--- a/ios/Cycle.xcodeproj/project.pbxproj
+++ b/ios/Cycle.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0ADAFA4B2F6D952200B3ABC8 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A10000000000000002 /* GoogleSignIn */; };
 		0ADAFA4C2F6D952200B3ABC8 /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = A1A1A1A10000000000000003 /* GoogleSignInSwift */; };
+		B4C0DE012F90000100B3ABC8 /* Pow in Frameworks */ = {isa = PBXBuildFile; productRef = B4C0DE032F90000100B3ABC8 /* Pow */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,6 +59,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B4C0DE012F90000100B3ABC8 /* Pow in Frameworks */,
 				0ADAFA4C2F6D952200B3ABC8 /* GoogleSignInSwift in Frameworks */,
 				0ADAFA4B2F6D952200B3ABC8 /* GoogleSignIn in Frameworks */,
 			);
@@ -123,6 +125,7 @@
 			packageProductDependencies = (
 				A1A1A1A10000000000000002 /* GoogleSignIn */,
 				A1A1A1A10000000000000003 /* GoogleSignInSwift */,
+				B4C0DE032F90000100B3ABC8 /* Pow */,
 			);
 			productName = Cycle;
 			productReference = 2E0FCB122EBF921700B9081E /* Cycle.app */;
@@ -208,6 +211,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				A1A1A1A10000000000000001 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */,
+				B4C0DE022F90000100B3ABC8 /* XCRemoteSwiftPackageReference "Pow" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 2E0FCB132EBF921700B9081E /* Products */;
@@ -598,6 +602,14 @@
 				minimumVersion = 8.0.0;
 			};
 		};
+		B4C0DE022F90000100B3ABC8 /* XCRemoteSwiftPackageReference "Pow" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/EmergeTools/Pow";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -610,6 +622,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A1A1A1A10000000000000001 /* XCRemoteSwiftPackageReference "GoogleSignIn-iOS" */;
 			productName = GoogleSignInSwift;
+		};
+		B4C0DE032F90000100B3ABC8 /* Pow */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B4C0DE022F90000100B3ABC8 /* XCRemoteSwiftPackageReference "Pow" */;
+			productName = Pow;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/ios/Cycle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/Cycle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "68aa00e3cba36db2e0a76f54dbc84d1f079d8aa9a19bfa9fce02d6286bd620b7",
+  "originHash" : "0c0b8ca921b85fbcf3711594222ebf7c598faee0082b09ec9a42e6c8ca4d3792",
   "pins" : [
     {
       "identity" : "app-check",
@@ -62,6 +62,15 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "pow",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/EmergeTools/Pow",
+      "state" : {
+        "revision" : "1b4b1dda28c50b95f0872927ee2226fe8b58950e",
+        "version" : "1.0.6"
       }
     }
   ],

--- a/ios/Cycle/App/ContentView.swift
+++ b/ios/Cycle/App/ContentView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Pow
 
 struct ContentView: View {
     @State private var selectedTab = 0
@@ -131,8 +132,18 @@ struct TabBarButton: View {
     var body: some View {
         Button(action: action) {
             VStack(spacing: 4) {
-                Image(systemName: isSelected ? selectedIcon : icon)
-                    .font(.system(size: DesignSystem.FontSize.title3))
+                ZStack {
+                    if isSelected {
+                        Image(systemName: selectedIcon)
+                            .transition(.movingParts.pop(DesignSystem.Colors.accent))
+                    } else {
+                        Image(systemName: icon)
+                            .transition(.opacity)
+                    }
+                }
+                .font(.system(size: DesignSystem.FontSize.title3))
+                .frame(width: DesignSystem.ComponentSize.iconSize, height: DesignSystem.ComponentSize.iconSize)
+                .changeEffect(.jump(height: 5), value: isSelected, isEnabled: isSelected)
 
                 Text(label)
                     .font(.system(size: 10))
@@ -140,6 +151,7 @@ struct TabBarButton: View {
             .foregroundStyle(isSelected ? DesignSystem.Colors.accent : DesignSystem.Colors.textSecondary)
             .frame(maxWidth: .infinity)
         }
+        .animation(DesignSystem.Timing.easing, value: isSelected)
         .accessibilityIdentifier("tab_\(label)")
     }
 }

--- a/ios/Cycle/Features/Journal/Views/TagSelector.swift
+++ b/ios/Cycle/Features/Journal/Views/TagSelector.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Pow
 
 /// タグ選択用のコンポーネント
 /// 利用可能なタグ一覧から複数選択可能
@@ -43,9 +44,6 @@ struct TagSelector: View {
             selectedTags.append(tag)
         }
 
-        // 触覚フィードバック
-        let impactFeedback = UIImpactFeedbackGenerator(style: .light)
-        impactFeedback.impactOccurred()
     }
 }
 
@@ -64,6 +62,16 @@ private struct TagButton: View {
                 .modifier(TagButtonStyle(isSelected: isSelected))
         }
         .buttonStyle(.plain)
+        .changeEffect(
+            .pulse(
+                shape: Capsule(style: .continuous),
+                style: DesignSystem.Colors.accent.opacity(0.2),
+                drawingMode: .stroke
+            ),
+            value: isSelected,
+            isEnabled: isSelected
+        )
+        .changeEffect(.feedbackHapticSelection, value: isSelected)
     }
 }
 

--- a/ios/Cycle/Features/Journal/Views/WeekCalendarView.swift
+++ b/ios/Cycle/Features/Journal/Views/WeekCalendarView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Pow
 
 /// 週単位のカレンダービューコンポーネント
 /// 横スワイプで週を切り替え、日付タップで選択可能
@@ -66,6 +67,8 @@ struct WeekCalendarView: View {
                         .fill(isSelected ? DesignSystem.Colors.accent : Color.clear)
                 )
                 .animation(DesignSystem.Timing.easing, value: isSelected)
+                .changeEffect(.jump(height: 4), value: isSelected, isEnabled: isSelected)
+                .changeEffect(.feedbackHapticSelection, value: isSelected, isEnabled: isSelected)
         }
         .frame(maxWidth: .infinity)
         .contentShape(Rectangle())

--- a/ios/Cycle/Features/Tasks/Views/Components/TaskFieldTabs.swift
+++ b/ios/Cycle/Features/Tasks/Views/Components/TaskFieldTabs.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Pow
 
 /// タスク詳細フィールド切り替えタブ
 /// 横スクロール可能なタブで、意図・完了イメージ・注意点を切り替え
@@ -80,5 +81,15 @@ private struct FieldTabButton: View {
                 )
         }
         .animation(DesignSystem.Timing.easing, value: isSelected)
+        .changeEffect(
+            .pulse(
+                shape: Capsule(style: .continuous),
+                style: DesignSystem.Colors.accent.opacity(0.18),
+                drawingMode: .stroke
+            ),
+            value: isSelected,
+            isEnabled: isSelected
+        )
+        .changeEffect(.feedbackHapticSelection, value: isSelected, isEnabled: isSelected)
     }
 }

--- a/ios/Cycle/Features/Tasks/Views/Components/TaskRow.swift
+++ b/ios/Cycle/Features/Tasks/Views/Components/TaskRow.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Pow
 
 /// タスク行のコンポーネント
 /// チェックボックス、タイトル、スワイプアクションを含む
@@ -56,6 +57,16 @@ struct TaskRow: View {
                         : DesignSystem.Colors.textTertiary
                 )
         }
+        .changeEffect(
+            .spray(origin: .center) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(DesignSystem.Colors.accent)
+                    .font(.system(size: 12))
+            },
+            value: task.isCompleted,
+            isEnabled: task.isCompleted
+        )
+        .changeEffect(.feedback(hapticNotification: .success), value: task.isCompleted, isEnabled: task.isCompleted)
     }
 
     private var taskTitle: some View {

--- a/ios/Cycle/Features/Tasks/Views/Components/TaskSectionTabs.swift
+++ b/ios/Cycle/Features/Tasks/Views/Components/TaskSectionTabs.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import Pow
 
 /// タスク入力セクション切り替えタブ
 /// 基本情報と詳細情報を切り替え
@@ -71,5 +72,7 @@ private struct SectionTabButton: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, DesignSystem.Spacing.md)
         }
+        .changeEffect(.jump(height: 4), value: isSelected, isEnabled: isSelected)
+        .changeEffect(.feedbackHapticSelection, value: isSelected, isEnabled: isSelected)
     }
 }

--- a/ios/Cycle/Shared/Components/ErrorBannerView.swift
+++ b/ios/Cycle/Shared/Components/ErrorBannerView.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import Pow
 
 struct ErrorBannerView: View {
     let message: String
@@ -45,6 +46,6 @@ struct ErrorBannerView: View {
         .background(DesignSystem.Colors.surface)
         .clipShape(RoundedRectangle(cornerRadius: DesignSystem.Spacing.md, style: .continuous))
         .padding(.horizontal, DesignSystem.Spacing.lg)
-        .transition(.move(edge: .top).combined(with: .opacity))
+        .transition(.movingParts.move(edge: .top).combined(with: .opacity))
     }
 }

--- a/ios/Cycle/Shared/Components/FloatingActionButton.swift
+++ b/ios/Cycle/Shared/Components/FloatingActionButton.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import Pow
 import UIKit
 
 /// フローティングアクションボタン（FAB）
@@ -16,22 +17,23 @@ struct FloatingActionButton: View {
     let icon: String
     let action: () -> Void
 
-    @State private var isPressed = false
+    @State private var tapCount = 0
 
     var body: some View {
         Button(action: {
-            let impactFeedback = UIImpactFeedbackGenerator(style: .medium)
-            impactFeedback.impactOccurred()
+            tapCount += 1
             action()
         }) {
             Image(systemName: icon)
                 .font(DesignSystem.Fonts.title2)
                 .foregroundStyle(fabForeground)
                 .frame(width: 56, height: 56)
-                .modifier(FABBackgroundStyle(isPressed: isPressed))
+                .modifier(FABBackgroundStyle())
                 .contentShape(Circle())
         }
         .buttonStyle(ScaleButtonStyle())
+        .changeEffect(.jump(height: 10), value: tapCount)
+        .changeEffect(.feedback(hapticImpact: .medium), value: tapCount)
         .accessibilityIdentifier("fab_\(icon)")
     }
 
@@ -54,8 +56,6 @@ struct FloatingActionButton: View {
 }
 
 private struct FABBackgroundStyle: ViewModifier {
-    let isPressed: Bool
-
     func body(content: Content) -> some View {
         if #available(iOS 26.0, *), FloatingActionButton.useLiquidGlass {
             content
@@ -65,20 +65,19 @@ private struct FABBackgroundStyle: ViewModifier {
                 .background(DesignSystem.Colors.accent)
                 .clipShape(Circle())
                 .shadow(
-                    color: Color.black.opacity(isPressed ? 0.1 : 0.2),
-                    radius: isPressed ? 4 : 8,
+                    color: Color.black.opacity(0.2),
+                    radius: 8,
                     x: 0,
-                    y: isPressed ? 2 : 4
+                    y: 4
                 )
         }
     }
 }
 
-/// ボタン押下時のスケールエフェクト
+/// ボタン押下時のPowプレスエフェクト
 private struct ScaleButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
-            .animation(DesignSystem.Timing.fastEasing, value: configuration.isPressed)
+            .conditionalEffect(.pushDown, condition: configuration.isPressed)
     }
 }

--- a/ios/Cycle/Shared/Components/NetworkStatusBanner.swift
+++ b/ios/Cycle/Shared/Components/NetworkStatusBanner.swift
@@ -4,6 +4,7 @@
 //
 
 import SwiftUI
+import Pow
 
 struct NetworkStatusBanner: View {
     @ObservedObject var networkMonitor = NetworkMonitor.shared
@@ -21,7 +22,7 @@ struct NetworkStatusBanner: View {
             .padding(.vertical, DesignSystem.Spacing.sm)
             .frame(maxWidth: .infinity)
             .background(DesignSystem.Colors.surface)
-            .transition(.move(edge: .top).combined(with: .opacity))
+            .transition(.movingParts.move(edge: .top).combined(with: .opacity))
         }
     }
 }

--- a/ios/Cycle/Shared/Components/PrimaryButton.swift
+++ b/ios/Cycle/Shared/Components/PrimaryButton.swift
@@ -8,6 +8,7 @@
 //
 
 import SwiftUI
+import Pow
 
 /// 全幅のプライマリボタン
 ///
@@ -21,6 +22,7 @@ struct PrimaryButton: View {
     var icon: String? = nil
     var color: Color = DesignSystem.Colors.accent
     let action: () -> Void
+    @State private var tapCount = 0
 
     init(_ title: String, icon: String? = nil, color: Color = DesignSystem.Colors.accent, action: @escaping () -> Void) {
         self.title = title
@@ -30,10 +32,15 @@ struct PrimaryButton: View {
     }
 
     var body: some View {
-        Button(action: action) {
+        Button {
+            tapCount += 1
+            action()
+        } label: {
             buttonContent
         }
         .modifier(PrimaryButtonStyle(color: color))
+        .changeEffect(.shine(angle: .degrees(24), duration: DesignSystem.Timing.slow), value: tapCount)
+        .changeEffect(.feedback(hapticImpact: .light), value: tapCount)
     }
 
     private var buttonContent: some View {
@@ -60,6 +67,7 @@ struct SecondaryButton: View {
     var icon: String? = nil
     var color: Color = DesignSystem.Colors.accent
     let action: () -> Void
+    @State private var tapCount = 0
 
     init(_ title: String, icon: String? = nil, color: Color = DesignSystem.Colors.accent, action: @escaping () -> Void) {
         self.title = title
@@ -69,10 +77,22 @@ struct SecondaryButton: View {
     }
 
     var body: some View {
-        Button(action: action) {
+        Button {
+            tapCount += 1
+            action()
+        } label: {
             buttonContent
         }
         .modifier(SecondaryButtonStyle(color: color))
+        .changeEffect(
+            .pulse(
+                shape: RoundedRectangle(cornerRadius: 12, style: .continuous),
+                style: color.opacity(0.24),
+                drawingMode: .stroke
+            ),
+            value: tapCount
+        )
+        .changeEffect(.feedbackHapticSelection, value: tapCount)
     }
 
     private var buttonContent: some View {

--- a/ios/Cycle/Shared/Components/TagChip.swift
+++ b/ios/Cycle/Shared/Components/TagChip.swift
@@ -6,20 +6,33 @@
 //
 
 import SwiftUI
+import Pow
 
 /// タグを表示するための小さなチップコンポーネント
 struct TagChip: View {
     let text: String
     var isInteractive: Bool = false
     var onTap: (() -> Void)? = nil
+    @State private var tapCount = 0
 
     var body: some View {
         Group {
             if isInteractive, let onTap = onTap {
-                Button(action: onTap) {
+                Button {
+                    tapCount += 1
+                    onTap()
+                } label: {
                     chipContent
                 }
                 .buttonStyle(.plain)
+                .changeEffect(
+                    .pulse(
+                        shape: Capsule(style: .continuous),
+                        style: DesignSystem.Colors.accent.opacity(0.18),
+                        drawingMode: .stroke
+                    ),
+                    value: tapCount
+                )
             } else {
                 chipContent
             }


### PR DESCRIPTION
## Summary
- Add Pow as a Swift Package dependency for the iOS app
- Apply Pow change effects to shared buttons, FAB, tag chips, banners, tab bar, task tabs, calendar dates, and task completion
- Replace direct haptic calls in updated components with Pow haptic change effects

## Verification
- `git diff --check`
- `plutil -lint ios/Cycle.xcodeproj/project.pbxproj`
- `jq . ios/Cycle.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`

Note: local `xcodebuild -resolvePackageDependencies` is blocked in this sandbox because SwiftPM tries to write diagnostics under `/Users/akito_ando/Library/Caches/org.swift.swiftpm/...`, which is outside writable roots. Package resolution for Pow 1.0.6 was separately checked with `swift package --disable-sandbox` in `/private/tmp`.