### PR TITLE
chore: #37 StoreKit Config を紐付けた共有スキームを追加 (A5)

### DIFF
--- a/ios/Cycle.xcodeproj/xcshareddata/xcschemes/Cycle.xcscheme
+++ b/ios/Cycle.xcodeproj/xcshareddata/xcschemes/Cycle.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2E0FCB112EBF921700B9081E"
+               BuildableName = "Cycle.app"
+               BlueprintName = "Cycle"
+               ReferencedContainer = "container:Cycle.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <StoreKitConfigurationFileReference
+         identifier = "Cycle/Configuration.storekit">
+      </StoreKitConfigurationFileReference>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2E0FCB112EBF921700B9081E"
+            BuildableName = "Cycle.app"
+            BlueprintName = "Cycle"
+            ReferencedContainer = "container:Cycle.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2E0FCB112EBF921700B9081E"
+            BuildableName = "Cycle.app"
+            BlueprintName = "Cycle"
+            ReferencedContainer = "container:Cycle.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
## 概要

手順05（A5）の残作業「`.storekit` を Scheme に紐付け」を、per-user の Xcode 設定ではなく**リポジトリに固定**する形で実装。

## 変更内容

- 共有スキーム `Cycle.xcodeproj/xcshareddata/xcschemes/Cycle.xcscheme` を新規追加
- `LaunchAction` に `StoreKitConfigurationFileReference = Cycle/Configuration.storekit` を設定
  → シミュレータ実行時にローカル StoreKit Config（月額¥1,800 / 年額¥14,400 + 7日トライアルのモック）が自動適用され、**Sandbox アカウント無しで購入フローをテスト可能**
- `.storekit` 本体は **Xcode 16 の同期グループ**（`PBXFileSystemSynchronizedRootGroup`）で既にプロジェクトに含まれるため **pbxproj 変更は不要**

## 検証

- `xmllint` で XML 妥当 / `xcodebuild -list` で `Cycle` スキーム認識
- 当該共有スキームで **BUILD SUCCEEDED**（ターゲット UUID 解決確認）
- ※ StoreKit Config の実適用（Paywall で商品2件ロード）は Xcode 実行時に確認（ヘッドレス検証不可）

## 確認のお願い（Xcode 実機/シミュレータ）

Xcode で Cycle スキーム実行 → Paywall 到達時に `Product.products(for:)` が 2 件返り「7日間無料で始める」が押せること。もし商品が空なら Edit Scheme → Run → Options → StoreKit Configuration を再選択（パス調整が必要な場合あり）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)