### PR TITLE
feat: complete #37 subscription lifecycle side effects

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -56,6 +56,14 @@ class Settings(BaseSettings):
     ga4_api_secret: str = ""
     ga4_endpoint: str = "https://www.google-analytics.com/mp/collect"
 
+    # Apple Push Notification service (silent push for subscription state changes)
+    # - APNs auth key is separate from Sign in with Apple / IAP keys.
+    # - Empty credentials make APNs sending a no-op in local/test environments.
+    apple_apns_team_id: str = ""
+    apple_apns_key_id: str = ""
+    apple_apns_private_key: str = ""
+    apple_apns_env: str = "Sandbox"
+
     model_config = {"env_prefix": "", "case_sensitive": False}
 
 

--- a/api/app/routers/iap.py
+++ b/api/app/routers/iap.py
@@ -2,12 +2,13 @@
 
 - POST /iap/apple/notifications  — App Store Server Notifications V2 受信口
 - POST /iap/apple/verify         — クライアント (StoreKit2) からの JWS 即時検証
+- POST /iap/apple/device-token   — silent push 用 APNs device token 登録
 
 Notification 処理ポリシー:
 - notificationUUID をドキュメント ID として iap_notifications コレクションに
   create() を試み、AlreadyExists なら冪等にスキップして 200 を返す。
 - 検証失敗 (JWS) は 400 を返し Apple のリトライ対象から外す。
-- 状態反映 (users/{uid}/subscription) はバックグラウンドタスクで実行し、
+- 状態反映 (users/{uid}/subscription)・GA4・silent push はバックグラウンドで実行し、
   Apple への ACK は即時 200 を返す (3〜5 秒以内の応答要件を満たすため)。
 
 ユーザー特定:
@@ -31,6 +32,9 @@ from google.cloud.firestore import SERVER_TIMESTAMP, AsyncClient
 from pydantic import BaseModel, Field
 
 from app.dependencies import get_current_user, get_firestore
+from app.services.analytics_service import send_event
+from app.services.apns_service import send_silent_push
+from app.services.iap_events import ga4_event_name, should_send_cancel_silent_push
 from app.services.iap_subscription import build_subscription_record
 from app.services.iap_verifier import get_verifier
 
