### PR TITLE
feat: #37 ASSN 受信時に GA4 ライフサイクルイベント送信 (B3)

### DIFF
--- a/api/app/routers/iap.py
+++ b/api/app/routers/iap.py
@@ -31,7 +31,12 @@ from google.cloud.firestore import SERVER_TIMESTAMP, AsyncClient
 from pydantic import BaseModel, Field
 
 from app.dependencies import get_current_user, get_firestore
-from app.services.iap_subscription import build_subscription_record
+from app.services.analytics_service import send_event
+from app.services.iap_subscription import (
+    build_subscription_record,
+    revenue_jpy_for,
+    select_lifecycle_event,
+)
 from app.services.iap_verifier import get_verifier
 
 router = APIRouter(prefix="/iap", tags=["iap"])
@@ -127,15 +132,71 @@ async def _apply_notification(
         if uid is None:
             return
 
+        # 直前の状態 (trial 起点の遷移を区別して KPI イベントを出すため)
+        sub_doc = (
+            db.collection("users")
+            .document(uid)
+            .collection("subscription")
+            .document(txn.originalTransactionId)
+        )
+        prior_snap = await sub_doc.get()
+        prior = prior_snap.to_dict() or {} if prior_snap.exists else {}
+
         record = build_subscription_record(
             txn,
             now_ms=_now_ms(),
             notification_type=payload.notificationType,
             subtype=payload.subtype,
         )
+
+        await _emit_lifecycle_event(
+            uid=uid,
+            payload=payload,
+            record=record,
+            prior_status=prior.get("status"),
+        )
         await _write_subscription_record(db, uid, record)
     except Exception:  # noqa: BLE001 - background task, never raise to caller
         return
+
+
+async def _emit_lifecycle_event(
+    *,
+    uid: str,
+    payload: Any,
+    record: dict[str, Any],
+    prior_status: str | None,
+) -> None:
+    """サブスクのライフサイクル遷移を GA4 サーバーイベントとして送る (B3).
+
+    GA4 未設定なら send_event は no-op。notificationUUID を event_id にして冪等化。
+    """
+    event_name = select_lifecycle_event(
+        notification_type=payload.notificationType,
+        subtype=payload.subtype,
+        prior_status=prior_status,
+        new_status=record["status"],
+    )
+    if event_name is None:
+        return
+
+    params: dict[str, Any] = {
+        "product_id": record["product_id"],
+        "environment": record["environment"],
+        "subscription_status": record["status"],
+    }
+    if event_name in {"trial_converted_to_paid", "subscription_renewed"}:
+        revenue = revenue_jpy_for(record["product_id"])
+        if revenue is not None:
+            params["revenue_jpy"] = revenue
+
+    await send_event(
+        client_id=uid,
+        user_id=uid,
+        event_name=event_name,
+        params=params,
+        event_id=payload.notificationUUID,
+    )
 
 
 class VerifyRequest(BaseModel):

--- a/api/app/services/iap_subscription.py
+++ b/api/app/services/iap_subscription.py
@@ -72,6 +72,57 @@ def resolve_status(
     return "active"
 
 
+_REVENUE_JPY_BY_SUFFIX = {
+    "monthly_1800": 1800,
+    "yearly_14400": 14400,
+}
+
+
+def revenue_jpy_for(product_id: str | None) -> int | None:
+    """product_id から税込相当の売上(円)を引く。未知の商品は None。"""
+    if not product_id:
+        return None
+    for suffix, amount in _REVENUE_JPY_BY_SUFFIX.items():
+        if product_id.endswith(suffix):
+            return amount
+    return None
+
+
+def select_lifecycle_event(
+    *,
+    notification_type: Any | None,
+    subtype: Any | None,
+    prior_status: str | None,
+    new_status: str,
+) -> str | None:
+    """ASSN 通知 + 直前の subscription status から GA4 サーバーイベント名を導出する.
+
+    KPI (Trial→Paid 転換率 / 継続率) 計測のため、トライアル起点の遷移を区別する:
+    - 初回購入(トライアル)         → trial_started
+    - トライアル→課金(初回更新)    → trial_converted_to_paid
+    - トライアルのまま失効         → trial_expired_without_conversion
+    送信不要な通知は None を返す。
+    """
+    nt = normalize_enum(notification_type)
+    st = normalize_enum(subtype)
+
+    if nt in {"REFUND", "REVOKE"}:
+        return "subscription_refunded"
+    if nt == "DID_CHANGE_RENEWAL_STATUS" and st == "AUTO_RENEW_DISABLED":
+        return "subscription_cancelled"
+    if nt == "EXPIRED":
+        if prior_status == "trial":
+            return "trial_expired_without_conversion"
+        return "subscription_expired"
+    if nt == "DID_RENEW":
+        if prior_status == "trial":
+            return "trial_converted_to_paid"
+        return "subscription_renewed"
+    if nt == "SUBSCRIBED":
+        return "trial_started" if new_status == "trial" else "subscription_started"
+    return None
+
+
 def build_subscription_record(
     txn: Any,
     *,

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -30,6 +30,7 @@ def _make_mock_firestore():
     mock_sub_doc = MagicMock()
     mock_sub_doc.set = AsyncMock()
     mock_sub_doc.delete = AsyncMock()
+    mock_sub_doc.get = AsyncMock(return_value=mock_snapshot)
     mock_subcollection.document.return_value = mock_sub_doc
 
     async def empty_stream():

--- a/api/tests/test_iap_router.py
+++ b/api/tests/test_iap_router.py
@@ -226,3 +226,31 @@ def test_notification_applies_when_uid_resolved(iap_client, mock_firestore):
 
     assert response.status_code == 200
     mock_firestore.collection.assert_any_call("users")
+
+
+def test_notification_emits_ga4_event(iap_client, mock_firestore, monkeypatch):
+    """B3: uid 解決時、webhook がライフサイクル GA4 イベントを送る."""
+    import app.routers.iap as iap_mod
+
+    send_mock = AsyncMock(return_value=None)
+    monkeypatch.setattr(iap_mod, "send_event", send_mock)
+
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_type="DID_RENEW", notification_uuid="uuid-ga4"
+    )
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {"uid": "user-xyz"}
+
+    response = client.post(
+        "/iap/apple/notifications",
+        json={"signedPayload": "valid-jws"},
+    )
+
+    assert response.status_code == 200
+    send_mock.assert_awaited_once()
+    kwargs = send_mock.await_args.kwargs
+    assert kwargs["event_name"] == "subscription_renewed"
+    assert kwargs["event_id"] == "uuid-ga4"
+    assert kwargs["params"]["revenue_jpy"] == 14400

--- a/api/tests/test_iap_subscription.py
+++ b/api/tests/test_iap_subscription.py
@@ -8,6 +8,8 @@ from app.services.iap_subscription import (
     build_subscription_record,
     normalize_enum,
     resolve_is_active,
+    revenue_jpy_for,
+    select_lifecycle_event,
 )
 
 NOW = 1_700_000_000_000  # 固定の現在時刻 (ms)
@@ -107,3 +109,104 @@ def test_grace_period_keeps_access():
     )
     assert rec["is_active"] is True
     assert rec["status"] == "grace_period"
+
+
+# --- B3: GA4 ライフサイクルイベント導出 ---
+
+
+def test_revenue_jpy_for():
+    assert revenue_jpy_for("com.akitoando.CycleJournal.yearly_14400") == 14400
+    assert revenue_jpy_for("com.akitoando.CycleJournal.monthly_1800") == 1800
+    assert revenue_jpy_for("unknown.product") is None
+    assert revenue_jpy_for(None) is None
+
+
+def test_select_lifecycle_event_trial_started():
+    assert (
+        select_lifecycle_event(
+            notification_type="SUBSCRIBED",
+            subtype="INITIAL_BUY",
+            prior_status=None,
+            new_status="trial",
+        )
+        == "trial_started"
+    )
+
+
+def test_select_lifecycle_event_trial_converted():
+    """トライアル中の更新は転換 (KPI の肝)。"""
+    assert (
+        select_lifecycle_event(
+            notification_type="DID_RENEW",
+            subtype=None,
+            prior_status="trial",
+            new_status="active",
+        )
+        == "trial_converted_to_paid"
+    )
+
+
+def test_select_lifecycle_event_plain_renew():
+    assert (
+        select_lifecycle_event(
+            notification_type="DID_RENEW",
+            subtype=None,
+            prior_status="active",
+            new_status="active",
+        )
+        == "subscription_renewed"
+    )
+
+
+def test_select_lifecycle_event_trial_expired_vs_normal():
+    assert (
+        select_lifecycle_event(
+            notification_type="EXPIRED",
+            subtype=None,
+            prior_status="trial",
+            new_status="expired",
+        )
+        == "trial_expired_without_conversion"
+    )
+    assert (
+        select_lifecycle_event(
+            notification_type="EXPIRED",
+            subtype=None,
+            prior_status="active",
+            new_status="expired",
+        )
+        == "subscription_expired"
+    )
+
+
+def test_select_lifecycle_event_cancel_and_refund():
+    assert (
+        select_lifecycle_event(
+            notification_type="DID_CHANGE_RENEWAL_STATUS",
+            subtype="AUTO_RENEW_DISABLED",
+            prior_status="active",
+            new_status="cancelled",
+        )
+        == "subscription_cancelled"
+    )
+    assert (
+        select_lifecycle_event(
+            notification_type="REFUND",
+            subtype=None,
+            prior_status="active",
+            new_status="revoked",
+        )
+        == "subscription_refunded"
+    )
+
+
+def test_select_lifecycle_event_none_for_unmapped():
+    assert (
+        select_lifecycle_event(
+            notification_type="DID_CHANGE_RENEWAL_PREF",
+            subtype=None,
+            prior_status="active",
+            new_status="active",
+        )
+        is None
+    )


### PR DESCRIPTION
## 概要

webhook の状態反映（B2）に、KPI 計測用の **GA4 サーバーサイドイベント送信**を統合（#37 残作業 B3）。`#37` の Trial→Paid 転換率 25% / 継続率などの計測の土台。

## 変更内容

- `_apply_notification` で**直前の subscription status を読み**、trial 起点の遷移を区別してイベント名を決定：

| 通知 | 条件 | GA4 イベント |
|---|---|---|
| SUBSCRIBED | new=trial | `trial_started` |
| DID_RENEW | prior=trial | `trial_converted_to_paid` |
| DID_RENEW | prior≠trial | `subscription_renewed` |
| EXPIRED | prior=trial | `trial_expired_without_conversion` |
| EXPIRED | prior≠trial | `subscription_expired` |
| DID_CHANGE_RENEWAL_STATUS + AUTO_RENEW_DISABLED | | `subscription_cancelled` |
| REFUND / REVOKE | | `subscription_refunded` |

- 転換・更新イベントには `revenue_jpy`（product_id から導出: 年¥14,400 / 月¥1,800）
- `event_id = notificationUUID` で GA4 重複排除
- GA4 未設定なら `send_event` は **no-op**（既存仕様）。例外は握り潰して Apple ACK を守る
- `services/iap_subscription.py` に純関数 `select_lifecycle_event` / `revenue_jpy_for` を追加

## テスト

- iap 24 / 全 80 pass、変更ファイル ruff clean
- 純関数の遷移網羅テスト + webhook が GA4 を呼ぶ結合テスト（`send_event` を patch）
- conftest: サブコレクション doc モックに `get()` を追加（追加のみ・既存無影響）

## 残・前提

- GA4 の実送信は手順07（`GA4_API_SECRET`）投入後に有効化（未投入なら no-op）
- 実環境 E2E は #58 の本番再デプロイ後

🤖 Generated with [Claude Code](https://claude.com/claude-code)