### PR TITLE
feat: #37 IAP verify エンドポイントと ASSN state machine (B1+B2)

### DIFF
--- a/api/app/routers/iap.py
+++ b/api/app/routers/iap.py
@@ -9,10 +9,16 @@ Notification 処理ポリシー:
 - 検証失敗 (JWS) は 400 を返し Apple のリトライ対象から外す。
 - 状態反映 (users/{uid}/subscription) はバックグラウンドタスクで実行し、
   Apple への ACK は即時 200 を返す (3〜5 秒以内の応答要件を満たすため)。
+
+ユーザー特定:
+- iOS は購入後 jwsRepresentation を POST /iap/apple/verify に送る。verify は
+  認証済みなので uid が分かり、originalTransactionId → uid を iap_links に記録する。
+- webhook は originalTransactionId から iap_links を引いて uid を解決する。
 """
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from appstoreserverlibrary.signed_data_verifier import (
@@ -22,11 +28,43 @@ from appstoreserverlibrary.signed_data_verifier import (
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from google.api_core.exceptions import AlreadyExists
 from google.cloud.firestore import SERVER_TIMESTAMP, AsyncClient
+from pydantic import BaseModel, Field
 
-from app.dependencies import get_firestore
+from app.dependencies import get_current_user, get_firestore
+from app.services.iap_subscription import build_subscription_record
 from app.services.iap_verifier import get_verifier
 
 router = APIRouter(prefix="/iap", tags=["iap"])
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+async def _write_subscription_record(
+    db: AsyncClient,
+    uid: str,
+    record: dict[str, Any],
+) -> None:
+    """users/{uid}/subscription/{originalTransactionId} を upsert する."""
+    original_tx_id = record["original_transaction_id"]
+    doc = (
+        db.collection("users")
+        .document(uid)
+        .collection("subscription")
+        .document(original_tx_id)
+    )
+    await doc.set({**record, "updated_at": SERVER_TIMESTAMP}, merge=True)
+
+
+async def _resolve_uid(db: AsyncClient, original_tx_id: str | None) -> str | None:
+    """originalTransactionId から uid を解決する (verify が記録した iap_links 経由)."""
+    if not original_tx_id:
+        return None
+    snap = await db.collection("iap_links").document(original_tx_id).get()
+    if snap.exists:
+        return (snap.to_dict() or {}).get("uid")
+    return None
 
 
 @router.post("/apple/notifications", status_code=200)
@@ -62,17 +100,86 @@ async def apple_notifications(
     except AlreadyExists:
         return {"status": "duplicate", "notificationUUID": notification_uuid}
 
-    # TODO(#37): バックグラウンドで users/{uid}/subscription を更新する
-    # (signedTransactionInfo / signedRenewalInfo をデコードして state machine 反映)
-    background_tasks.add_task(_noop_apply_notification, payload)
+    background_tasks.add_task(_apply_notification, db, verifier, payload)
 
     return {"status": "accepted", "notificationUUID": notification_uuid}
 
 
-async def _noop_apply_notification(payload: Any) -> None:
-    """状態反映ロジックの placeholder.
+async def _apply_notification(
+    db: AsyncClient,
+    verifier: SignedDataVerifier,
+    payload: Any,
+) -> None:
+    """signedTransactionInfo をデコードして users/{uid}/subscription に状態反映する.
 
-    後続 PR で signedTransactionInfo / signedRenewalInfo をデコードし
-    users/{uid}/subscription を更新する処理に差し替える。
+    - TEST 通知やトランザクションを伴わない通知は何もしない。
+    - uid が未解決 (verify 未実行) の場合はスキップ。次回の verify で整合する。
+    - バックグラウンド実行のため例外は握り潰す (Apple への ACK は既に返済み)。
     """