@@ -57,14 +61,85 @@ async def _write_subscription_record(
     await doc.set({**record, "updated_at": SERVER_TIMESTAMP}, merge=True)
 
 
-async def _resolve_uid(db: AsyncClient, original_tx_id: str | None) -> str | None:
-    """originalTransactionId から uid を解決する (verify が記録した iap_links 経由)."""
+async def _get_iap_link(
+    db: AsyncClient,
+    original_tx_id: str | None,
+) -> dict[str, Any] | None:
+    """originalTransactionId から verify 時に保存したリンク情報を取得する."""
     if not original_tx_id:
         return None
     snap = await db.collection("iap_links").document(original_tx_id).get()
     if snap.exists:
-        return (snap.to_dict() or {}).get("uid")
+        return snap.to_dict() or {}
     return None
+
+
+async def _resolve_uid(db: AsyncClient, original_tx_id: str | None) -> str | None:
+    """originalTransactionId から uid を解決する (verify が記録した iap_links 経由)."""
+    link = await _get_iap_link(db, original_tx_id)
+    return link.get("uid") if link else None
+
+
+def _analytics_params(record: dict[str, Any], notification_uuid: str) -> dict[str, Any]:
+    return {
+        "product_id": record["product_id"],
+        "subscription_status": record["status"],
+        "is_active": record["is_active"],
+        "transaction_id": record["transaction_id"],
+        "original_transaction_id": record["original_transaction_id"],
+        "expires_date_ms": record["expires_date_ms"],
+        "notification_type": record["last_notification_type"],
+        "notification_subtype": record["last_subtype"],
+        "environment": record["environment"],
+    }
+
+
+async def _send_ga4_subscription_event(
+    *,
+    uid: str,
+    link: dict[str, Any] | None,
+    record: dict[str, Any],
+    payload: Any,
+) -> None:
+    event_name = ga4_event_name(
+        payload.notificationType,
+        payload.subtype,
+        record["status"],
+    )
+    if event_name is None:
+        return
+
+    client_id = (link or {}).get("ga4_client_id") or uid
+    await send_event(
+        client_id=client_id,
+        user_id=uid,
+        event_name=event_name,
+        params=_analytics_params(record, payload.notificationUUID),
+        event_id=payload.notificationUUID,
+    )
+
+
+async def _send_cancel_silent_pushes(
+    *,
+    db: AsyncClient,
+    uid: str,
+    record: dict[str, Any],
+) -> None:
+    token_collection = db.collection("users").document(uid).collection("apns_tokens")
+    async for snap in token_collection.stream():
+        token_data = snap.to_dict() or {}
+        token = token_data.get("device_token")
+        if not token:
+            continue
+        await send_silent_push(
+            device_token=token,
+            event="cancel_trial_notifications",
+            reason="subscription_auto_renew_disabled",
+            extra={
+                "product_id": record["product_id"],
+                "original_transaction_id": record["original_transaction_id"],
+            },
+        )
 
 
 @router.post("/apple/notifications", status_code=200)
@@ -110,7 +185,7 @@ async def _apply_notification(
     verifier: SignedDataVerifier,
     payload: Any,
 ) -> None:
-    """signedTransactionInfo をデコードして users/{uid}/subscription に状態反映する.
+    """ASSN transaction を反映し、GA4 / silent push の後続処理を実行する.
 
     - TEST 通知やトランザクションを伴わない通知は何もしない。
     - uid が未解決 (verify 未実行) の場合はスキップ。次回の verify で整合する。
@@ -123,7 +198,8 @@ async def _apply_notification(
             return
 
         txn = verifier.verify_and_decode_signed_transaction(signed_tx)
-        uid = await _resolve_uid(db, txn.originalTransactionId)
+        link = await _get_iap_link(db, txn.originalTransactionId)
+        uid = link.get("uid") if link else None
         if uid is None:
             return
 
@@ -134,6 +210,14 @@ async def _apply_notification(
             subtype=payload.subtype,
         )
         await _write_subscription_record(db, uid, record)
+        await _send_ga4_subscription_event(
+            uid=uid,
+            link=link,
+            record=record,
+            payload=payload,
+        )
+        if should_send_cancel_silent_push(payload.notificationType, payload.subtype):
+            await _send_cancel_silent_pushes(db=db, uid=uid, record=record)
     except Exception:  # noqa: BLE001 - background task, never raise to caller
         return
 
@@ -142,6 +226,7 @@ class VerifyRequest(BaseModel):
     """StoreKit2 の Transaction.jwsRepresentation を渡す."""
 
     jws_representation: str = Field(alias="jwsRepresentation")
+    ga4_client_id: str | None = Field(default=None, alias="ga4ClientId")
 
     model_config = {"populate_by_name": True}
 
@@ -168,8 +253,11 @@ async def apple_verify(
     if not original_tx_id:
         raise HTTPException(status_code=400, detail="missing originalTransactionId")
 
+    link_record: dict[str, Any] = {"uid": uid, "updated_at": SERVER_TIMESTAMP}
+    if req.ga4_client_id:
+        link_record["ga4_client_id"] = req.ga4_client_id
     await db.collection("iap_links").document(original_tx_id).set(
-        {"uid": uid, "updated_at": SERVER_TIMESTAMP},
+        link_record,
         merge=True,
     )
 
@@ -183,3 +271,40 @@ async def apple_verify(
         "productId": record["product_id"],
         "expiresDateMs": record["expires_date_ms"],
     }
+
+
+class DeviceTokenRequest(BaseModel):
+    """APNs device token registration for silent push."""
+
+    device_token: str = Field(alias="deviceToken", min_length=16, max_length=512)
+    environment: str | None = None
+
+    model_config = {"populate_by_name": True}
+
+
+@router.post("/apple/device-token", status_code=200)
+async def register_device_token(
+    req: DeviceTokenRequest,
+    uid: str = Depends(get_current_user),
+    db: AsyncClient = Depends(get_firestore),
+) -> dict[str, Any]:
+    """Register an APNs token used for subscription silent pushes."""
+    token = req.device_token.strip().replace(" ", "").lower()
+    if not token:
+        raise HTTPException(status_code=400, detail="missing deviceToken")
+
+    await (
+        db.collection("users")
+        .document(uid)
+        .collection("apns_tokens")
+        .document(token)
+        .set(
+            {
+                "device_token": token,
+                "environment": req.environment,
+                "updated_at": SERVER_TIMESTAMP,
+            },
+            merge=True,
+        )
+    )
+    return {"status": "registered"}

--- a/api/app/services/apns_service.py
+++ b/api/app/services/apns_service.py
@@ -1,0 +1,71 @@
+"""Apple Push Notification service sender for silent subscription updates."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+import jwt
+
+from app.config import settings
+
+
+def _apns_host() -> str:
+    env = settings.apple_apns_env.lower()
+    return "api.push.apple.com" if env == "production" else "api.sandbox.push.apple.com"
+
+
+def _build_provider_token() -> str | None:
+    if (
+        not settings.apple_apns_team_id
+        or not settings.apple_apns_key_id
+        or not settings.apple_apns_private_key
+    ):
+        return None
+    return jwt.encode(
+        {"iss": settings.apple_apns_team_id, "iat": int(time.time())},
+        settings.apple_apns_private_key,
+        algorithm="ES256",
+        headers={"kid": settings.apple_apns_key_id},
+    )
+
+
+async def send_silent_push(
+    *,
+    device_token: str,
+    event: str,
+    reason: str,
+    extra: dict[str, Any] | None = None,
+) -> bool:
+    """Send one APNs background notification.
+
+    Returns false for missing configuration or network/APNs errors so webhook handling
+    never fails because a best-effort push could not be delivered.
+    """
+    provider_token = _build_provider_token()
+    if provider_token is None:
+        return False
+
+    payload: dict[str, Any] = {
+        "aps": {"content-available": 1},
+        "cycle_event": event,
+        "reason": reason,
+    }
+    if extra:
+        payload.update(extra)
+
+    url = f"https://{_apns_host()}/3/device/{device_token}"
+    headers = {
+        "authorization": f"bearer {provider_token}",
+        "apns-topic": settings.apple_bundle_id,
+        "apns-push-type": "background",
+        "apns-priority": "5",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0, http2=True) as client:
+            response = await client.post(url, json=payload, headers=headers)
+            return 200 <= response.status_code < 300
+    except httpx.HTTPError:
+        return False

--- a/api/app/services/iap_events.py
+++ b/api/app/services/iap_events.py
@@ -1,0 +1,58 @@
+"""ASSN V2 notification side-effect mapping for analytics and push."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.iap_subscription import normalize_enum
+
+
+def ga4_event_name(
+    notification_type: Any | None,
+    subtype: Any | None,
+    status: str,
+) -> str | None:
+    """Map App Store Server Notifications V2 to GA4 event names."""
+    nt = normalize_enum(notification_type)
+    st = normalize_enum(subtype)
+
+    if nt == "SUBSCRIBED":
+        return (
+            "subscription_trial_started"
+            if status == "trial"
+            else "subscription_started"
+        )
+    if nt == "DID_RENEW":
+        return "subscription_renewed"
+    if nt == "DID_CHANGE_RENEWAL_STATUS":
+        if st == "AUTO_RENEW_DISABLED":
+            return "subscription_cancelled"
+        if st == "AUTO_RENEW_ENABLED":
+            return "subscription_reactivated"
+    if nt in {"REFUND", "REVOKE", "REFUND_REVERSED"}:
+        return (
+            "subscription_refund_reversed"
+            if nt == "REFUND_REVERSED"
+            else "subscription_refunded"
+        )
+    if nt == "EXPIRED":
+        return (
+            "trial_expired_without_conversion"
+            if status == "expired"
+            else "subscription_expired"
+        )
+    if nt == "DID_FAIL_TO_RENEW":
+        return "subscription_billing_issue"
+    if nt == "GRACE_PERIOD_EXPIRED":
+        return "subscription_grace_period_expired"
+    return None
+
+
+def should_send_cancel_silent_push(
+    notification_type: Any | None,
+    subtype: Any | None,
+) -> bool:
+    """Return true when local trial notifications should be cancelled on device."""
+    nt = normalize_enum(notification_type)
+    st = normalize_enum(subtype)
+    return nt == "DID_CHANGE_RENEWAL_STATUS" and st == "AUTO_RENEW_DISABLED"

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "anthropic[vertex]>=0.42.0",
     "pyjwt[crypto]>=2.9.0",
     "httpx>=0.27.0",
+    "h2>=4.1.0",
     "langgraph>=0.2.0",
     "langchain-core>=0.3.0",
     "app-store-server-library>=1.5.0",

--- a/api/tests/test_analytics_config.py
+++ b/api/tests/test_analytics_config.py
@@ -33,3 +33,14 @@ def test_ga4_overridable_via_env():
         settings = Settings()
         assert settings.ga4_measurement_id == "G-TEST123"
         assert settings.ga4_api_secret == "secret-xyz"
+
+
+def test_apns_config_exists():
+    """B5: APNs silent push 設定項目."""
+    from app.config import settings
+
+    assert hasattr(settings, "apple_apns_team_id")
+    assert hasattr(settings, "apple_apns_key_id")
+    assert hasattr(settings, "apple_apns_private_key")
+    assert hasattr(settings, "apple_apns_env")
+    assert settings.apple_apns_env == "Sandbox"

--- a/api/tests/test_apns_service.py
+++ b/api/tests/test_apns_service.py
@@ -1,0 +1,55 @@
+"""APNs silent push sender tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_send_silent_push_skips_when_not_configured():
+    from app.services import apns_service
+
+    with (
+        patch.object(apns_service.settings, "apple_apns_team_id", ""),
+        patch.object(apns_service.settings, "apple_apns_key_id", ""),
+        patch.object(apns_service.settings, "apple_apns_private_key", ""),
+        patch("app.services.apns_service.httpx.AsyncClient") as mock_client,
+    ):
+        sent = await apns_service.send_silent_push(
+            device_token="abcd",
+            event="cancel_trial_notifications",
+            reason="subscription_auto_renew_disabled",
+        )
+
+    assert sent is False
+    mock_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_silent_push_posts_background_payload():
+    from app.services import apns_service
+
+    mock_response = MagicMock(status_code=200)
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_context = AsyncMock()
+    mock_context.__aenter__.return_value = mock_client
+
+    with (
+        patch.object(apns_service.settings, "apple_apns_team_id", "TEAMID1234"),
+        patch.object(apns_service.settings, "apple_apns_key_id", "KEYID12345"),
+        patch.object(apns_service.settings, "apple_apns_private_key", "pem"),
+        patch.object(apns_service.jwt, "encode", return_value="provider-token"),
+        patch("app.services.apns_service.httpx.AsyncClient", return_value=mock_context),
+    ):
+        sent = await apns_service.send_silent_push(
+            device_token="abcd",
+            event="cancel_trial_notifications",
+            reason="subscription_auto_renew_disabled",
+        )
+
+    assert sent is True
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["json"]["aps"] == {"content-available": 1}
+    assert kwargs["headers"]["apns-push-type"] == "background"
+    assert kwargs["headers"]["apns-priority"] == "5"

--- a/api/tests/test_iap_events.py
+++ b/api/tests/test_iap_events.py
@@ -1,0 +1,31 @@
+"""ASSN side-effect mapping tests for #37 B3/B5."""
+
+from app.services.iap_events import ga4_event_name, should_send_cancel_silent_push
+
+
+def test_ga4_event_name_maps_subscription_lifecycle():
+    assert ga4_event_name("SUBSCRIBED", None, "trial") == (
+        "subscription_trial_started"
+    )
+    assert ga4_event_name("DID_RENEW", None, "active") == "subscription_renewed"
+    assert (
+        ga4_event_name(
+            "DID_CHANGE_RENEWAL_STATUS",
+            "AUTO_RENEW_DISABLED",
+            "cancelled",
+        )
+        == "subscription_cancelled"
+    )
+    assert ga4_event_name("REFUND", None, "revoked") == "subscription_refunded"
+
+
+def test_cancel_silent_push_only_for_auto_renew_disabled():
+    assert should_send_cancel_silent_push(
+        "DID_CHANGE_RENEWAL_STATUS",
+        "AUTO_RENEW_DISABLED",
+    )
+    assert not should_send_cancel_silent_push(
+        "DID_CHANGE_RENEWAL_STATUS",
+        "AUTO_RENEW_ENABLED",
+    )
+    assert not should_send_cancel_silent_push("DID_RENEW", None)

--- a/api/tests/test_iap_router.py
+++ b/api/tests/test_iap_router.py
@@ -18,11 +18,12 @@ def _make_decoded_payload(
     notification_type: str = "SUBSCRIBED",
     notification_uuid: str = "uuid-1",
     environment: str = "Sandbox",
+    subtype: str | None = None,
 ):
     """ResponseBodyV2DecodedPayload 風のモックを返す."""
     payload = MagicMock()
     payload.notificationType = notification_type
-    payload.subtype = None
+    payload.subtype = subtype
     payload.notificationUUID = notification_uuid
     payload.signedDate = 1700000000000
     data = MagicMock()
@@ -225,4 +226,84 @@ def test_notification_applies_when_uid_resolved(iap_client, mock_firestore):
     )
 
     assert response.status_code == 200
+    mock_firestore.collection.assert_any_call("users")
+
+
+def test_notification_sends_ga4_event_when_uid_resolved(iap_client, mock_firestore):
+    """B3: ASSN 反映後に notificationUUID を event_id として GA4 に送る."""
+    from unittest.mock import patch
+
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_type="DID_RENEW", notification_uuid="uuid-ga4"
+    )
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {
+        "uid": "user-ga4",
+        "ga4_client_id": "client-123",
+    }
+
+    with patch("app.routers.iap.send_event", new_callable=AsyncMock) as send_event:
+        response = client.post(
+            "/iap/apple/notifications",
+            json={"signedPayload": "valid-jws"},
+        )
+
+    assert response.status_code == 200
+    send_event.assert_awaited_once()
+    kwargs = send_event.await_args.kwargs
+    assert kwargs["client_id"] == "client-123"
+    assert kwargs["user_id"] == "user-ga4"
+    assert kwargs["event_name"] == "subscription_renewed"
+    assert kwargs["event_id"] == "uuid-ga4"
+    assert kwargs["params"]["product_id"].endswith("yearly_14400")
+
+
+def test_notification_sends_cancel_silent_push(iap_client, mock_firestore):
+    """B5: 解約予約 ASSN で登録済み端末へ silent push を送る."""
+    from unittest.mock import patch
+
+    async def token_stream():
+        snap = MagicMock()
+        snap.to_dict.return_value = {"device_token": "abcd1234"}
+        yield snap
+
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_type="DID_CHANGE_RENEWAL_STATUS",
+        subtype="AUTO_RENEW_DISABLED",
+        notification_uuid="uuid-cancel",
+    )
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {"uid": "user-cancel"}
+    mock_firestore._mock_subcollection.stream.return_value = token_stream()
+
+    with (
+        patch("app.routers.iap.send_event", new_callable=AsyncMock),
+        patch("app.routers.iap.send_silent_push", new_callable=AsyncMock) as send_push,
+    ):
+        response = client.post(
+            "/iap/apple/notifications",
+            json={"signedPayload": "valid-jws"},
+        )
+
+    assert response.status_code == 200
+    send_push.assert_awaited_once()
+    assert send_push.await_args.kwargs["device_token"] == "abcd1234"
+    assert send_push.await_args.kwargs["event"] == "cancel_trial_notifications"
+
+
+def test_register_device_token(iap_auth_client, mock_firestore):
+    """B5: 認証済みユーザーの APNs token を保存する."""
+    client, _, _ = iap_auth_client
+
+    response = client.post(
+        "/iap/apple/device-token",
+        json={"deviceToken": "ABCDEF1234567890", "environment": "Sandbox"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "registered"
     mock_firestore.collection.assert_any_call("users")

--- a/ios/Cycle.xcodeproj/project.pbxproj
+++ b/ios/Cycle.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2E0FCB402EBF930000B9081E /* Local.xcconfig */;
 			buildSettings = {
+				APS_ENVIRONMENT = development;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Cycle/Cycle.entitlements;
@@ -420,6 +421,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = "remote-notification";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -443,6 +445,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2E0FCB402EBF930000B9081E /* Local.xcconfig */;
 			buildSettings = {
+				APS_ENVIRONMENT = production;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Cycle/Cycle.entitlements;
@@ -453,6 +456,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = "remote-notification";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/ios/Cycle/App/CycleApp.swift
+++ b/ios/Cycle/App/CycleApp.swift
@@ -16,7 +16,35 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        application.registerForRemoteNotifications()
         return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+        APNsDeviceTokenRegistry.save(token)
+        Task {
+            try? await SubscriptionService().registerAPNsDeviceToken(token)
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        guard userInfo["cycle_event"] as? String == "cancel_trial_notifications" else {
+            completionHandler(.noData)
+            return
+        }
+
+        Task { @MainActor in
+            TrialNotificationScheduler.shared.cancelAllTrialNotifications()
+            completionHandler(.newData)
+        }
     }
 
     /// フォアグラウンドで通知を受信した場合にバナーとサウンドで表示

--- a/ios/Cycle/Cycle.entitlements
+++ b/ios/Cycle/Cycle.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>$(APS_ENVIRONMENT)</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/ios/Cycle/Features/Auth/Store/AuthStore.swift
+++ b/ios/Cycle/Features/Auth/Store/AuthStore.swift
@@ -280,6 +280,7 @@ class AuthStore: NSObject, ObservableObject {
 
         currentUser = user
         APIClient.shared.setAuthToken(accessToken)
+        Task { await SubscriptionService().registerStoredAPNsDeviceTokenIfAvailable() }
         state = .authenticated(userId: user.userId)
     }
 
@@ -313,6 +314,7 @@ class AuthStore: NSObject, ObservableObject {
         saveUserToKeychain(user)
         deleteFromKeychain(key: legacyTokenKey)
         APIClient.shared.setAuthToken(accessToken)
+        Task { await SubscriptionService().registerStoredAPNsDeviceTokenIfAvailable() }
     }
 
     private func clearLocalAuth() {

--- a/ios/Cycle/Features/Onboarding/Store/OnboardingFlow.swift
+++ b/ios/Cycle/Features/Onboarding/Store/OnboardingFlow.swift
@@ -67,6 +67,7 @@ final class OnboardingFlow: ObservableObject {
 
     func selectGoal(_ goal: OnboardingGoal) {
         selectedGoal = goal
+        UserDefaults.standard.set(goal.rawValue, forKey: "userGoal")
     }
 
     func setFirstJournalText(_ text: String) {

--- a/ios/Cycle/Features/Subscription/Store/SubscriptionStore.swift
+++ b/ios/Cycle/Features/Subscription/Store/SubscriptionStore.swift
@@ -84,6 +84,7 @@ final class SubscriptionStore: ObservableObject {
             switch verification {
             case .verified(let transaction):
                 await refreshEntitlements()
+                await applyTrialNotificationSideEffects(for: transaction)
                 await transaction.finish()
                 return verification.jwsRepresentation
             case .unverified:
@@ -104,8 +105,42 @@ final class SubscriptionStore: ObservableObject {
         for await result in Transaction.updates {
             guard case .verified(let transaction) = result else { continue }
             await refreshEntitlements()
+            await applyTrialNotificationSideEffects(for: transaction)
             await transaction.finish()
         }
+    }
+
+    // MARK: - Trial notification side effects
+
+    private func applyTrialNotificationSideEffects(for transaction: Transaction) async {
+        let scheduler = TrialNotificationScheduler.shared
+
+        if transaction.revocationDate != nil {
+            scheduler.cancelAllTrialNotifications()
+            return
+        }
+
+        if let expirationDate = transaction.expirationDate, expirationDate < Date() {
+            scheduler.cancelAllTrialNotifications()
+            return
+        }
+
+        guard transaction.offerType == .introductory else {
+            scheduler.cancelAllTrialNotifications()
+            return
+        }
+
+        await scheduler.scheduleTrialNotifications(
+            purchaseDate: transaction.purchaseDate,
+            goal: Self.storedOnboardingGoal()
+        )
+    }
+
+    private static func storedOnboardingGoal() -> OnboardingGoal? {
+        guard let rawValue = UserDefaults.standard.string(forKey: "userGoal") else {
+            return nil
+        }
+        return OnboardingGoal(rawValue: rawValue)
     }
 }
 

--- a/ios/Cycle/Services/SubscriptionService.swift
+++ b/ios/Cycle/Services/SubscriptionService.swift
@@ -1,0 +1,62 @@
+//
+//  SubscriptionService.swift
+//  CycleJournal
+//
+//  Backend integration for subscription verification and silent-push token sync.
+//
+
+import Foundation
+
+struct IAPDeviceTokenRequest: Encodable {
+    let deviceToken: String
+    let environment: String
+}
+
+struct IAPDeviceTokenResponse: Decodable {
+    let status: String
+}
+
+enum APNsDeviceTokenRegistry {
+    private static let key = "apnsDeviceToken"
+
+    static func save(_ token: String) {
+        UserDefaults.standard.set(token, forKey: key)
+    }
+
+    static var currentToken: String? {
+        UserDefaults.standard.string(forKey: key)
+    }
+}
+
+final class SubscriptionService {
+    private let apiClient: APIClient
+
+    init(apiClient: APIClient = .shared) {
+        self.apiClient = apiClient
+    }
+
+    func registerAPNsDeviceToken(_ token: String) async throws {
+        let request = IAPDeviceTokenRequest(
+            deviceToken: token,
+            environment: Self.apnsEnvironment
+        )
+        let _: IAPDeviceTokenResponse = try await apiClient.post(
+            path: "/iap/apple/device-token",
+            body: request,
+            requiresAuth: true
+        )
+    }
+
+    func registerStoredAPNsDeviceTokenIfAvailable() async {
+        guard let token = APNsDeviceTokenRegistry.currentToken else { return }
+        try? await registerAPNsDeviceToken(token)
+    }
+
+    private static var apnsEnvironment: String {
+        #if DEBUG
+        return "Sandbox"
+        #else
+        return "Production"
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
- wire ASSN subscription updates to GA4 Measurement Protocol events with notificationUUID event IDs
- add APNs device-token registration and silent push sending for auto-renew cancellation
- cancel/schedule trial local notifications from StoreKit Transaction updates and silent pushes

## Verification
- API: `/private/tmp/cycle-journal-b3-b5-venv/bin/python -m pytest` -> 77 passed
- API changed files: `ruff check app/routers/iap.py app/services/apns_service.py app/services/iap_events.py tests/test_apns_service.py tests/test_iap_events.py tests/test_iap_router.py tests/test_analytics_config.py` -> passed
- iOS plist: `plutil -lint ios/Cycle/Cycle.entitlements` -> OK
- iOS syntax: `swiftc -parse` for changed subscription/app files against iOS 17 SDK -> passed

## Note
- Full `xcodebuild` could not run in this sandbox because SwiftPM writes manifest diagnostics under `~/Library/Caches/org.swift.swiftpm`, which is outside the writable roots and fails with Operation not permitted.