### PR TITLE
fix: use valid dev Firestore database id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,5 @@
 - Do not use Terraform workspaces for environment switching.
 - Shared project-level resources live in `shared`; environment-specific Cloud Run,
   Secret Manager, IAM, and Firestore resources live in `dev` or `prod`.
+- Firestore named database IDs must be at least 4 characters. The dev database
+  is `dev-db`; production remains `(default)`.

--- a/docs/guides/branching-and-deployment.md
+++ b/docs/guides/branching-and-deployment.md
@@ -17,7 +17,7 @@ only through pull requests.
 
 | Environment | Branch | Cloud Run | Firestore |
 | --- | --- | --- | --- |
-| dev | `develop` | `cycle-api-dev` | `dev` |
+| dev | `develop` | `cycle-api-dev` | `dev-db` |
 | prod | `main` | `cycle-api-prod` | `(default)` |
 
 The GCP project remains `cycle-journal`. Project-level IAM, billing, quotas, and

--- a/infra/README.md
+++ b/infra/README.md
@@ -5,7 +5,7 @@ Terraform is split by directory and state:
 | Directory | State prefix | Owns |
 | --- | --- | --- |
 | `environments/shared` | `terraform/state/shared` | Project APIs, Artifact Registry |
-| `environments/dev` | `terraform/state/dev` | `cycle-api-dev`, Firestore `dev`, dev secrets/IAM |
+| `environments/dev` | `terraform/state/dev` | `cycle-api-dev`, Firestore `dev-db`, dev secrets/IAM |
 | `environments/prod` | `terraform/state/prod` | `cycle-api-prod`, Firestore `(default)`, prod secrets/IAM |
 
 The legacy root Terraform files are retained only as the source for the first

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -9,7 +9,7 @@ module "api" {
   project_id            = var.project_id
   region                = var.region
   environment           = "dev"
-  firestore_database_id = "dev"
+  firestore_database_id = "dev-db"
   apple_team_id         = var.apple_team_id
   apple_key_id          = var.apple_key_id
   apple_iap_issuer_id   = var.apple_iap_issuer_id

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -229,6 +229,8 @@ resource "google_cloud_run_v2_service" "api" {
 
   lifecycle {
     ignore_changes = [
+      client,
+      client_version,
       template[0].containers[0].image,
     ]
   }


### PR DESCRIPTION
## Summary
- change dev Firestore database ID from invalid `dev` to `dev-db`
- document the real dev DB name
- ignore Cloud Run `client` metadata drift after `gcloud run deploy`

## Verification
- `terraform fmt -recursive infra`
- `git diff --check`
- `CLOUDSDK_CONFIG=/private/tmp/cyclejournal-gcloud terraform -chdir=infra/environments/dev plan -no-color` -> no changes

Refs #58
