### PR TITLE
chore: split dev/prod infra and add API CD

### DIFF
--- a/.github/workflows/api-ci-cd.yml
+++ b/.github/workflows/api-ci-cd.yml
@@ -1,0 +1,123 @@
+name: API CI/CD
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - api/**
+      - .github/workflows/api-ci-cd.yml
+  push:
+    branches: [develop, main]
+    paths:
+      - api/**
+      - .github/workflows/api-ci-cd.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy target"
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: api-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  PROJECT_ID: cycle-journal
+  REGION: asia-northeast1
+  REPOSITORY: cycle-api
+
+jobs:
+  api-test:
+    name: API lint and test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Test
+        run: uv run pytest
+
+  deploy:
+    name: Deploy API
+    needs: api-test
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'main')) ||
+      github.event_name == 'workflow_dispatch'
+    environment: api-${{ github.event_name == 'workflow_dispatch' && inputs.environment || (github.ref_name == 'main' && 'prod' || 'dev') }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve target
+        id: target
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            target="${{ inputs.environment }}"
+          elif [[ "${{ github.ref_name }}" == "main" ]]; then
+            target="prod"
+          else
+            target="dev"
+          fi
+
+          echo "environment=${target}" >> "$GITHUB_OUTPUT"
+          echo "service=cycle-api-${target}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/api:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "track_tag=${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/api:${target}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+      - name: Build image
+        run: |
+          docker build \
+            --tag "${{ steps.target.outputs.image }}" \
+            --tag "${{ steps.target.outputs.track_tag }}" \
+            api
+
+      - name: Push image
+        run: |
+          docker push "${{ steps.target.outputs.image }}"
+          docker push "${{ steps.target.outputs.track_tag }}"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy "${{ steps.target.outputs.service }}" \
+            --image "${{ steps.target.outputs.image }}" \
+            --region "${REGION}" \
+            --project "${PROJECT_ID}" \
+            --quiet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Cycle Journal Repository Rules
+
+## Branch Flow
+
+- Default branch: `develop`
+- Feature work: `feature/*` -> pull request -> `develop`
+- Release promotion: `develop` -> pull request -> `main`
+- Hotfix only: `fix/*` -> pull request -> `main`, then merge `main` back into `develop`
+- Do not push directly to `main`. Use pull requests for production changes.
+
+## Deployments
+
+- Push to `develop` deploys the API to `cycle-api-dev`.
+- Push to `main` deploys the API to `cycle-api-prod`.
+- Production approval is controlled by the GitHub Environment named `api-prod`.
+
+## Infrastructure
+
+- Use `infra/environments/shared`, `infra/environments/dev`, and `infra/environments/prod`.
+- Do not use Terraform workspaces for environment switching.
+- Shared project-level resources live in `shared`; environment-specific Cloud Run,
+  Secret Manager, IAM, and Firestore resources live in `dev` or `prod`.

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     environment: str = "dev"
     gcp_project_id: str = "cycle-journal"
     gcp_region: str = "asia-northeast1"
+    firestore_database_id: str = "(default)"
     apple_bundle_id: str = "com.akitoando.CycleJournal"
     google_client_id: str = ""  # iOS用Google OAuth Client ID
 

--- a/api/app/models/auth.py
+++ b/api/app/models/auth.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 class VerifyTokenRequest(BaseModel):
     identity_token: str
-    # iOS から `ASAuthorizationAppleIDCredential.authorizationCode` を base64/utf8 で送る。
+    # iOS から Apple の authorizationCode を base64/utf8 で送る。
     # 受け取った場合はサーバ側で Apple refresh_token に交換し、アカウント削除時の
     # revoke 用に保存する。任意フィールド（無くてもサインインは成立する）。
     authorization_code: str | None = None

--- a/api/app/models/common.py
+++ b/api/app/models/common.py
@@ -1,12 +1,12 @@
 """Common Pydantic models for API responses."""
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel
 
 
-class CycleElement(str, Enum):
+class CycleElement(StrEnum):
     soil = "soil"
     water = "water"
     root = "root"

--- a/api/app/routers/auth.py
+++ b/api/app/routers/auth.py
@@ -52,8 +52,8 @@ async def verify_token(
     apple_user_id = claims.get("sub", "")
     email = claims.get("email")
 
-    # authorization_code があれば Apple refresh_token に交換してユーザードキュメントに保存する。
-    # アカウント削除時に Apple 側で revoke するために必要（App Store ガイドライン 5.1.1(v)）。
+    # authorization_code があれば Apple refresh_token に交換して保存する。
+    # アカウント削除時の revoke に必要（App Store ガイドライン 5.1.1(v)）。
     # 失敗しても識別トークン検証自体は成功しているのでサインインは続行する。
     apple_refresh_token: str | None = None
     if body.authorization_code:
@@ -141,7 +141,10 @@ async def refresh(
     if not body.refresh_token:
         raise ValidationError("refresh_token is required")
 
-    access_token, new_refresh, expires_in = await rotate_refresh_token(db, body.refresh_token)
+    access_token, new_refresh, expires_in = await rotate_refresh_token(
+        db,
+        body.refresh_token,
+    )
 
     return {
         "data": RefreshTokenData(

--- a/api/app/routers/coach.py
+++ b/api/app/routers/coach.py
@@ -43,17 +43,23 @@ async def chat(
     # セッションが未作成の場合は作成
     session_snap = await session_doc.get()
     if not session_snap.exists:
-        cycle_element = body.context.cycle_element.value if body.context and body.context.cycle_element else None
-        await session_doc.set({
-            "user_id": user_id,
-            "title": None,
-            "cycle_element": cycle_element,
-            "has_diary_context": body.diary_content is not None,
-            "message_count": 0,
-            "last_message_at": now,
-            "created_at": now,
-            "updated_at": now,
-        })
+        cycle_element = (
+            body.context.cycle_element.value
+            if body.context and body.context.cycle_element
+            else None
+        )
+        await session_doc.set(
+            {
+                "user_id": user_id,
+                "title": None,
+                "cycle_element": cycle_element,
+                "has_diary_context": body.diary_content is not None,
+                "message_count": 0,
+                "last_message_at": now,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
 
     # 過去のメッセージ履歴を取得
     messages_ref = session_doc.collection("messages")

--- a/api/app/services/firestore_client.py
+++ b/api/app/services/firestore_client.py
@@ -11,7 +11,10 @@ def get_db() -> AsyncClient:
     """Get or create Firestore async client."""
     global _db
     if _db is None:
-        _db = AsyncClient(project=settings.gcp_project_id)
+        _db = AsyncClient(
+            project=settings.gcp_project_id,
+            database=settings.firestore_database_id,
+        )
     return _db
 
 

--- a/api/app/services/token_service.py
+++ b/api/app/services/token_service.py
@@ -35,7 +35,11 @@ def create_access_token(user_id: str, provider: Provider) -> tuple[str, int]:
         "iat": int(now.timestamp()),
         "exp": int(exp.timestamp()),
     }
-    token = pyjwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    token = pyjwt.encode(
+        payload,
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
     return token, int(expires_delta.total_seconds())
 
 
@@ -133,7 +137,7 @@ async def revoke_all_refresh_tokens_for_user(db: AsyncClient, user_id: str) -> i
 async def rotate_refresh_token(
     db: AsyncClient, old_token: str
 ) -> tuple[str, str, int]:
-    """Verify old refresh, revoke it, issue a new pair. Returns (access, refresh, access_expires_in)."""
+    """Verify old refresh, revoke it, and issue a new token pair."""
     user_id, provider = await verify_refresh_token(db, old_token)
     await revoke_refresh_token(db, old_token)
     access_token, expires_in = create_access_token(user_id, provider)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -34,7 +34,7 @@ def _make_mock_firestore():
 
     async def empty_stream():
         return
-        yield  # noqa: unreachable - makes this an async generator
+        yield
 
     mock_sub_query = MagicMock()
     mock_sub_query.stream.return_value = empty_stream()
@@ -67,7 +67,11 @@ def mock_auth():
     with patch(
         "app.middleware.auth_middleware.verify_access_token",
     ) as mock:
-        mock.return_value = {"sub": "test-user-123", "provider": "apple", "type": "access"}
+        mock.return_value = {
+            "sub": "test-user-123",
+            "provider": "apple",
+            "type": "access",
+        }
         yield mock
 
 

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -32,3 +32,16 @@ def test_claude_model_quick_overridable_via_env():
     with patch.dict(os.environ, {"CLAUDE_MODEL_QUICK": "claude-haiku-test@99999999"}):
         settings = Settings()
         assert settings.claude_model_quick == "claude-haiku-test@99999999"
+
+
+def test_firestore_database_id_defaults_to_default_database():
+    """Firestore DB は既存本番データ互換のため (default) を既定にする."""
+    settings = Settings()
+    assert settings.firestore_database_id == "(default)"
+
+
+def test_firestore_database_id_overridable_via_env():
+    """dev/prod Cloud Run から FIRESTORE_DATABASE_ID で DB を分離できる."""
+    with patch.dict(os.environ, {"FIRESTORE_DATABASE_ID": "dev"}):
+        settings = Settings()
+        assert settings.firestore_database_id == "dev"

--- a/api/tests/test_firestore_client.py
+++ b/api/tests/test_firestore_client.py
@@ -1,0 +1,29 @@
+"""Firestore client tests."""
+
+from unittest.mock import patch
+
+from app.services import firestore_client
+
+
+def test_get_db_uses_configured_database_id():
+    """Firestore AsyncClient に database_id を渡して環境ごとの DB を使う."""
+    firestore_client._db = None
+    try:
+        with (
+            patch.object(
+                firestore_client.settings,
+                "gcp_project_id",
+                "cycle-journal-test",
+            ),
+            patch.object(firestore_client.settings, "firestore_database_id", "dev"),
+            patch.object(firestore_client, "AsyncClient") as async_client,
+        ):
+            db = firestore_client.get_db()
+
+        assert db == async_client.return_value
+        async_client.assert_called_once_with(
+            project="cycle-journal-test",
+            database="dev",
+        )
+    finally:
+        firestore_client._db = None

--- a/api/tests/test_token_service.py
+++ b/api/tests/test_token_service.py
@@ -34,7 +34,11 @@ def test_access_token_rejects_non_access_type():
         "iss": settings.jwt_issuer,
         "exp": 9999999999,
     }
-    token = pyjwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    token = pyjwt.encode(
+        payload,
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
     with pytest.raises(InvalidTokenError):
         token_service.verify_access_token(token)
 
@@ -51,7 +55,11 @@ def test_access_token_expiry(monkeypatch):
         "iss": settings.jwt_issuer,
         "exp": 1,
     }
-    token = pyjwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    token = pyjwt.encode(
+        payload,
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
     with pytest.raises(TokenExpiredError):
         token_service.verify_access_token(token)
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,6 +45,7 @@ export default defineConfig({
         items: [
           { text: 'Getting Started', link: '/guides/getting-started' },
           { text: '開発規約', link: '/guides/conventions' },
+          { text: 'ブランチ・デプロイ運用', link: '/guides/branching-and-deployment' },
           { text: 'App Storeリリース', link: '/guides/app-store-release' },
           {
             text: '#37 デプロイメントセットアップ',

--- a/docs/guides/branching-and-deployment.md
+++ b/docs/guides/branching-and-deployment.md
@@ -1,0 +1,58 @@
+# Branching and Deployment
+
+## Branch Strategy
+
+Cycle Journal uses a GitLab Flow style environment branch model.
+
+| Flow | Target |
+| --- | --- |
+| `feature/*` -> PR -> `develop` | Integration and dev deploy |
+| `develop` -> PR -> `main` | Production release |
+| `fix/*` -> PR -> `main` -> merge back to `develop` | Production hotfix |
+
+`develop` is the default branch. `main` is production and must receive changes
+only through pull requests.
+
+## Environments
+
+| Environment | Branch | Cloud Run | Firestore |
+| --- | --- | --- | --- |
+| dev | `develop` | `cycle-api-dev` | `dev` |
+| prod | `main` | `cycle-api-prod` | `(default)` |
+
+The GCP project remains `cycle-journal`. Project-level IAM, billing, quotas, and
+Artifact Registry are shared.
+
+## CI/CD
+
+`.github/workflows/api-ci-cd.yml` runs API lint and tests on pull requests to
+`develop` or `main`.
+
+On push:
+
+- `develop` builds and deploys the API image to `cycle-api-dev`.
+- `main` builds and deploys the API image to `cycle-api-prod`.
+
+The workflow expects these GitHub secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Federation provider |
+| `GCP_SERVICE_ACCOUNT` | Deploy service account email |
+
+Use GitHub Environments:
+
+- `api-dev`: no approval gate
+- `api-prod`: require reviewer approval before production deploy
+
+## Terraform
+
+Use directory-per-environment Terraform:
+
+```bash
+terraform -chdir=infra/environments/shared plan
+terraform -chdir=infra/environments/dev plan
+terraform -chdir=infra/environments/prod plan
+```
+
+Do not switch environments with Terraform workspaces.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,81 @@
+# Cycle Journal Infrastructure
+
+Terraform is split by directory and state:
+
+| Directory | State prefix | Owns |
+| --- | --- | --- |
+| `environments/shared` | `terraform/state/shared` | Project APIs, Artifact Registry |
+| `environments/dev` | `terraform/state/dev` | `cycle-api-dev`, Firestore `dev`, dev secrets/IAM |
+| `environments/prod` | `terraform/state/prod` | `cycle-api-prod`, Firestore `(default)`, prod secrets/IAM |
+
+The legacy root Terraform files are retained only as the source for the first
+state migration. Do not run regular plans from `infra/`; use one of the
+`infra/environments/*` directories instead.
+
+## Commands
+
+```bash
+terraform -chdir=infra/environments/shared init
+terraform -chdir=infra/environments/shared plan
+
+terraform -chdir=infra/environments/dev init
+terraform -chdir=infra/environments/dev plan
+
+terraform -chdir=infra/environments/prod init
+terraform -chdir=infra/environments/prod plan
+```
+
+## State Migration Outline
+
+Do the migration before removing the legacy root state from operation.
+
+1. Back up the current state:
+
+   ```bash
+   terraform -chdir=infra workspace select prod
+   terraform -chdir=infra state pull > infra-state-prod-backup.json
+   ```
+
+2. Move shared resources into `environments/shared` state:
+
+   ```bash
+   terraform -chdir=infra/environments/shared init
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_artifact_registry_repository.api' \
+     'projects/cycle-journal/locations/asia-northeast1/repositories/cycle-api'
+
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["run.googleapis.com"]' \
+     'cycle-journal/run.googleapis.com'
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["firestore.googleapis.com"]' \
+     'cycle-journal/firestore.googleapis.com'
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["artifactregistry.googleapis.com"]' \
+     'cycle-journal/artifactregistry.googleapis.com'
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["secretmanager.googleapis.com"]' \
+     'cycle-journal/secretmanager.googleapis.com'
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["aiplatform.googleapis.com"]' \
+     'cycle-journal/aiplatform.googleapis.com'
+   ```
+
+3. Move existing production resources into `environments/prod` state with
+   `terraform import` or `terraform state mv -state-out`. Keep Firestore
+   `(default)` in prod; do not create a new prod database.
+
+4. Create the dev environment from the new directory:
+
+   ```bash
+   terraform -chdir=infra/environments/dev init
+   terraform -chdir=infra/environments/dev plan
+   terraform -chdir=infra/environments/dev apply
+   ```
+
+5. Confirm both environment plans show no unintended destroy:
+
+   ```bash
+   terraform -chdir=infra/environments/prod plan
+   terraform -chdir=infra/environments/dev plan
+   ```

--- a/infra/environments/dev/.terraform.lock.hcl
+++ b/infra/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.5"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -1,0 +1,18 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "api" {
+  source = "../../modules/api"
+
+  project_id            = var.project_id
+  region                = var.region
+  environment           = "dev"
+  firestore_database_id = "dev"
+  apple_team_id         = var.apple_team_id
+  apple_key_id          = var.apple_key_id
+  apple_iap_issuer_id   = var.apple_iap_issuer_id
+  apple_iap_key_id      = var.apple_iap_key_id
+  apple_iap_env         = "Sandbox"
+}

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -1,0 +1,14 @@
+output "cloud_run_url" {
+  description = "Cloud Run service URL"
+  value       = module.api.cloud_run_url
+}
+
+output "service_account_email" {
+  description = "Cloud Run service account email"
+  value       = module.api.service_account_email
+}
+
+output "firestore_database_id" {
+  description = "Firestore database ID"
+  value       = module.api.firestore_database_id
+}

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -1,0 +1,8 @@
+project_id    = "cycle-journal"
+region        = "asia-northeast1"
+apple_team_id = "AXSR25N22T"
+apple_key_id  = "TXTX42VXG4"
+
+# IAP 専用キー (Sign in with Apple とは別物)
+apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
+apple_iap_key_id    = "7W562GZ399"

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -1,0 +1,30 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "apple_team_id" {
+  description = "Apple Developer Team ID"
+  type        = string
+}
+
+variable "apple_key_id" {
+  description = "Apple Sign in with Apple Key ID"
+  type        = string
+}
+
+variable "apple_iap_issuer_id" {
+  description = "App Store Connect IAP Key Issuer ID"
+  type        = string
+}
+
+variable "apple_iap_key_id" {
+  description = "App Store Connect IAP Key ID"
+  type        = string
+}

--- a/infra/environments/dev/versions.tf
+++ b/infra/environments/dev/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "cycle-journal-tfstate"
+    prefix = "terraform/state/dev"
+  }
+}

--- a/infra/environments/prod/.terraform.lock.hcl
+++ b/infra/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.5"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -1,0 +1,18 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "api" {
+  source = "../../modules/api"
+
+  project_id            = var.project_id
+  region                = var.region
+  environment           = "prod"
+  firestore_database_id = "(default)"
+  apple_team_id         = var.apple_team_id
+  apple_key_id          = var.apple_key_id
+  apple_iap_issuer_id   = var.apple_iap_issuer_id
+  apple_iap_key_id      = var.apple_iap_key_id
+  apple_iap_env         = "Sandbox" # テスト完了後 "Production" に変更
+}

--- a/infra/environments/prod/outputs.tf
+++ b/infra/environments/prod/outputs.tf
@@ -1,0 +1,14 @@
+output "cloud_run_url" {
+  description = "Cloud Run service URL"
+  value       = module.api.cloud_run_url
+}
+
+output "service_account_email" {
+  description = "Cloud Run service account email"
+  value       = module.api.service_account_email
+}
+
+output "firestore_database_id" {
+  description = "Firestore database ID"
+  value       = module.api.firestore_database_id
+}

--- a/infra/environments/prod/terraform.tfvars
+++ b/infra/environments/prod/terraform.tfvars
@@ -1,0 +1,8 @@
+project_id    = "cycle-journal"
+region        = "asia-northeast1"
+apple_team_id = "AXSR25N22T"
+apple_key_id  = "TXTX42VXG4"
+
+# IAP 専用キー (Sign in with Apple とは別物。issuer/key id は環境共通)
+apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
+apple_iap_key_id    = "7W562GZ399"

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -1,0 +1,30 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "apple_team_id" {
+  description = "Apple Developer Team ID"
+  type        = string
+}
+
+variable "apple_key_id" {
+  description = "Apple Sign in with Apple Key ID"
+  type        = string
+}
+
+variable "apple_iap_issuer_id" {
+  description = "App Store Connect IAP Key Issuer ID"
+  type        = string
+}
+
+variable "apple_iap_key_id" {
+  description = "App Store Connect IAP Key ID"
+  type        = string
+}

--- a/infra/environments/prod/versions.tf
+++ b/infra/environments/prod/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "cycle-journal-tfstate"
+    prefix = "terraform/state/prod"
+  }
+}

--- a/infra/environments/shared/.terraform.lock.hcl
+++ b/infra/environments/shared/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -1,0 +1,11 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "shared" {
+  source = "../../modules/shared"
+
+  project_id = var.project_id
+  region     = var.region
+}

--- a/infra/environments/shared/outputs.tf
+++ b/infra/environments/shared/outputs.tf
@@ -1,0 +1,4 @@
+output "artifact_registry_repo" {
+  description = "Artifact Registry repository path"
+  value       = module.shared.artifact_registry_repo
+}

--- a/infra/environments/shared/terraform.tfvars
+++ b/infra/environments/shared/terraform.tfvars
@@ -1,0 +1,2 @@
+project_id = "cycle-journal"
+region     = "asia-northeast1"

--- a/infra/environments/shared/variables.tf
+++ b/infra/environments/shared/variables.tf
@@ -1,0 +1,10 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}

--- a/infra/environments/shared/versions.tf
+++ b/infra/environments/shared/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "cycle-journal-tfstate"
+    prefix = "terraform/state/shared"
+  }
+}

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -1,0 +1,250 @@
+locals {
+  api_image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.artifact_registry_repository_id}/api:${var.image_tag}"
+}
+
+resource "google_service_account" "cloud_run" {
+  account_id   = "cycle-api-${var.environment}"
+  display_name = "CycleJournal API (${var.environment})"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "firestore" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_project_iam_member" "secret_manager" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_project_iam_member" "vertex_ai" {
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_secret_manager_secret" "apple_auth" {
+  secret_id = "apple-auth-config-${var.environment}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "apple_iap_private_key" {
+  secret_id = "apple-iap-private-key-${var.environment}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "jwt_secret" {
+  secret_id = "jwt-secret-${var.environment}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "random_password" "jwt_secret" {
+  length  = 64
+  special = false
+}
+
+resource "google_secret_manager_secret_version" "jwt_secret" {
+  secret      = google_secret_manager_secret.jwt_secret.id
+  secret_data = random_password.jwt_secret.result
+}
+
+resource "google_firestore_database" "main" {
+  project     = var.project_id
+  name        = var.firestore_database_id
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+
+  deletion_policy = var.firestore_deletion_policy
+}
+
+resource "google_firestore_index" "sessions_by_created_at" {
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "sessions"
+
+  fields {
+    field_path = "user_id"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+resource "google_firestore_index" "tasks_by_status" {
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "tasks"
+
+  fields {
+    field_path = "user_id"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "status"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+resource "google_cloud_run_v2_service" "api" {
+  name     = "cycle-api-${var.environment}"
+  location = var.region
+
+  template {
+    service_account = google_service_account.cloud_run.email
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 2
+    }
+
+    containers {
+      image = local.api_image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      env {
+        name  = "ENVIRONMENT"
+        value = var.environment
+      }
+
+      env {
+        name  = "GCP_PROJECT_ID"
+        value = var.project_id
+      }
+
+      env {
+        name  = "GCP_REGION"
+        value = var.region
+      }
+
+      env {
+        name  = "FIRESTORE_DATABASE_ID"
+        value = var.firestore_database_id
+      }
+
+      env {
+        name  = "APPLE_BUNDLE_ID"
+        value = var.apple_bundle_id
+      }
+
+      env {
+        name  = "APPLE_TEAM_ID"
+        value = var.apple_team_id
+      }
+
+      env {
+        name  = "APPLE_KEY_ID"
+        value = var.apple_key_id
+      }
+
+      env {
+        name = "APPLE_PRIVATE_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.apple_auth.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "APPLE_IAP_ISSUER_ID"
+        value = var.apple_iap_issuer_id
+      }
+
+      env {
+        name  = "APPLE_IAP_KEY_ID"
+        value = var.apple_iap_key_id
+      }
+
+      env {
+        name = "APPLE_IAP_PRIVATE_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.apple_iap_private_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "APPLE_IAP_ENV"
+        value = var.apple_iap_env
+      }
+
+      env {
+        name  = "USE_LANGGRAPH"
+        value = var.use_langgraph ? "true" : "false"
+      }
+
+      env {
+        name  = "GOOGLE_CLIENT_ID"
+        value = var.google_client_id
+      }
+
+      env {
+        name = "JWT_SECRET_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.jwt_secret.secret_id
+            version = "latest"
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+    ]
+  }
+
+  depends_on = [
+    google_firestore_database.main,
+    google_secret_manager_secret_version.jwt_secret,
+    google_secret_manager_secret.apple_auth,
+    google_secret_manager_secret.apple_iap_private_key,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.api.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/infra/modules/api/outputs.tf
+++ b/infra/modules/api/outputs.tf
@@ -1,0 +1,14 @@
+output "cloud_run_url" {
+  description = "Cloud Run service URL"
+  value       = google_cloud_run_v2_service.api.uri
+}
+
+output "service_account_email" {
+  description = "Cloud Run service account email"
+  value       = google_service_account.cloud_run.email
+}
+
+output "firestore_database_id" {
+  description = "Firestore database ID used by this environment"
+  value       = google_firestore_database.main.name
+}

--- a/infra/modules/api/variables.tf
+++ b/infra/modules/api/variables.tf
@@ -1,0 +1,97 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "environment" {
+  description = "Environment name (dev / prod)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "prod"], var.environment)
+    error_message = "environment must be dev or prod."
+  }
+}
+
+variable "firestore_database_id" {
+  description = "Firestore database ID used by the API"
+  type        = string
+}
+
+variable "firestore_deletion_policy" {
+  description = "Deletion behavior for Firestore databases when Terraform destroys the resource"
+  type        = string
+  default     = "ABANDON"
+
+  validation {
+    condition     = contains(["ABANDON", "DELETE"], var.firestore_deletion_policy)
+    error_message = "firestore_deletion_policy must be ABANDON or DELETE."
+  }
+}
+
+variable "artifact_registry_repository_id" {
+  description = "Artifact Registry repository ID for API Docker images"
+  type        = string
+  default     = "cycle-api"
+}
+
+variable "image_tag" {
+  description = "Initial Docker image tag. CD owns later image updates."
+  type        = string
+  default     = "latest"
+}
+
+variable "use_langgraph" {
+  description = "Enable LangGraph coaching flow"
+  type        = bool
+  default     = false
+}
+
+variable "google_client_id" {
+  description = "Google OAuth Client ID for iOS Sign-In"
+  type        = string
+  default     = "1031235624127-6fgcbv1khltu4snpktpdd0cab025coab.apps.googleusercontent.com"
+}
+
+variable "apple_bundle_id" {
+  description = "Apple app bundle ID"
+  type        = string
+  default     = "com.akitoando.CycleJournal"
+}
+
+variable "apple_team_id" {
+  description = "Apple Developer Team ID"
+  type        = string
+}
+
+variable "apple_key_id" {
+  description = "Apple Sign in with Apple Key ID"
+  type        = string
+}
+
+variable "apple_iap_issuer_id" {
+  description = "App Store Connect IAP Key Issuer ID"
+  type        = string
+}
+
+variable "apple_iap_key_id" {
+  description = "App Store Connect IAP Key ID"
+  type        = string
+}
+
+variable "apple_iap_env" {
+  description = "IAP verification Apple environment: Sandbox or Production"
+  type        = string
+  default     = "Sandbox"
+
+  validation {
+    condition     = contains(["Sandbox", "Production"], var.apple_iap_env)
+    error_message = "apple_iap_env must be Sandbox or Production."
+  }
+}

--- a/infra/modules/shared/main.tf
+++ b/infra/modules/shared/main.tf
@@ -1,0 +1,26 @@
+locals {
+  project_services = toset([
+    "run.googleapis.com",
+    "firestore.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "secretmanager.googleapis.com",
+    "aiplatform.googleapis.com",
+  ])
+}
+
+resource "google_project_service" "apis" {
+  for_each = local.project_services
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_artifact_registry_repository" "api" {
+  location      = var.region
+  repository_id = var.artifact_registry_repository_id
+  format        = "DOCKER"
+  description   = "CycleJournal API Docker images"
+
+  depends_on = [google_project_service.apis]
+}

--- a/infra/modules/shared/outputs.tf
+++ b/infra/modules/shared/outputs.tf
@@ -1,0 +1,9 @@
+output "artifact_registry_repository_id" {
+  description = "Artifact Registry repository ID"
+  value       = google_artifact_registry_repository.api.repository_id
+}
+
+output "artifact_registry_repo" {
+  description = "Artifact Registry repository path"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.api.repository_id}"
+}

--- a/infra/modules/shared/variables.tf
+++ b/infra/modules/shared/variables.tf
@@ -1,0 +1,16 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "artifact_registry_repository_id" {
+  description = "Artifact Registry repository ID for API Docker images"
+  type        = string
+  default     = "cycle-api"
+}


### PR DESCRIPTION
## Summary
- add `FIRESTORE_DATABASE_ID` config and pass it to Firestore `AsyncClient`
- add directory-per-environment Terraform for shared/dev/prod and document state migration
- add API CI/CD workflow for `develop` -> dev and `main` -> prod
- document branch/deploy rules in `CLAUDE.md` and docs
- clean up existing Ruff violations so the new API CI starts green

## Verification
- `UV_CACHE_DIR=/private/tmp/cyclejournal-uv-cache uv run --extra dev ruff check .`
- `UV_CACHE_DIR=/private/tmp/cyclejournal-uv-cache uv run --extra dev pytest`
- `terraform -chdir=infra/environments/shared init -backend=false && terraform -chdir=infra/environments/shared validate`
- `terraform -chdir=infra/environments/dev init -backend=false && terraform -chdir=infra/environments/dev validate`
- `terraform -chdir=infra/environments/prod init -backend=false && terraform -chdir=infra/environments/prod validate`
- `terraform fmt -check -recursive infra`
- workflow YAML parse via Ruby

Refs #58
