### PR TITLE
chore: wire #37 APNs config into Cloud Run

### DIFF
--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -12,7 +12,9 @@ module "api" {
   firestore_database_id = "dev"
   apple_team_id         = var.apple_team_id
   apple_key_id          = var.apple_key_id
+  apple_apns_key_id     = var.apple_apns_key_id
   apple_iap_issuer_id   = var.apple_iap_issuer_id
   apple_iap_key_id      = var.apple_iap_key_id
   apple_iap_env         = "Sandbox"
+  apple_apns_env        = "Sandbox"
 }

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -6,3 +6,6 @@ apple_key_id  = "TXTX42VXG4"
 # IAP 専用キー (Sign in with Apple とは別物)
 apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
 apple_iap_key_id    = "7W562GZ399"
+
+# APNs Auth Key ID. Empty keeps silent push disabled until the key is issued.
+apple_apns_key_id = ""

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -28,3 +28,10 @@ variable "apple_iap_key_id" {
   description = "App Store Connect IAP Key ID"
   type        = string
 }
+
+
+variable "apple_apns_key_id" {
+  description = "Apple Push Notification service Auth Key ID. Empty disables APNs sending."
+  type        = string
+  default     = ""
+}

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -12,7 +12,9 @@ module "api" {
   firestore_database_id = "(default)"
   apple_team_id         = var.apple_team_id
   apple_key_id          = var.apple_key_id
+  apple_apns_key_id     = var.apple_apns_key_id
   apple_iap_issuer_id   = var.apple_iap_issuer_id
   apple_iap_key_id      = var.apple_iap_key_id
   apple_iap_env         = "Sandbox" # テスト完了後 "Production" に変更
+  apple_apns_env        = "Production"
 }

--- a/infra/environments/prod/terraform.tfvars
+++ b/infra/environments/prod/terraform.tfvars
@@ -6,3 +6,6 @@ apple_key_id  = "TXTX42VXG4"
 # IAP 専用キー (Sign in with Apple とは別物。issuer/key id は環境共通)
 apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
 apple_iap_key_id    = "7W562GZ399"
+
+# APNs Auth Key ID. Empty keeps silent push disabled until the key is issued.
+apple_apns_key_id = ""

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -28,3 +28,10 @@ variable "apple_iap_key_id" {
   description = "App Store Connect IAP Key ID"
   type        = string
 }
+
+
+variable "apple_apns_key_id" {
+  description = "Apple Push Notification service Auth Key ID. Empty disables APNs sending."
+  type        = string
+  default     = ""
+}

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -44,6 +44,15 @@ resource "google_secret_manager_secret" "apple_iap_private_key" {
   }
 }
 
+resource "google_secret_manager_secret" "apple_apns_private_key" {
+  secret_id = "apple-apns-private-key-${var.environment}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
 resource "google_secret_manager_secret" "jwt_secret" {
   secret_id = "jwt-secret-${var.environment}"
   project   = var.project_id
@@ -181,6 +190,35 @@ resource "google_cloud_run_v2_service" "api" {
       }
 
       env {
+        name  = "APPLE_APNS_TEAM_ID"
+        value = var.apple_team_id
+      }
+
+      env {
+        name  = "APPLE_APNS_KEY_ID"
+        value = var.apple_apns_key_id
+      }
+
+      dynamic "env" {
+        for_each = var.apple_apns_key_id == "" ? [] : [1]
+
+        content {
+          name = "APPLE_APNS_PRIVATE_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.apple_apns_private_key.secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      env {
+        name  = "APPLE_APNS_ENV"
+        value = var.apple_apns_env
+      }
+
+      env {
         name  = "APPLE_IAP_ISSUER_ID"
         value = var.apple_iap_issuer_id
       }
@@ -238,6 +276,7 @@ resource "google_cloud_run_v2_service" "api" {
     google_secret_manager_secret_version.jwt_secret,
     google_secret_manager_secret.apple_auth,
     google_secret_manager_secret.apple_iap_private_key,
+    google_secret_manager_secret.apple_apns_private_key,
   ]
 }
 

--- a/infra/modules/api/variables.tf
+++ b/infra/modules/api/variables.tf
@@ -75,6 +75,23 @@ variable "apple_key_id" {
   type        = string
 }
 
+variable "apple_apns_key_id" {
+  description = "Apple Push Notification service Auth Key ID. Empty disables APNs sending."
+  type        = string
+  default     = ""
+}
+
+variable "apple_apns_env" {
+  description = "APNs environment: Sandbox or Production"
+  type        = string
+  default     = "Sandbox"
+
+  validation {
+    condition     = contains(["Sandbox", "Production"], var.apple_apns_env)
+    error_message = "apple_apns_env must be Sandbox or Production."
+  }
+}
+
 variable "apple_iap_issuer_id" {
   description = "App Store Connect IAP Key Issuer ID"
   type        = string


### PR DESCRIPTION
## Summary
- add APNs private-key Secret Manager resources per environment
- pass APPLE_APNS_TEAM_ID / KEY_ID / ENV to Cloud Run
- conditionally mount APPLE_APNS_PRIVATE_KEY only when an APNs key id is configured

## Verification
- terraform fmt -check infra/modules/api infra/environments/dev infra/environments/prod
- terraform -chdir=infra/environments/dev init -backend=false
- terraform -chdir=infra/environments/dev validate
- terraform -chdir=infra/environments/prod init -backend=false
- terraform -chdir=infra/environments/prod validate

## Operational note
APNs stays disabled while apple_apns_key_id is empty. To enable B5 in an environment, issue an APNs Auth Key, set apple_apns_key_id, add the .p8 as a version of apple-apns-private-key-<env>, and apply Terraform.