-    return None
+    try:
+        data = getattr(payload, "data", None)
+        signed_tx = getattr(data, "signedTransactionInfo", None) if data else None
+        if not signed_tx:
+            return
+
+        txn = verifier.verify_and_decode_signed_transaction(signed_tx)
+        uid = await _resolve_uid(db, txn.originalTransactionId)
+        if uid is None:
+            return
+
+        record = build_subscription_record(
+            txn,
+            now_ms=_now_ms(),
+            notification_type=payload.notificationType,
+            subtype=payload.subtype,
+        )
+        await _write_subscription_record(db, uid, record)
+    except Exception:  # noqa: BLE001 - background task, never raise to caller
+        return
+
+
+class VerifyRequest(BaseModel):
+    """StoreKit2 の Transaction.jwsRepresentation を渡す."""
+
+    jws_representation: str = Field(alias="jwsRepresentation")
+
+    model_config = {"populate_by_name": True}
+
+
+@router.post("/apple/verify", status_code=200)
+async def apple_verify(
+    req: VerifyRequest,
+    uid: str = Depends(get_current_user),
+    verifier: SignedDataVerifier = Depends(get_verifier),
+    db: AsyncClient = Depends(get_firestore),
+) -> dict[str, Any]:
+    """クライアント (StoreKit2) からの JWS 即時検証.
+
+    - jwsRepresentation を検証・デコード。
+    - originalTransactionId → uid を iap_links に記録 (webhook がこれで uid 解決)。
+    - users/{uid}/subscription にエンタイトルメントを反映し、状態を返す。
+    """
+    try:
+        txn = verifier.verify_and_decode_signed_transaction(req.jws_representation)
+    except VerificationException as exc:
+        raise HTTPException(status_code=400, detail=f"invalid signature: {exc}") from exc  # noqa: E501
+
+    original_tx_id = txn.originalTransactionId
+    if not original_tx_id:
+        raise HTTPException(status_code=400, detail="missing originalTransactionId")
+
+    await db.collection("iap_links").document(original_tx_id).set(
+        {"uid": uid, "updated_at": SERVER_TIMESTAMP},
+        merge=True,
+    )
+
+    record = build_subscription_record(txn, now_ms=_now_ms())
+    await _write_subscription_record(db, uid, record)
+
+    return {
+        "status": "verified",
+        "isActive": record["is_active"],
+        "subscriptionStatus": record["status"],
+        "productId": record["product_id"],
+        "expiresDateMs": record["expires_date_ms"],
+    }

--- a/api/app/services/iap_subscription.py
+++ b/api/app/services/iap_subscription.py
@@ -1,0 +1,121 @@
+"""IAP サブスクリプション状態の組み立て (B1 verify / B2 ASSN webhook 共通).
+
+App Store の `JWSTransactionDecodedPayload` と ASSN の通知種別から、Firestore の
+`users/{uid}/subscription/{originalTransactionId}` に保存する状態レコードを構築する
+純関数を提供する。Firestore I/O は呼び出し側 (router) が担い、本モジュールは
+ライブラリ型と通知種別のみに依存させてユニットテスト可能にする。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_enum(value: Any) -> str | None:
+    """ライブラリの Enum (例 NotificationTypeV2.SUBSCRIBED) でも、テストで渡される
+    生文字列でも、一貫して "SUBSCRIBED" のような素の名前に正規化する。"""
+    if value is None:
+        return None
+    # str Enum は .value を持つ
+    inner = getattr(value, "value", None)
+    if isinstance(inner, str):
+        return inner
+    return str(value)
+
+
+def resolve_is_active(
+    *,
+    expires_date_ms: int | None,
+    revocation_date_ms: int | None,
+    now_ms: int,
+) -> bool:
+    """エンタイトルメントが有効かを判定する (権威的なシグナル).
+
+    返金/失効 (revocationDate あり) は無効。期限なし (買い切り等) は有効。
+    それ以外は expiresDate が現在時刻より未来なら有効。
+    """
+    if revocation_date_ms is not None:
+        return False
+    if expires_date_ms is None:
+        return True
+    return expires_date_ms > now_ms
+
+
+def resolve_status(
+    *,
+    is_active: bool,
+    notification_type: str | None,
+    subtype: str | None,
+    revocation_date_ms: int | None,
+    offer_type: Any | None,
+) -> str:
+    """ユーザー向けのサブスク状態ラベルを導出する.
+
+    isActive (権威判定) を補完する人間可読ステータス。
+    """
+    nt = normalize_enum(notification_type)
+    st = normalize_enum(subtype)
+
+    if revocation_date_ms is not None or nt in {"REFUND", "REVOKE"}:
+        return "revoked"
+    if not is_active:
+        return "expired"
+    if nt == "DID_FAIL_TO_RENEW":
+        # GRACE_PERIOD 中はアクセス維持、それ以外は請求リトライ
+        return "grace_period" if st == "GRACE_PERIOD" else "billing_retry"
+    if nt == "DID_CHANGE_RENEWAL_STATUS" and st == "AUTO_RENEW_DISABLED":
+        # 解約予約済みだが期限までは有効
+        return "cancelled"
+    # offerType=1 (INTRODUCTORY) は本アプリでは 7 日無料トライアルのみ
+    if normalize_enum(offer_type) in {"1", "INTRODUCTORY", "OfferType.INTRODUCTORY"}:
+        return "trial"
+    return "active"
+
+
+def build_subscription_record(
+    txn: Any,
+    *,
+    now_ms: int,
+    notification_type: Any | None = None,
+    subtype: Any | None = None,
+) -> dict[str, Any]:
+    """検証済みトランザクションから subscription レコード (dict) を構築する.
+
+    `updated_at` などの Firestore センチネルは含めない (呼び出し側で付与)。
+    """
+    expires = txn.expiresDate
+    revocation = txn.revocationDate
+    is_active = resolve_is_active(
+        expires_date_ms=expires,
+        revocation_date_ms=revocation,
+        now_ms=now_ms,
+    )
+    status = resolve_status(
+        is_active=is_active,
+        notification_type=notification_type,
+        subtype=subtype,
+        revocation_date_ms=revocation,
+        offer_type=getattr(txn, "offerType", None),
+    )
+
+    auto_renew: bool | None = None
+    st = normalize_enum(subtype)
+    if st == "AUTO_RENEW_DISABLED":
+        auto_renew = False
+    elif st == "AUTO_RENEW_ENABLED":
+        auto_renew = True
+
+    return {
+        "product_id": txn.productId,
+        "original_transaction_id": txn.originalTransactionId,
+        "transaction_id": txn.transactionId,
+        "is_active": is_active,
+        "status": status,
+        "expires_date_ms": expires,
+        "purchase_date_ms": txn.purchaseDate,
+        "revocation_date_ms": revocation,
+        "environment": normalize_enum(getattr(txn, "environment", None)),
+        "auto_renew": auto_renew,
+        "last_notification_type": normalize_enum(notification_type),
+        "last_subtype": st,
+    }

--- a/api/tests/test_iap_router.py
+++ b/api/tests/test_iap_router.py
@@ -7,6 +7,7 @@ library 本体 (SignedDataVerifier) はモック化、Firestore も既存 confte
 の mock を流用する。
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -112,3 +113,116 @@ def test_apple_notifications_is_idempotent(iap_client, mock_firestore):
     assert response.status_code == 200
     body = response.json()
     assert body.get("status") == "duplicate"
+
+
+# ---------------------------------------------------------------------------
+# B1: POST /iap/apple/verify
+# ---------------------------------------------------------------------------
+
+# endpoint は実時刻 (time.time()) を使うため、実 now より十分未来の固定値を使う
+NOW_MS = 1_700_000_000_000
+FUTURE_MS = 4_102_444_800_000  # 2100-01-01 頃
+
+
+def _make_txn(
+    original_tx_id: str | None = "2000000000000001",
+    expires: int | None = FUTURE_MS,
+    revocation: int | None = None,
+):
+    """JWSTransactionDecodedPayload 風のモック."""
+    return SimpleNamespace(
+        productId="com.akitoando.CycleJournal.yearly_14400",
+        originalTransactionId=original_tx_id,
+        transactionId="2000000000000002",
+        expiresDate=expires,
+        purchaseDate=NOW_MS - 1000,
+        revocationDate=revocation,
+        environment="Sandbox",
+        offerType=None,
+    )
+
+
+@pytest.fixture
+def iap_auth_client(mock_firestore):
+    """get_current_user も差し替えた認証済みクライアント."""
+    from app.dependencies import get_current_user, get_firestore
+    from app.main import app
+    from app.services.iap_verifier import get_verifier
+
+    verifier = MagicMock()
+    app.dependency_overrides[get_firestore] = lambda: mock_firestore
+    app.dependency_overrides[get_verifier] = lambda: verifier
+    app.dependency_overrides[get_current_user] = lambda: "user-abc"
+    yield TestClient(app), verifier, mock_firestore
+    app.dependency_overrides.clear()
+
+
+def test_verify_records_link_and_subscription(iap_auth_client):
+    """B1: 正常な jws で 200・iap_links と users/{uid}/subscription を書き込む."""
+    client, verifier, mock_firestore = iap_auth_client
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+
+    response = client.post(
+        "/iap/apple/verify",
+        json={"jwsRepresentation": "valid-jws"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "verified"
+    assert body["isActive"] is True
+    assert body["subscriptionStatus"] == "active"
+    mock_firestore.collection.assert_any_call("iap_links")
+    mock_firestore.collection.assert_any_call("users")
+
+
+def test_verify_rejects_invalid_signature(iap_auth_client):
+    """B1: JWS 検証失敗は 400."""
+    from appstoreserverlibrary.signed_data_verifier import (
+        VerificationException,
+        VerificationStatus,
+    )
+
+    client, verifier, _ = iap_auth_client
+    verifier.verify_and_decode_signed_transaction.side_effect = VerificationException(
+        VerificationStatus.INVALID_CERTIFICATE
+    )
+
+    response = client.post(
+        "/iap/apple/verify",
+        json={"jwsRepresentation": "bad-jws"},
+    )
+    assert response.status_code == 400
+
+
+def test_verify_rejects_missing_original_transaction_id(iap_auth_client):
+    """B1: originalTransactionId が無い場合は 400."""
+    client, verifier, _ = iap_auth_client
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn(
+        original_tx_id=None
+    )
+
+    response = client.post(
+        "/iap/apple/verify",
+        json={"jwsRepresentation": "jws-no-otid"},
+    )
+    assert response.status_code == 400
+
+
+def test_notification_applies_when_uid_resolved(iap_client, mock_firestore):
+    """B2: iap_links に uid があれば webhook が subscription を更新する."""
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_type="DID_RENEW", notification_uuid="uuid-apply"
+    )
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {"uid": "user-xyz"}
+
+    response = client.post(
+        "/iap/apple/notifications",
+        json={"signedPayload": "valid-jws"},
+    )
+
+    assert response.status_code == 200
+    mock_firestore.collection.assert_any_call("users")

--- a/api/tests/test_iap_subscription.py
+++ b/api/tests/test_iap_subscription.py
@@ -1,0 +1,109 @@
+"""build_subscription_record / 状態導出ロジックのユニットテスト (B1/B2 共通)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.services.iap_subscription import (
+    build_subscription_record,
+    normalize_enum,
+    resolve_is_active,
+)
+
+NOW = 1_700_000_000_000  # 固定の現在時刻 (ms)
+FUTURE = NOW + 7 * 24 * 60 * 60 * 1000
+PAST = NOW - 1000
+
+
+def _txn(**overrides):
+    base = dict(
+        productId="com.akitoando.CycleJournal.yearly_14400",
+        originalTransactionId="2000000000000001",
+        transactionId="2000000000000002",
+        expiresDate=FUTURE,
+        purchaseDate=NOW - 1000,
+        revocationDate=None,
+        environment="Sandbox",
+        offerType=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_normalize_enum_handles_enum_and_str():
+    assert normalize_enum("SUBSCRIBED") == "SUBSCRIBED"
+    assert normalize_enum(SimpleNamespace(value="DID_RENEW")) == "DID_RENEW"
+    assert normalize_enum(None) is None
+
+
+def test_resolve_is_active_rules():
+    assert resolve_is_active(
+        expires_date_ms=FUTURE, revocation_date_ms=None, now_ms=NOW
+    )
+    assert not resolve_is_active(
+        expires_date_ms=PAST, revocation_date_ms=None, now_ms=NOW
+    )
+    # 返金/失効は期限が未来でも無効
+    assert not resolve_is_active(
+        expires_date_ms=FUTURE, revocation_date_ms=NOW, now_ms=NOW
+    )
+    # 期限なし (買い切り) は有効
+    assert resolve_is_active(
+        expires_date_ms=None, revocation_date_ms=None, now_ms=NOW
+    )
+
+
+def test_active_subscription():
+    rec = build_subscription_record(_txn(), now_ms=NOW, notification_type="DID_RENEW")
+    assert rec["is_active"] is True
+    assert rec["status"] == "active"
+    assert rec["product_id"].endswith("yearly_14400")
+    assert rec["original_transaction_id"] == "2000000000000001"
+
+
+def test_trial_subscription_from_offer_type():
+    rec = build_subscription_record(
+        _txn(offerType="INTRODUCTORY"), now_ms=NOW, notification_type="SUBSCRIBED"
+    )
+    assert rec["is_active"] is True
+    assert rec["status"] == "trial"
+
+
+def test_expired_subscription():
+    rec = build_subscription_record(
+        _txn(expiresDate=PAST), now_ms=NOW, notification_type="EXPIRED"
+    )
+    assert rec["is_active"] is False
+    assert rec["status"] == "expired"
+
+
+def test_revoked_subscription():
+    rec = build_subscription_record(
+        _txn(revocationDate=NOW), now_ms=NOW, notification_type="REFUND"
+    )
+    assert rec["is_active"] is False
+    assert rec["status"] == "revoked"
+
+
+def test_cancelled_but_still_active():
+    """解約予約 (AUTO_RENEW_DISABLED) でも期限までは有効・status=cancelled."""
+    rec = build_subscription_record(
+        _txn(),
+        now_ms=NOW,
+        notification_type="DID_CHANGE_RENEWAL_STATUS",
+        subtype="AUTO_RENEW_DISABLED",
+    )
+    assert rec["is_active"] is True
+    assert rec["status"] == "cancelled"
+    assert rec["auto_renew"] is False
+
+
+def test_grace_period_keeps_access():
+    rec = build_subscription_record(
+        _txn(),
+        now_ms=NOW,
+        notification_type="DID_FAIL_TO_RENEW",
+        subtype="GRACE_PERIOD",
+    )
+    assert rec["is_active"] is True
+    assert rec["status"] == "grace_period"


### PR DESCRIPTION
## 概要

課金のサーバー側の心臓部。購入を **`users/{uid}/subscription` に永続化**するロジックを実装（#37 残作業 B1・B2）。これが無いと購入が成立してもサーバーにエンタイトルメントが反映されない。

## 設計上のキモ：ユーザー特定

iOS は現状 `appAccountToken` を設定していないため、webhook 単体では「どのユーザーの購入か」が分からない。そこで：

1. **B1 `/iap/apple/verify`（認証付き）** で `originalTransactionId → uid` を `iap_links` に記録
2. **B2 webhook** は `originalTransactionId` から `iap_links` を引いて uid を解決

→ `appAccountToken`（UUID 制約あり）に依存せず確立できる mapping 方式。

## 変更内容

### B1 `POST /iap/apple/verify`（新規・認証必須）
- StoreKit2 の `jwsRepresentation` を検証・デコード
- `iap_links/{originalTransactionId} = {uid}` を記録
- `users/{uid}/subscription/{originalTransactionId}` に状態を upsert
- レスポンス: `isActive` / `subscriptionStatus` / `productId` / `expiresDateMs`
- 署名不正 → 400 / `originalTransactionId` 欠落 → 400

### B2 ASSN webhook の state machine
- `_noop_apply_notification` placeholder を実装に差し替え
- `signedTransactionInfo` をデコード → `iap_links` で uid 解決 → subscription 反映
- TEST 通知・トランザクション無し・uid 未解決は安全に skip（バックグラウンドで例外握り潰し）

### `services/iap_subscription.py`（新規・純関数）
- transaction + 通知種別から subscription レコードを構築
- `is_active`（revocation/expires による**権威判定**）+ `status` ラベル導出
- `trial` / `active` / `cancelled` / `grace_period` / `billing_retry` / `expired` / `revoked`

## テスト

- iap 関連 **16 pass** / 全体 **73 pass**、変更ファイル ruff clean
- 純関数のユニットテスト（各状態）+ verify/webhook の結合テスト（モック）

## 残作業（このPR外）

- iOS: 購入後に `/iap/apple/verify` を叩く結線（`SubscriptionStore.purchase` の TODO）
- 実環境での E2E 検証は **#58（本番再デプロイ / webhook 404 解消）後**
- B3 GA4 連携 / B4 通知連携 / B5 解約 silent push

> ⚠️ ブランチは暫定で `main` 起点（#58 で `develop→main` 運用に移行予定。付け替えは別途）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)