### PR TITLE
release: promote develop to main

### DIFF
--- a/.github/workflows/api-ci-cd.yml
+++ b/.github/workflows/api-ci-cd.yml
@@ -1,0 +1,123 @@
+name: API CI/CD
+
+on:
+  pull_request:
+    branches: [develop, main]
+    paths:
+      - api/**
+      - .github/workflows/api-ci-cd.yml
+  push:
+    branches: [develop, main]
+    paths:
+      - api/**
+      - .github/workflows/api-ci-cd.yml
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Deploy target"
+        required: true
+        type: choice
+        options:
+          - dev
+          - prod
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: api-${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  PROJECT_ID: cycle-journal
+  REGION: asia-northeast1
+  REPOSITORY: cycle-api
+
+jobs:
+  api-test:
+    name: API lint and test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: api
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --frozen --extra dev
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Test
+        run: uv run pytest
+
+  deploy:
+    name: Deploy API
+    needs: api-test
+    runs-on: ubuntu-latest
+    if: |
+      (github.event_name == 'push' && (github.ref_name == 'develop' || github.ref_name == 'main')) ||
+      github.event_name == 'workflow_dispatch'
+    environment: api-${{ github.event_name == 'workflow_dispatch' && inputs.environment || (github.ref_name == 'main' && 'prod' || 'dev') }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve target
+        id: target
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            target="${{ inputs.environment }}"
+          elif [[ "${{ github.ref_name }}" == "main" ]]; then
+            target="prod"
+          else
+            target="dev"
+          fi
+
+          echo "environment=${target}" >> "$GITHUB_OUTPUT"
+          echo "service=cycle-api-${target}" >> "$GITHUB_OUTPUT"
+          echo "image=${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/api:${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          echo "track_tag=${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPOSITORY}/api:${target}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker "${REGION}-docker.pkg.dev" --quiet
+
+      - name: Build image
+        run: |
+          docker build \
+            --tag "${{ steps.target.outputs.image }}" \
+            --tag "${{ steps.target.outputs.track_tag }}" \
+            api
+
+      - name: Push image
+        run: |
+          docker push "${{ steps.target.outputs.image }}"
+          docker push "${{ steps.target.outputs.track_tag }}"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy "${{ steps.target.outputs.service }}" \
+            --image "${{ steps.target.outputs.image }}" \
+            --region "${REGION}" \
+            --project "${PROJECT_ID}" \
+            --quiet

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,3 +20,5 @@
 - Do not use Terraform workspaces for environment switching.
 - Shared project-level resources live in `shared`; environment-specific Cloud Run,
   Secret Manager, IAM, and Firestore resources live in `dev` or `prod`.
+- Firestore named database IDs must be at least 4 characters. The dev database
+  is `dev-db`; production remains `(default)`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,22 @@
+# Cycle Journal Repository Rules
+
+## Branch Flow
+
+- Default branch: `develop`
+- Feature work: `feature/*` -> pull request -> `develop`
+- Release promotion: `develop` -> pull request -> `main`
+- Hotfix only: `fix/*` -> pull request -> `main`, then merge `main` back into `develop`
+- Do not push directly to `main`. Use pull requests for production changes.
+
+## Deployments
+
+- Push to `develop` deploys the API to `cycle-api-dev`.
+- Push to `main` deploys the API to `cycle-api-prod`.
+- Production approval is controlled by the GitHub Environment named `api-prod`.
+
+## Infrastructure
+
+- Use `infra/environments/shared`, `infra/environments/dev`, and `infra/environments/prod`.
+- Do not use Terraform workspaces for environment switching.
+- Shared project-level resources live in `shared`; environment-specific Cloud Run,
+  Secret Manager, IAM, and Firestore resources live in `dev` or `prod`.

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -57,6 +57,14 @@ class Settings(BaseSettings):
     ga4_api_secret: str = ""
     ga4_endpoint: str = "https://www.google-analytics.com/mp/collect"
 
+    # Apple Push Notification service (silent push for subscription state changes)
+    # - APNs auth key is separate from Sign in with Apple / IAP keys.
+    # - Empty credentials make APNs sending a no-op in local/test environments.
+    apple_apns_team_id: str = ""
+    apple_apns_key_id: str = ""
+    apple_apns_private_key: str = ""
+    apple_apns_env: str = "Sandbox"
+
     model_config = {"env_prefix": "", "case_sensitive": False}
 
 

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -7,6 +7,7 @@ class Settings(BaseSettings):
     environment: str = "dev"
     gcp_project_id: str = "cycle-journal"
     gcp_region: str = "asia-northeast1"
+    firestore_database_id: str = "(default)"
     apple_bundle_id: str = "com.akitoando.CycleJournal"
     google_client_id: str = ""  # iOS用Google OAuth Client ID
 

--- a/api/app/models/auth.py
+++ b/api/app/models/auth.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 
 class VerifyTokenRequest(BaseModel):
     identity_token: str
-    # iOS から `ASAuthorizationAppleIDCredential.authorizationCode` を base64/utf8 で送る。
+    # iOS から Apple の authorizationCode を base64/utf8 で送る。
     # 受け取った場合はサーバ側で Apple refresh_token に交換し、アカウント削除時の
     # revoke 用に保存する。任意フィールド（無くてもサインインは成立する）。
     authorization_code: str | None = None

--- a/api/app/models/common.py
+++ b/api/app/models/common.py
@@ -1,12 +1,12 @@
 """Common Pydantic models for API responses."""
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel
 
 
-class CycleElement(str, Enum):
+class CycleElement(StrEnum):
     soil = "soil"
     water = "water"
     root = "root"

--- a/api/app/routers/auth.py
+++ b/api/app/routers/auth.py
@@ -52,8 +52,8 @@ async def verify_token(
     apple_user_id = claims.get("sub", "")
     email = claims.get("email")
 
-    # authorization_code があれば Apple refresh_token に交換してユーザードキュメントに保存する。
-    # アカウント削除時に Apple 側で revoke するために必要（App Store ガイドライン 5.1.1(v)）。
+    # authorization_code があれば Apple refresh_token に交換して保存する。
+    # アカウント削除時の revoke に必要（App Store ガイドライン 5.1.1(v)）。
     # 失敗しても識別トークン検証自体は成功しているのでサインインは続行する。
     apple_refresh_token: str | None = None
     if body.authorization_code:
@@ -141,7 +141,10 @@ async def refresh(
     if not body.refresh_token:
         raise ValidationError("refresh_token is required")
 
-    access_token, new_refresh, expires_in = await rotate_refresh_token(db, body.refresh_token)
+    access_token, new_refresh, expires_in = await rotate_refresh_token(
+        db,
+        body.refresh_token,
+    )
 
     return {
         "data": RefreshTokenData(

--- a/api/app/routers/coach.py
+++ b/api/app/routers/coach.py
@@ -43,17 +43,23 @@ async def chat(
     # セッションが未作成の場合は作成
     session_snap = await session_doc.get()
     if not session_snap.exists:
-        cycle_element = body.context.cycle_element.value if body.context and body.context.cycle_element else None
-        await session_doc.set({
-            "user_id": user_id,
-            "title": None,
-            "cycle_element": cycle_element,
-            "has_diary_context": body.diary_content is not None,
-            "message_count": 0,
-            "last_message_at": now,
-            "created_at": now,
-            "updated_at": now,
-        })
+        cycle_element = (
+            body.context.cycle_element.value
+            if body.context and body.context.cycle_element
+            else None
+        )
+        await session_doc.set(
+            {
+                "user_id": user_id,
+                "title": None,
+                "cycle_element": cycle_element,
+                "has_diary_context": body.diary_content is not None,
+                "message_count": 0,
+                "last_message_at": now,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
 
     # 過去のメッセージ履歴を取得
     messages_ref = session_doc.collection("messages")

--- a/api/app/routers/iap.py
+++ b/api/app/routers/iap.py
@@ -2,12 +2,13 @@
 
 - POST /iap/apple/notifications  — App Store Server Notifications V2 受信口
 - POST /iap/apple/verify         — クライアント (StoreKit2) からの JWS 即時検証
+- POST /iap/apple/device-token   — silent push 用 APNs device token 登録
 
 Notification 処理ポリシー:
 - notificationUUID をドキュメント ID として iap_notifications コレクションに
   create() を試み、AlreadyExists なら冪等にスキップして 200 を返す。
 - 検証失敗 (JWS) は 400 を返し Apple のリトライ対象から外す。
-- 状態反映 (users/{uid}/subscription) はバックグラウンドタスクで実行し、
+- 状態反映 (users/{uid}/subscription)・GA4・silent push はバックグラウンドで実行し、
   Apple への ACK は即時 200 を返す (3〜5 秒以内の応答要件を満たすため)。
 
 ユーザー特定:
@@ -31,6 +32,9 @@ from google.cloud.firestore import SERVER_TIMESTAMP, AsyncClient
 from pydantic import BaseModel, Field
 
 from app.dependencies import get_current_user, get_firestore
+from app.services.analytics_service import send_event
+from app.services.apns_service import send_silent_push
+from app.services.iap_events import ga4_event_name, should_send_cancel_silent_push
 from app.services.iap_subscription import build_subscription_record
 from app.services.iap_verifier import get_verifier
 
@@ -57,14 +61,85 @@ async def _write_subscription_record(
     await doc.set({**record, "updated_at": SERVER_TIMESTAMP}, merge=True)
 
 
-async def _resolve_uid(db: AsyncClient, original_tx_id: str | None) -> str | None:
-    """originalTransactionId から uid を解決する (verify が記録した iap_links 経由)."""
+async def _get_iap_link(
+    db: AsyncClient,
+    original_tx_id: str | None,
+) -> dict[str, Any] | None:
+    """originalTransactionId から verify 時に保存したリンク情報を取得する."""
     if not original_tx_id:
         return None
     snap = await db.collection("iap_links").document(original_tx_id).get()
     if snap.exists:
-        return (snap.to_dict() or {}).get("uid")
+        return snap.to_dict() or {}
     return None
+
+
+async def _resolve_uid(db: AsyncClient, original_tx_id: str | None) -> str | None:
+    """originalTransactionId から uid を解決する (verify が記録した iap_links 経由)."""
+    link = await _get_iap_link(db, original_tx_id)
+    return link.get("uid") if link else None
+
+
+def _analytics_params(record: dict[str, Any], notification_uuid: str) -> dict[str, Any]:
+    return {
+        "product_id": record["product_id"],
+        "subscription_status": record["status"],
+        "is_active": record["is_active"],
+        "transaction_id": record["transaction_id"],
+        "original_transaction_id": record["original_transaction_id"],
+        "expires_date_ms": record["expires_date_ms"],
+        "notification_type": record["last_notification_type"],
+        "notification_subtype": record["last_subtype"],
+        "environment": record["environment"],
+    }
+
+
+async def _send_ga4_subscription_event(
+    *,
+    uid: str,
+    link: dict[str, Any] | None,
+    record: dict[str, Any],
+    payload: Any,
+) -> None:
+    event_name = ga4_event_name(
+        payload.notificationType,
+        payload.subtype,
+        record["status"],
+    )
+    if event_name is None:
+        return
+
+    client_id = (link or {}).get("ga4_client_id") or uid
+    await send_event(
+        client_id=client_id,
+        user_id=uid,
+        event_name=event_name,
+        params=_analytics_params(record, payload.notificationUUID),
+        event_id=payload.notificationUUID,
+    )
+
+
+async def _send_cancel_silent_pushes(
+    *,
+    db: AsyncClient,
+    uid: str,
+    record: dict[str, Any],
+) -> None:
+    token_collection = db.collection("users").document(uid).collection("apns_tokens")
+    async for snap in token_collection.stream():
+        token_data = snap.to_dict() or {}
+        token = token_data.get("device_token")
+        if not token:
+            continue
+        await send_silent_push(
+            device_token=token,
+            event="cancel_trial_notifications",
+            reason="subscription_auto_renew_disabled",
+            extra={
+                "product_id": record["product_id"],
+                "original_transaction_id": record["original_transaction_id"],
+            },
+        )
 
 
 @router.post("/apple/notifications", status_code=200)
@@ -110,7 +185,7 @@ async def _apply_notification(
     verifier: SignedDataVerifier,
     payload: Any,
 ) -> None:
-    """signedTransactionInfo をデコードして users/{uid}/subscription に状態反映する.
+    """ASSN transaction を反映し、GA4 / silent push の後続処理を実行する.
 
     - TEST 通知やトランザクションを伴わない通知は何もしない。
     - uid が未解決 (verify 未実行) の場合はスキップ。次回の verify で整合する。
@@ -123,7 +198,8 @@ async def _apply_notification(
             return
 
         txn = verifier.verify_and_decode_signed_transaction(signed_tx)
-        uid = await _resolve_uid(db, txn.originalTransactionId)
+        link = await _get_iap_link(db, txn.originalTransactionId)
+        uid = link.get("uid") if link else None
         if uid is None:
             return
 
@@ -134,6 +210,14 @@ async def _apply_notification(
             subtype=payload.subtype,
         )
         await _write_subscription_record(db, uid, record)
+        await _send_ga4_subscription_event(
+            uid=uid,
+            link=link,
+            record=record,
+            payload=payload,
+        )
+        if should_send_cancel_silent_push(payload.notificationType, payload.subtype):
+            await _send_cancel_silent_pushes(db=db, uid=uid, record=record)
     except Exception:  # noqa: BLE001 - background task, never raise to caller
         return
 
@@ -142,6 +226,7 @@ class VerifyRequest(BaseModel):
     """StoreKit2 の Transaction.jwsRepresentation を渡す."""
 
     jws_representation: str = Field(alias="jwsRepresentation")
+    ga4_client_id: str | None = Field(default=None, alias="ga4ClientId")
 
     model_config = {"populate_by_name": True}
 
@@ -168,8 +253,11 @@ async def apple_verify(
     if not original_tx_id:
         raise HTTPException(status_code=400, detail="missing originalTransactionId")
 
+    link_record: dict[str, Any] = {"uid": uid, "updated_at": SERVER_TIMESTAMP}
+    if req.ga4_client_id:
+        link_record["ga4_client_id"] = req.ga4_client_id
     await db.collection("iap_links").document(original_tx_id).set(
-        {"uid": uid, "updated_at": SERVER_TIMESTAMP},
+        link_record,
         merge=True,
     )
 
@@ -183,3 +271,40 @@ async def apple_verify(
         "productId": record["product_id"],
         "expiresDateMs": record["expires_date_ms"],
     }
+
+
+class DeviceTokenRequest(BaseModel):
+    """APNs device token registration for silent push."""
+
+    device_token: str = Field(alias="deviceToken", min_length=16, max_length=512)
+    environment: str | None = None
+
+    model_config = {"populate_by_name": True}
+
+
+@router.post("/apple/device-token", status_code=200)
+async def register_device_token(
+    req: DeviceTokenRequest,
+    uid: str = Depends(get_current_user),
+    db: AsyncClient = Depends(get_firestore),
+) -> dict[str, Any]:
+    """Register an APNs token used for subscription silent pushes."""
+    token = req.device_token.strip().replace(" ", "").lower()
+    if not token:
+        raise HTTPException(status_code=400, detail="missing deviceToken")
+
+    await (
+        db.collection("users")
+        .document(uid)
+        .collection("apns_tokens")
+        .document(token)
+        .set(
+            {
+                "device_token": token,
+                "environment": req.environment,
+                "updated_at": SERVER_TIMESTAMP,
+            },
+            merge=True,
+        )
+    )
+    return {"status": "registered"}

--- a/api/app/routers/iap.py
+++ b/api/app/routers/iap.py
@@ -9,10 +9,16 @@ Notification 処理ポリシー:
 - 検証失敗 (JWS) は 400 を返し Apple のリトライ対象から外す。
 - 状態反映 (users/{uid}/subscription) はバックグラウンドタスクで実行し、
   Apple への ACK は即時 200 を返す (3〜5 秒以内の応答要件を満たすため)。
+
+ユーザー特定:
+- iOS は購入後 jwsRepresentation を POST /iap/apple/verify に送る。verify は
+  認証済みなので uid が分かり、originalTransactionId → uid を iap_links に記録する。
+- webhook は originalTransactionId から iap_links を引いて uid を解決する。
 """
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from appstoreserverlibrary.signed_data_verifier import (
@@ -22,11 +28,43 @@ from appstoreserverlibrary.signed_data_verifier import (
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Request
 from google.api_core.exceptions import AlreadyExists
 from google.cloud.firestore import SERVER_TIMESTAMP, AsyncClient
+from pydantic import BaseModel, Field
 
-from app.dependencies import get_firestore
+from app.dependencies import get_current_user, get_firestore
+from app.services.iap_subscription import build_subscription_record
 from app.services.iap_verifier import get_verifier
 
 router = APIRouter(prefix="/iap", tags=["iap"])
+
+
+def _now_ms() -> int:
+    return int(time.time() * 1000)
+
+
+async def _write_subscription_record(
+    db: AsyncClient,
+    uid: str,
+    record: dict[str, Any],
+) -> None:
+    """users/{uid}/subscription/{originalTransactionId} を upsert する."""
+    original_tx_id = record["original_transaction_id"]
+    doc = (
+        db.collection("users")
+        .document(uid)
+        .collection("subscription")
+        .document(original_tx_id)
+    )
+    await doc.set({**record, "updated_at": SERVER_TIMESTAMP}, merge=True)
+
+
+async def _resolve_uid(db: AsyncClient, original_tx_id: str | None) -> str | None:
+    """originalTransactionId から uid を解決する (verify が記録した iap_links 経由)."""
+    if not original_tx_id:
+        return None
+    snap = await db.collection("iap_links").document(original_tx_id).get()
+    if snap.exists:
+        return (snap.to_dict() or {}).get("uid")
+    return None
 
 
 @router.post("/apple/notifications", status_code=200)
@@ -62,17 +100,86 @@ async def apple_notifications(
     except AlreadyExists:
         return {"status": "duplicate", "notificationUUID": notification_uuid}
 
-    # TODO(#37): バックグラウンドで users/{uid}/subscription を更新する
-    # (signedTransactionInfo / signedRenewalInfo をデコードして state machine 反映)
-    background_tasks.add_task(_noop_apply_notification, payload)
+    background_tasks.add_task(_apply_notification, db, verifier, payload)
 
     return {"status": "accepted", "notificationUUID": notification_uuid}
 
 
-async def _noop_apply_notification(payload: Any) -> None:
-    """状態反映ロジックの placeholder.
+async def _apply_notification(
+    db: AsyncClient,
+    verifier: SignedDataVerifier,
+    payload: Any,
+) -> None:
+    """signedTransactionInfo をデコードして users/{uid}/subscription に状態反映する.
 
-    後続 PR で signedTransactionInfo / signedRenewalInfo をデコードし
-    users/{uid}/subscription を更新する処理に差し替える。
+    - TEST 通知やトランザクションを伴わない通知は何もしない。
+    - uid が未解決 (verify 未実行) の場合はスキップ。次回の verify で整合する。
+    - バックグラウンド実行のため例外は握り潰す (Apple への ACK は既に返済み)。
     """
-    return None
+    try:
+        data = getattr(payload, "data", None)
+        signed_tx = getattr(data, "signedTransactionInfo", None) if data else None
+        if not signed_tx:
+            return
+
+        txn = verifier.verify_and_decode_signed_transaction(signed_tx)
+        uid = await _resolve_uid(db, txn.originalTransactionId)
+        if uid is None:
+            return
+
+        record = build_subscription_record(
+            txn,
+            now_ms=_now_ms(),
+            notification_type=payload.notificationType,
+            subtype=payload.subtype,
+        )
+        await _write_subscription_record(db, uid, record)
+    except Exception:  # noqa: BLE001 - background task, never raise to caller
+        return
+
+
+class VerifyRequest(BaseModel):
+    """StoreKit2 の Transaction.jwsRepresentation を渡す."""
+
+    jws_representation: str = Field(alias="jwsRepresentation")
+
+    model_config = {"populate_by_name": True}
+
+
+@router.post("/apple/verify", status_code=200)
+async def apple_verify(
+    req: VerifyRequest,
+    uid: str = Depends(get_current_user),
+    verifier: SignedDataVerifier = Depends(get_verifier),
+    db: AsyncClient = Depends(get_firestore),
+) -> dict[str, Any]:
+    """クライアント (StoreKit2) からの JWS 即時検証.
+
+    - jwsRepresentation を検証・デコード。
+    - originalTransactionId → uid を iap_links に記録 (webhook がこれで uid 解決)。
+    - users/{uid}/subscription にエンタイトルメントを反映し、状態を返す。
+    """
+    try:
+        txn = verifier.verify_and_decode_signed_transaction(req.jws_representation)
+    except VerificationException as exc:
+        raise HTTPException(status_code=400, detail=f"invalid signature: {exc}") from exc  # noqa: E501
+
+    original_tx_id = txn.originalTransactionId
+    if not original_tx_id:
+        raise HTTPException(status_code=400, detail="missing originalTransactionId")
+
+    await db.collection("iap_links").document(original_tx_id).set(
+        {"uid": uid, "updated_at": SERVER_TIMESTAMP},
+        merge=True,
+    )
+
+    record = build_subscription_record(txn, now_ms=_now_ms())
+    await _write_subscription_record(db, uid, record)
+
+    return {
+        "status": "verified",
+        "isActive": record["is_active"],
+        "subscriptionStatus": record["status"],
+        "productId": record["product_id"],
+        "expiresDateMs": record["expires_date_ms"],
+    }

--- a/api/app/services/apns_service.py
+++ b/api/app/services/apns_service.py
@@ -1,0 +1,71 @@
+"""Apple Push Notification service sender for silent subscription updates."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import httpx
+import jwt
+
+from app.config import settings
+
+
+def _apns_host() -> str:
+    env = settings.apple_apns_env.lower()
+    return "api.push.apple.com" if env == "production" else "api.sandbox.push.apple.com"
+
+
+def _build_provider_token() -> str | None:
+    if (
+        not settings.apple_apns_team_id
+        or not settings.apple_apns_key_id
+        or not settings.apple_apns_private_key
+    ):
+        return None
+    return jwt.encode(
+        {"iss": settings.apple_apns_team_id, "iat": int(time.time())},
+        settings.apple_apns_private_key,
+        algorithm="ES256",
+        headers={"kid": settings.apple_apns_key_id},
+    )
+
+
+async def send_silent_push(
+    *,
+    device_token: str,
+    event: str,
+    reason: str,
+    extra: dict[str, Any] | None = None,
+) -> bool:
+    """Send one APNs background notification.
+
+    Returns false for missing configuration or network/APNs errors so webhook handling
+    never fails because a best-effort push could not be delivered.
+    """
+    provider_token = _build_provider_token()
+    if provider_token is None:
+        return False
+
+    payload: dict[str, Any] = {
+        "aps": {"content-available": 1},
+        "cycle_event": event,
+        "reason": reason,
+    }
+    if extra:
+        payload.update(extra)
+
+    url = f"https://{_apns_host()}/3/device/{device_token}"
+    headers = {
+        "authorization": f"bearer {provider_token}",
+        "apns-topic": settings.apple_bundle_id,
+        "apns-push-type": "background",
+        "apns-priority": "5",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=5.0, http2=True) as client:
+            response = await client.post(url, json=payload, headers=headers)
+            return 200 <= response.status_code < 300
+    except httpx.HTTPError:
+        return False

--- a/api/app/services/firestore_client.py
+++ b/api/app/services/firestore_client.py
@@ -11,7 +11,10 @@ def get_db() -> AsyncClient:
     """Get or create Firestore async client."""
     global _db
     if _db is None:
-        _db = AsyncClient(project=settings.gcp_project_id)
+        _db = AsyncClient(
+            project=settings.gcp_project_id,
+            database=settings.firestore_database_id,
+        )
     return _db
 
 

--- a/api/app/services/iap_events.py
+++ b/api/app/services/iap_events.py
@@ -1,0 +1,58 @@
+"""ASSN V2 notification side-effect mapping for analytics and push."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.iap_subscription import normalize_enum
+
+
+def ga4_event_name(
+    notification_type: Any | None,
+    subtype: Any | None,
+    status: str,
+) -> str | None:
+    """Map App Store Server Notifications V2 to GA4 event names."""
+    nt = normalize_enum(notification_type)
+    st = normalize_enum(subtype)
+
+    if nt == "SUBSCRIBED":
+        return (
+            "subscription_trial_started"
+            if status == "trial"
+            else "subscription_started"
+        )
+    if nt == "DID_RENEW":
+        return "subscription_renewed"
+    if nt == "DID_CHANGE_RENEWAL_STATUS":
+        if st == "AUTO_RENEW_DISABLED":
+            return "subscription_cancelled"
+        if st == "AUTO_RENEW_ENABLED":
+            return "subscription_reactivated"
+    if nt in {"REFUND", "REVOKE", "REFUND_REVERSED"}:
+        return (
+            "subscription_refund_reversed"
+            if nt == "REFUND_REVERSED"
+            else "subscription_refunded"
+        )
+    if nt == "EXPIRED":
+        return (
+            "trial_expired_without_conversion"
+            if status == "expired"
+            else "subscription_expired"
+        )
+    if nt == "DID_FAIL_TO_RENEW":
+        return "subscription_billing_issue"
+    if nt == "GRACE_PERIOD_EXPIRED":
+        return "subscription_grace_period_expired"
+    return None
+
+
+def should_send_cancel_silent_push(
+    notification_type: Any | None,
+    subtype: Any | None,
+) -> bool:
+    """Return true when local trial notifications should be cancelled on device."""
+    nt = normalize_enum(notification_type)
+    st = normalize_enum(subtype)
+    return nt == "DID_CHANGE_RENEWAL_STATUS" and st == "AUTO_RENEW_DISABLED"

--- a/api/app/services/iap_subscription.py
+++ b/api/app/services/iap_subscription.py
@@ -1,0 +1,121 @@
+"""IAP サブスクリプション状態の組み立て (B1 verify / B2 ASSN webhook 共通).
+
+App Store の `JWSTransactionDecodedPayload` と ASSN の通知種別から、Firestore の
+`users/{uid}/subscription/{originalTransactionId}` に保存する状態レコードを構築する
+純関数を提供する。Firestore I/O は呼び出し側 (router) が担い、本モジュールは
+ライブラリ型と通知種別のみに依存させてユニットテスト可能にする。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def normalize_enum(value: Any) -> str | None:
+    """ライブラリの Enum (例 NotificationTypeV2.SUBSCRIBED) でも、テストで渡される
+    生文字列でも、一貫して "SUBSCRIBED" のような素の名前に正規化する。"""
+    if value is None:
+        return None
+    # str Enum は .value を持つ
+    inner = getattr(value, "value", None)
+    if isinstance(inner, str):
+        return inner
+    return str(value)
+
+
+def resolve_is_active(
+    *,
+    expires_date_ms: int | None,
+    revocation_date_ms: int | None,
+    now_ms: int,
+) -> bool:
+    """エンタイトルメントが有効かを判定する (権威的なシグナル).
+
+    返金/失効 (revocationDate あり) は無効。期限なし (買い切り等) は有効。
+    それ以外は expiresDate が現在時刻より未来なら有効。
+    """
+    if revocation_date_ms is not None:
+        return False
+    if expires_date_ms is None:
+        return True
+    return expires_date_ms > now_ms
+
+
+def resolve_status(
+    *,
+    is_active: bool,
+    notification_type: str | None,
+    subtype: str | None,
+    revocation_date_ms: int | None,
+    offer_type: Any | None,
+) -> str:
+    """ユーザー向けのサブスク状態ラベルを導出する.
+
+    isActive (権威判定) を補完する人間可読ステータス。
+    """
+    nt = normalize_enum(notification_type)
+    st = normalize_enum(subtype)
+
+    if revocation_date_ms is not None or nt in {"REFUND", "REVOKE"}:
+        return "revoked"
+    if not is_active:
+        return "expired"
+    if nt == "DID_FAIL_TO_RENEW":
+        # GRACE_PERIOD 中はアクセス維持、それ以外は請求リトライ
+        return "grace_period" if st == "GRACE_PERIOD" else "billing_retry"
+    if nt == "DID_CHANGE_RENEWAL_STATUS" and st == "AUTO_RENEW_DISABLED":
+        # 解約予約済みだが期限までは有効
+        return "cancelled"
+    # offerType=1 (INTRODUCTORY) は本アプリでは 7 日無料トライアルのみ
+    if normalize_enum(offer_type) in {"1", "INTRODUCTORY", "OfferType.INTRODUCTORY"}:
+        return "trial"
+    return "active"
+
+
+def build_subscription_record(
+    txn: Any,
+    *,
+    now_ms: int,
+    notification_type: Any | None = None,
+    subtype: Any | None = None,
+) -> dict[str, Any]:
+    """検証済みトランザクションから subscription レコード (dict) を構築する.
+
+    `updated_at` などの Firestore センチネルは含めない (呼び出し側で付与)。
+    """
+    expires = txn.expiresDate
+    revocation = txn.revocationDate
+    is_active = resolve_is_active(
+        expires_date_ms=expires,
+        revocation_date_ms=revocation,
+        now_ms=now_ms,
+    )
+    status = resolve_status(
+        is_active=is_active,
+        notification_type=notification_type,
+        subtype=subtype,
+        revocation_date_ms=revocation,
+        offer_type=getattr(txn, "offerType", None),
+    )
+
+    auto_renew: bool | None = None
+    st = normalize_enum(subtype)
+    if st == "AUTO_RENEW_DISABLED":
+        auto_renew = False
+    elif st == "AUTO_RENEW_ENABLED":
+        auto_renew = True
+
+    return {
+        "product_id": txn.productId,
+        "original_transaction_id": txn.originalTransactionId,
+        "transaction_id": txn.transactionId,
+        "is_active": is_active,
+        "status": status,
+        "expires_date_ms": expires,
+        "purchase_date_ms": txn.purchaseDate,
+        "revocation_date_ms": revocation,
+        "environment": normalize_enum(getattr(txn, "environment", None)),
+        "auto_renew": auto_renew,
+        "last_notification_type": normalize_enum(notification_type),
+        "last_subtype": st,
+    }

--- a/api/app/services/token_service.py
+++ b/api/app/services/token_service.py
@@ -35,7 +35,11 @@ def create_access_token(user_id: str, provider: Provider) -> tuple[str, int]:
         "iat": int(now.timestamp()),
         "exp": int(exp.timestamp()),
     }
-    token = pyjwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    token = pyjwt.encode(
+        payload,
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
     return token, int(expires_delta.total_seconds())
 
 
@@ -133,7 +137,7 @@ async def revoke_all_refresh_tokens_for_user(db: AsyncClient, user_id: str) -> i
 async def rotate_refresh_token(
     db: AsyncClient, old_token: str
 ) -> tuple[str, str, int]:
-    """Verify old refresh, revoke it, issue a new pair. Returns (access, refresh, access_expires_in)."""
+    """Verify old refresh, revoke it, and issue a new token pair."""
     user_id, provider = await verify_refresh_token(db, old_token)
     await revoke_refresh_token(db, old_token)
     access_token, expires_in = create_access_token(user_id, provider)

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "anthropic[vertex]>=0.42.0",
     "pyjwt[crypto]>=2.9.0",
     "httpx>=0.27.0",
+    "h2>=4.1.0",
     "langgraph>=0.2.0",
     "langchain-core>=0.3.0",
     "app-store-server-library>=1.5.0",

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -34,7 +34,7 @@ def _make_mock_firestore():
 
     async def empty_stream():
         return
-        yield  # noqa: unreachable - makes this an async generator
+        yield
 
     mock_sub_query = MagicMock()
     mock_sub_query.stream.return_value = empty_stream()
@@ -67,7 +67,11 @@ def mock_auth():
     with patch(
         "app.middleware.auth_middleware.verify_access_token",
     ) as mock:
-        mock.return_value = {"sub": "test-user-123", "provider": "apple", "type": "access"}
+        mock.return_value = {
+            "sub": "test-user-123",
+            "provider": "apple",
+            "type": "access",
+        }
         yield mock
 
 

--- a/api/tests/test_analytics_config.py
+++ b/api/tests/test_analytics_config.py
@@ -33,3 +33,14 @@ def test_ga4_overridable_via_env():
         settings = Settings()
         assert settings.ga4_measurement_id == "G-TEST123"
         assert settings.ga4_api_secret == "secret-xyz"
+
+
+def test_apns_config_exists():
+    """B5: APNs silent push 設定項目."""
+    from app.config import settings
+
+    assert hasattr(settings, "apple_apns_team_id")
+    assert hasattr(settings, "apple_apns_key_id")
+    assert hasattr(settings, "apple_apns_private_key")
+    assert hasattr(settings, "apple_apns_env")
+    assert settings.apple_apns_env == "Sandbox"

--- a/api/tests/test_apns_service.py
+++ b/api/tests/test_apns_service.py
@@ -1,0 +1,55 @@
+"""APNs silent push sender tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_send_silent_push_skips_when_not_configured():
+    from app.services import apns_service
+
+    with (
+        patch.object(apns_service.settings, "apple_apns_team_id", ""),
+        patch.object(apns_service.settings, "apple_apns_key_id", ""),
+        patch.object(apns_service.settings, "apple_apns_private_key", ""),
+        patch("app.services.apns_service.httpx.AsyncClient") as mock_client,
+    ):
+        sent = await apns_service.send_silent_push(
+            device_token="abcd",
+            event="cancel_trial_notifications",
+            reason="subscription_auto_renew_disabled",
+        )
+
+    assert sent is False
+    mock_client.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_send_silent_push_posts_background_payload():
+    from app.services import apns_service
+
+    mock_response = MagicMock(status_code=200)
+    mock_client = AsyncMock()
+    mock_client.post.return_value = mock_response
+    mock_context = AsyncMock()
+    mock_context.__aenter__.return_value = mock_client
+
+    with (
+        patch.object(apns_service.settings, "apple_apns_team_id", "TEAMID1234"),
+        patch.object(apns_service.settings, "apple_apns_key_id", "KEYID12345"),
+        patch.object(apns_service.settings, "apple_apns_private_key", "pem"),
+        patch.object(apns_service.jwt, "encode", return_value="provider-token"),
+        patch("app.services.apns_service.httpx.AsyncClient", return_value=mock_context),
+    ):
+        sent = await apns_service.send_silent_push(
+            device_token="abcd",
+            event="cancel_trial_notifications",
+            reason="subscription_auto_renew_disabled",
+        )
+
+    assert sent is True
+    _, kwargs = mock_client.post.call_args
+    assert kwargs["json"]["aps"] == {"content-available": 1}
+    assert kwargs["headers"]["apns-push-type"] == "background"
+    assert kwargs["headers"]["apns-priority"] == "5"

--- a/api/tests/test_config.py
+++ b/api/tests/test_config.py
@@ -32,3 +32,16 @@ def test_claude_model_quick_overridable_via_env():
     with patch.dict(os.environ, {"CLAUDE_MODEL_QUICK": "claude-haiku-test@99999999"}):
         settings = Settings()
         assert settings.claude_model_quick == "claude-haiku-test@99999999"
+
+
+def test_firestore_database_id_defaults_to_default_database():
+    """Firestore DB は既存本番データ互換のため (default) を既定にする."""
+    settings = Settings()
+    assert settings.firestore_database_id == "(default)"
+
+
+def test_firestore_database_id_overridable_via_env():
+    """dev/prod Cloud Run から FIRESTORE_DATABASE_ID で DB を分離できる."""
+    with patch.dict(os.environ, {"FIRESTORE_DATABASE_ID": "dev"}):
+        settings = Settings()
+        assert settings.firestore_database_id == "dev"

--- a/api/tests/test_firestore_client.py
+++ b/api/tests/test_firestore_client.py
@@ -1,0 +1,29 @@
+"""Firestore client tests."""
+
+from unittest.mock import patch
+
+from app.services import firestore_client
+
+
+def test_get_db_uses_configured_database_id():
+    """Firestore AsyncClient に database_id を渡して環境ごとの DB を使う."""
+    firestore_client._db = None
+    try:
+        with (
+            patch.object(
+                firestore_client.settings,
+                "gcp_project_id",
+                "cycle-journal-test",
+            ),
+            patch.object(firestore_client.settings, "firestore_database_id", "dev"),
+            patch.object(firestore_client, "AsyncClient") as async_client,
+        ):
+            db = firestore_client.get_db()
+
+        assert db == async_client.return_value
+        async_client.assert_called_once_with(
+            project="cycle-journal-test",
+            database="dev",
+        )
+    finally:
+        firestore_client._db = None

--- a/api/tests/test_iap_events.py
+++ b/api/tests/test_iap_events.py
@@ -1,0 +1,31 @@
+"""ASSN side-effect mapping tests for #37 B3/B5."""
+
+from app.services.iap_events import ga4_event_name, should_send_cancel_silent_push
+
+
+def test_ga4_event_name_maps_subscription_lifecycle():
+    assert ga4_event_name("SUBSCRIBED", None, "trial") == (
+        "subscription_trial_started"
+    )
+    assert ga4_event_name("DID_RENEW", None, "active") == "subscription_renewed"
+    assert (
+        ga4_event_name(
+            "DID_CHANGE_RENEWAL_STATUS",
+            "AUTO_RENEW_DISABLED",
+            "cancelled",
+        )
+        == "subscription_cancelled"
+    )
+    assert ga4_event_name("REFUND", None, "revoked") == "subscription_refunded"
+
+
+def test_cancel_silent_push_only_for_auto_renew_disabled():
+    assert should_send_cancel_silent_push(
+        "DID_CHANGE_RENEWAL_STATUS",
+        "AUTO_RENEW_DISABLED",
+    )
+    assert not should_send_cancel_silent_push(
+        "DID_CHANGE_RENEWAL_STATUS",
+        "AUTO_RENEW_ENABLED",
+    )
+    assert not should_send_cancel_silent_push("DID_RENEW", None)

--- a/api/tests/test_iap_router.py
+++ b/api/tests/test_iap_router.py
@@ -7,6 +7,7 @@ library 本体 (SignedDataVerifier) はモック化、Firestore も既存 confte
 の mock を流用する。
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -112,3 +113,116 @@ def test_apple_notifications_is_idempotent(iap_client, mock_firestore):
     assert response.status_code == 200
     body = response.json()
     assert body.get("status") == "duplicate"
+
+
+# ---------------------------------------------------------------------------
+# B1: POST /iap/apple/verify
+# ---------------------------------------------------------------------------
+
+# endpoint は実時刻 (time.time()) を使うため、実 now より十分未来の固定値を使う
+NOW_MS = 1_700_000_000_000
+FUTURE_MS = 4_102_444_800_000  # 2100-01-01 頃
+
+
+def _make_txn(
+    original_tx_id: str | None = "2000000000000001",
+    expires: int | None = FUTURE_MS,
+    revocation: int | None = None,
+):
+    """JWSTransactionDecodedPayload 風のモック."""
+    return SimpleNamespace(
+        productId="com.akitoando.CycleJournal.yearly_14400",
+        originalTransactionId=original_tx_id,
+        transactionId="2000000000000002",
+        expiresDate=expires,
+        purchaseDate=NOW_MS - 1000,
+        revocationDate=revocation,
+        environment="Sandbox",
+        offerType=None,
+    )
+
+
+@pytest.fixture
+def iap_auth_client(mock_firestore):
+    """get_current_user も差し替えた認証済みクライアント."""
+    from app.dependencies import get_current_user, get_firestore
+    from app.main import app
+    from app.services.iap_verifier import get_verifier
+
+    verifier = MagicMock()
+    app.dependency_overrides[get_firestore] = lambda: mock_firestore
+    app.dependency_overrides[get_verifier] = lambda: verifier
+    app.dependency_overrides[get_current_user] = lambda: "user-abc"
+    yield TestClient(app), verifier, mock_firestore
+    app.dependency_overrides.clear()
+
+
+def test_verify_records_link_and_subscription(iap_auth_client):
+    """B1: 正常な jws で 200・iap_links と users/{uid}/subscription を書き込む."""
+    client, verifier, mock_firestore = iap_auth_client
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+
+    response = client.post(
+        "/iap/apple/verify",
+        json={"jwsRepresentation": "valid-jws"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "verified"
+    assert body["isActive"] is True
+    assert body["subscriptionStatus"] == "active"
+    mock_firestore.collection.assert_any_call("iap_links")
+    mock_firestore.collection.assert_any_call("users")
+
+
+def test_verify_rejects_invalid_signature(iap_auth_client):
+    """B1: JWS 検証失敗は 400."""
+    from appstoreserverlibrary.signed_data_verifier import (
+        VerificationException,
+        VerificationStatus,
+    )
+
+    client, verifier, _ = iap_auth_client
+    verifier.verify_and_decode_signed_transaction.side_effect = VerificationException(
+        VerificationStatus.INVALID_CERTIFICATE
+    )
+
+    response = client.post(
+        "/iap/apple/verify",
+        json={"jwsRepresentation": "bad-jws"},
+    )
+    assert response.status_code == 400
+
+
+def test_verify_rejects_missing_original_transaction_id(iap_auth_client):
+    """B1: originalTransactionId が無い場合は 400."""
+    client, verifier, _ = iap_auth_client
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn(
+        original_tx_id=None
+    )
+
+    response = client.post(
+        "/iap/apple/verify",
+        json={"jwsRepresentation": "jws-no-otid"},
+    )
+    assert response.status_code == 400
+
+
+def test_notification_applies_when_uid_resolved(iap_client, mock_firestore):
+    """B2: iap_links に uid があれば webhook が subscription を更新する."""
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_type="DID_RENEW", notification_uuid="uuid-apply"
+    )
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {"uid": "user-xyz"}
+
+    response = client.post(
+        "/iap/apple/notifications",
+        json={"signedPayload": "valid-jws"},
+    )
+
+    assert response.status_code == 200
+    mock_firestore.collection.assert_any_call("users")

--- a/api/tests/test_iap_router.py
+++ b/api/tests/test_iap_router.py
@@ -18,11 +18,12 @@ def _make_decoded_payload(
     notification_type: str = "SUBSCRIBED",
     notification_uuid: str = "uuid-1",
     environment: str = "Sandbox",
+    subtype: str | None = None,
 ):
     """ResponseBodyV2DecodedPayload 風のモックを返す."""
     payload = MagicMock()
     payload.notificationType = notification_type
-    payload.subtype = None
+    payload.subtype = subtype
     payload.notificationUUID = notification_uuid
     payload.signedDate = 1700000000000
     data = MagicMock()
@@ -225,4 +226,84 @@ def test_notification_applies_when_uid_resolved(iap_client, mock_firestore):
     )
 
     assert response.status_code == 200
+    mock_firestore.collection.assert_any_call("users")
+
+
+def test_notification_sends_ga4_event_when_uid_resolved(iap_client, mock_firestore):
+    """B3: ASSN 反映後に notificationUUID を event_id として GA4 に送る."""
+    from unittest.mock import patch
+
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_type="DID_RENEW", notification_uuid="uuid-ga4"
+    )
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {
+        "uid": "user-ga4",
+        "ga4_client_id": "client-123",
+    }
+
+    with patch("app.routers.iap.send_event", new_callable=AsyncMock) as send_event:
+        response = client.post(
+            "/iap/apple/notifications",
+            json={"signedPayload": "valid-jws"},
+        )
+
+    assert response.status_code == 200
+    send_event.assert_awaited_once()
+    kwargs = send_event.await_args.kwargs
+    assert kwargs["client_id"] == "client-123"
+    assert kwargs["user_id"] == "user-ga4"
+    assert kwargs["event_name"] == "subscription_renewed"
+    assert kwargs["event_id"] == "uuid-ga4"
+    assert kwargs["params"]["product_id"].endswith("yearly_14400")
+
+
+def test_notification_sends_cancel_silent_push(iap_client, mock_firestore):
+    """B5: 解約予約 ASSN で登録済み端末へ silent push を送る."""
+    from unittest.mock import patch
+
+    async def token_stream():
+        snap = MagicMock()
+        snap.to_dict.return_value = {"device_token": "abcd1234"}
+        yield snap
+
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_type="DID_CHANGE_RENEWAL_STATUS",
+        subtype="AUTO_RENEW_DISABLED",
+        notification_uuid="uuid-cancel",
+    )
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {"uid": "user-cancel"}
+    mock_firestore._mock_subcollection.stream.return_value = token_stream()
+
+    with (
+        patch("app.routers.iap.send_event", new_callable=AsyncMock),
+        patch("app.routers.iap.send_silent_push", new_callable=AsyncMock) as send_push,
+    ):
+        response = client.post(
+            "/iap/apple/notifications",
+            json={"signedPayload": "valid-jws"},
+        )
+
+    assert response.status_code == 200
+    send_push.assert_awaited_once()
+    assert send_push.await_args.kwargs["device_token"] == "abcd1234"
+    assert send_push.await_args.kwargs["event"] == "cancel_trial_notifications"
+
+
+def test_register_device_token(iap_auth_client, mock_firestore):
+    """B5: 認証済みユーザーの APNs token を保存する."""
+    client, _, _ = iap_auth_client
+
+    response = client.post(
+        "/iap/apple/device-token",
+        json={"deviceToken": "ABCDEF1234567890", "environment": "Sandbox"},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "registered"
     mock_firestore.collection.assert_any_call("users")

--- a/api/tests/test_iap_subscription.py
+++ b/api/tests/test_iap_subscription.py
@@ -1,0 +1,109 @@
+"""build_subscription_record / 状態導出ロジックのユニットテスト (B1/B2 共通)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.services.iap_subscription import (
+    build_subscription_record,
+    normalize_enum,
+    resolve_is_active,
+)
+
+NOW = 1_700_000_000_000  # 固定の現在時刻 (ms)
+FUTURE = NOW + 7 * 24 * 60 * 60 * 1000
+PAST = NOW - 1000
+
+
+def _txn(**overrides):
+    base = dict(
+        productId="com.akitoando.CycleJournal.yearly_14400",
+        originalTransactionId="2000000000000001",
+        transactionId="2000000000000002",
+        expiresDate=FUTURE,
+        purchaseDate=NOW - 1000,
+        revocationDate=None,
+        environment="Sandbox",
+        offerType=None,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_normalize_enum_handles_enum_and_str():
+    assert normalize_enum("SUBSCRIBED") == "SUBSCRIBED"
+    assert normalize_enum(SimpleNamespace(value="DID_RENEW")) == "DID_RENEW"
+    assert normalize_enum(None) is None
+
+
+def test_resolve_is_active_rules():
+    assert resolve_is_active(
+        expires_date_ms=FUTURE, revocation_date_ms=None, now_ms=NOW
+    )
+    assert not resolve_is_active(
+        expires_date_ms=PAST, revocation_date_ms=None, now_ms=NOW
+    )
+    # 返金/失効は期限が未来でも無効
+    assert not resolve_is_active(
+        expires_date_ms=FUTURE, revocation_date_ms=NOW, now_ms=NOW
+    )
+    # 期限なし (買い切り) は有効
+    assert resolve_is_active(
+        expires_date_ms=None, revocation_date_ms=None, now_ms=NOW
+    )
+
+
+def test_active_subscription():
+    rec = build_subscription_record(_txn(), now_ms=NOW, notification_type="DID_RENEW")
+    assert rec["is_active"] is True
+    assert rec["status"] == "active"
+    assert rec["product_id"].endswith("yearly_14400")
+    assert rec["original_transaction_id"] == "2000000000000001"
+
+
+def test_trial_subscription_from_offer_type():
+    rec = build_subscription_record(
+        _txn(offerType="INTRODUCTORY"), now_ms=NOW, notification_type="SUBSCRIBED"
+    )
+    assert rec["is_active"] is True
+    assert rec["status"] == "trial"
+
+
+def test_expired_subscription():
+    rec = build_subscription_record(
+        _txn(expiresDate=PAST), now_ms=NOW, notification_type="EXPIRED"
+    )
+    assert rec["is_active"] is False
+    assert rec["status"] == "expired"
+
+
+def test_revoked_subscription():
+    rec = build_subscription_record(
+        _txn(revocationDate=NOW), now_ms=NOW, notification_type="REFUND"
+    )
+    assert rec["is_active"] is False
+    assert rec["status"] == "revoked"
+
+
+def test_cancelled_but_still_active():
+    """解約予約 (AUTO_RENEW_DISABLED) でも期限までは有効・status=cancelled."""
+    rec = build_subscription_record(
+        _txn(),
+        now_ms=NOW,
+        notification_type="DID_CHANGE_RENEWAL_STATUS",
+        subtype="AUTO_RENEW_DISABLED",
+    )
+    assert rec["is_active"] is True
+    assert rec["status"] == "cancelled"
+    assert rec["auto_renew"] is False
+
+
+def test_grace_period_keeps_access():
+    rec = build_subscription_record(
+        _txn(),
+        now_ms=NOW,
+        notification_type="DID_FAIL_TO_RENEW",
+        subtype="GRACE_PERIOD",
+    )
+    assert rec["is_active"] is True
+    assert rec["status"] == "grace_period"

--- a/api/tests/test_token_service.py
+++ b/api/tests/test_token_service.py
@@ -34,7 +34,11 @@ def test_access_token_rejects_non_access_type():
         "iss": settings.jwt_issuer,
         "exp": 9999999999,
     }
-    token = pyjwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    token = pyjwt.encode(
+        payload,
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
     with pytest.raises(InvalidTokenError):
         token_service.verify_access_token(token)
 
@@ -51,7 +55,11 @@ def test_access_token_expiry(monkeypatch):
         "iss": settings.jwt_issuer,
         "exp": 1,
     }
-    token = pyjwt.encode(payload, settings.jwt_secret_key, algorithm=settings.jwt_algorithm)
+    token = pyjwt.encode(
+        payload,
+        settings.jwt_secret_key,
+        algorithm=settings.jwt_algorithm,
+    )
     with pytest.raises(TokenExpiredError):
         token_service.verify_access_token(token)
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -45,6 +45,7 @@ export default defineConfig({
         items: [
           { text: 'Getting Started', link: '/guides/getting-started' },
           { text: '開発規約', link: '/guides/conventions' },
+          { text: 'ブランチ・デプロイ運用', link: '/guides/branching-and-deployment' },
           { text: 'App Storeリリース', link: '/guides/app-store-release' },
           {
             text: '#37 デプロイメントセットアップ',

--- a/docs/guides/branching-and-deployment.md
+++ b/docs/guides/branching-and-deployment.md
@@ -17,7 +17,7 @@ only through pull requests.
 
 | Environment | Branch | Cloud Run | Firestore |
 | --- | --- | --- | --- |
-| dev | `develop` | `cycle-api-dev` | `dev` |
+| dev | `develop` | `cycle-api-dev` | `dev-db` |
 | prod | `main` | `cycle-api-prod` | `(default)` |
 
 The GCP project remains `cycle-journal`. Project-level IAM, billing, quotas, and

--- a/docs/guides/branching-and-deployment.md
+++ b/docs/guides/branching-and-deployment.md
@@ -1,0 +1,58 @@
+# Branching and Deployment
+
+## Branch Strategy
+
+Cycle Journal uses a GitLab Flow style environment branch model.
+
+| Flow | Target |
+| --- | --- |
+| `feature/*` -> PR -> `develop` | Integration and dev deploy |
+| `develop` -> PR -> `main` | Production release |
+| `fix/*` -> PR -> `main` -> merge back to `develop` | Production hotfix |
+
+`develop` is the default branch. `main` is production and must receive changes
+only through pull requests.
+
+## Environments
+
+| Environment | Branch | Cloud Run | Firestore |
+| --- | --- | --- | --- |
+| dev | `develop` | `cycle-api-dev` | `dev` |
+| prod | `main` | `cycle-api-prod` | `(default)` |
+
+The GCP project remains `cycle-journal`. Project-level IAM, billing, quotas, and
+Artifact Registry are shared.
+
+## CI/CD
+
+`.github/workflows/api-ci-cd.yml` runs API lint and tests on pull requests to
+`develop` or `main`.
+
+On push:
+
+- `develop` builds and deploys the API image to `cycle-api-dev`.
+- `main` builds and deploys the API image to `cycle-api-prod`.
+
+The workflow expects these GitHub secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `GCP_WORKLOAD_IDENTITY_PROVIDER` | Workload Identity Federation provider |
+| `GCP_SERVICE_ACCOUNT` | Deploy service account email |
+
+Use GitHub Environments:
+
+- `api-dev`: no approval gate
+- `api-prod`: require reviewer approval before production deploy
+
+## Terraform
+
+Use directory-per-environment Terraform:
+
+```bash
+terraform -chdir=infra/environments/shared plan
+terraform -chdir=infra/environments/dev plan
+terraform -chdir=infra/environments/prod plan
+```
+
+Do not switch environments with Terraform workspaces.

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,81 @@
+# Cycle Journal Infrastructure
+
+Terraform is split by directory and state:
+
+| Directory | State prefix | Owns |
+| --- | --- | --- |
+| `environments/shared` | `terraform/state/shared` | Project APIs, Artifact Registry |
+| `environments/dev` | `terraform/state/dev` | `cycle-api-dev`, Firestore `dev`, dev secrets/IAM |
+| `environments/prod` | `terraform/state/prod` | `cycle-api-prod`, Firestore `(default)`, prod secrets/IAM |
+
+The legacy root Terraform files are retained only as the source for the first
+state migration. Do not run regular plans from `infra/`; use one of the
+`infra/environments/*` directories instead.
+
+## Commands
+
+```bash
+terraform -chdir=infra/environments/shared init
+terraform -chdir=infra/environments/shared plan
+
+terraform -chdir=infra/environments/dev init
+terraform -chdir=infra/environments/dev plan
+
+terraform -chdir=infra/environments/prod init
+terraform -chdir=infra/environments/prod plan
+```
+
+## State Migration Outline
+
+Do the migration before removing the legacy root state from operation.
+
+1. Back up the current state:
+
+   ```bash
+   terraform -chdir=infra workspace select prod
+   terraform -chdir=infra state pull > infra-state-prod-backup.json
+   ```
+
+2. Move shared resources into `environments/shared` state:
+
+   ```bash
+   terraform -chdir=infra/environments/shared init
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_artifact_registry_repository.api' \
+     'projects/cycle-journal/locations/asia-northeast1/repositories/cycle-api'
+
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["run.googleapis.com"]' \
+     'cycle-journal/run.googleapis.com'
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["firestore.googleapis.com"]' \
+     'cycle-journal/firestore.googleapis.com'
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["artifactregistry.googleapis.com"]' \
+     'cycle-journal/artifactregistry.googleapis.com'
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["secretmanager.googleapis.com"]' \
+     'cycle-journal/secretmanager.googleapis.com'
+   terraform -chdir=infra/environments/shared import \
+     'module.shared.google_project_service.apis["aiplatform.googleapis.com"]' \
+     'cycle-journal/aiplatform.googleapis.com'
+   ```
+
+3. Move existing production resources into `environments/prod` state with
+   `terraform import` or `terraform state mv -state-out`. Keep Firestore
+   `(default)` in prod; do not create a new prod database.
+
+4. Create the dev environment from the new directory:
+
+   ```bash
+   terraform -chdir=infra/environments/dev init
+   terraform -chdir=infra/environments/dev plan
+   terraform -chdir=infra/environments/dev apply
+   ```
+
+5. Confirm both environment plans show no unintended destroy:
+
+   ```bash
+   terraform -chdir=infra/environments/prod plan
+   terraform -chdir=infra/environments/dev plan
+   ```

--- a/infra/README.md
+++ b/infra/README.md
@@ -5,7 +5,7 @@ Terraform is split by directory and state:
 | Directory | State prefix | Owns |
 | --- | --- | --- |
 | `environments/shared` | `terraform/state/shared` | Project APIs, Artifact Registry |
-| `environments/dev` | `terraform/state/dev` | `cycle-api-dev`, Firestore `dev`, dev secrets/IAM |
+| `environments/dev` | `terraform/state/dev` | `cycle-api-dev`, Firestore `dev-db`, dev secrets/IAM |
 | `environments/prod` | `terraform/state/prod` | `cycle-api-prod`, Firestore `(default)`, prod secrets/IAM |
 
 The legacy root Terraform files are retained only as the source for the first

--- a/infra/environments/dev/.terraform.lock.hcl
+++ b/infra/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.5"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -12,7 +12,9 @@ module "api" {
   firestore_database_id = "dev"
   apple_team_id         = var.apple_team_id
   apple_key_id          = var.apple_key_id
+  apple_apns_key_id     = var.apple_apns_key_id
   apple_iap_issuer_id   = var.apple_iap_issuer_id
   apple_iap_key_id      = var.apple_iap_key_id
   apple_iap_env         = "Sandbox"
+  apple_apns_env        = "Sandbox"
 }

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -9,7 +9,7 @@ module "api" {
   project_id            = var.project_id
   region                = var.region
   environment           = "dev"
-  firestore_database_id = "dev"
+  firestore_database_id = "dev-db"
   apple_team_id         = var.apple_team_id
   apple_key_id          = var.apple_key_id
   apple_iap_issuer_id   = var.apple_iap_issuer_id

--- a/infra/environments/dev/main.tf
+++ b/infra/environments/dev/main.tf
@@ -1,0 +1,18 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "api" {
+  source = "../../modules/api"
+
+  project_id            = var.project_id
+  region                = var.region
+  environment           = "dev"
+  firestore_database_id = "dev"
+  apple_team_id         = var.apple_team_id
+  apple_key_id          = var.apple_key_id
+  apple_iap_issuer_id   = var.apple_iap_issuer_id
+  apple_iap_key_id      = var.apple_iap_key_id
+  apple_iap_env         = "Sandbox"
+}

--- a/infra/environments/dev/outputs.tf
+++ b/infra/environments/dev/outputs.tf
@@ -1,0 +1,14 @@
+output "cloud_run_url" {
+  description = "Cloud Run service URL"
+  value       = module.api.cloud_run_url
+}
+
+output "service_account_email" {
+  description = "Cloud Run service account email"
+  value       = module.api.service_account_email
+}
+
+output "firestore_database_id" {
+  description = "Firestore database ID"
+  value       = module.api.firestore_database_id
+}

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -1,0 +1,8 @@
+project_id    = "cycle-journal"
+region        = "asia-northeast1"
+apple_team_id = "AXSR25N22T"
+apple_key_id  = "TXTX42VXG4"
+
+# IAP 専用キー (Sign in with Apple とは別物)
+apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
+apple_iap_key_id    = "7W562GZ399"

--- a/infra/environments/dev/terraform.tfvars
+++ b/infra/environments/dev/terraform.tfvars
@@ -6,3 +6,6 @@ apple_key_id  = "TXTX42VXG4"
 # IAP 専用キー (Sign in with Apple とは別物)
 apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
 apple_iap_key_id    = "7W562GZ399"
+
+# APNs Auth Key ID. Empty keeps silent push disabled until the key is issued.
+apple_apns_key_id = ""

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -28,3 +28,10 @@ variable "apple_iap_key_id" {
   description = "App Store Connect IAP Key ID"
   type        = string
 }
+
+
+variable "apple_apns_key_id" {
+  description = "Apple Push Notification service Auth Key ID. Empty disables APNs sending."
+  type        = string
+  default     = ""
+}

--- a/infra/environments/dev/variables.tf
+++ b/infra/environments/dev/variables.tf
@@ -1,0 +1,30 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "apple_team_id" {
+  description = "Apple Developer Team ID"
+  type        = string
+}
+
+variable "apple_key_id" {
+  description = "Apple Sign in with Apple Key ID"
+  type        = string
+}
+
+variable "apple_iap_issuer_id" {
+  description = "App Store Connect IAP Key Issuer ID"
+  type        = string
+}
+
+variable "apple_iap_key_id" {
+  description = "App Store Connect IAP Key ID"
+  type        = string
+}

--- a/infra/environments/dev/versions.tf
+++ b/infra/environments/dev/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "cycle-journal-tfstate"
+    prefix = "terraform/state/dev"
+  }
+}

--- a/infra/environments/prod/.terraform.lock.hcl
+++ b/infra/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,43 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.5"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -12,7 +12,9 @@ module "api" {
   firestore_database_id = "(default)"
   apple_team_id         = var.apple_team_id
   apple_key_id          = var.apple_key_id
+  apple_apns_key_id     = var.apple_apns_key_id
   apple_iap_issuer_id   = var.apple_iap_issuer_id
   apple_iap_key_id      = var.apple_iap_key_id
   apple_iap_env         = "Sandbox" # テスト完了後 "Production" に変更
+  apple_apns_env        = "Production"
 }

--- a/infra/environments/prod/main.tf
+++ b/infra/environments/prod/main.tf
@@ -1,0 +1,18 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "api" {
+  source = "../../modules/api"
+
+  project_id            = var.project_id
+  region                = var.region
+  environment           = "prod"
+  firestore_database_id = "(default)"
+  apple_team_id         = var.apple_team_id
+  apple_key_id          = var.apple_key_id
+  apple_iap_issuer_id   = var.apple_iap_issuer_id
+  apple_iap_key_id      = var.apple_iap_key_id
+  apple_iap_env         = "Sandbox" # テスト完了後 "Production" に変更
+}

--- a/infra/environments/prod/outputs.tf
+++ b/infra/environments/prod/outputs.tf
@@ -1,0 +1,14 @@
+output "cloud_run_url" {
+  description = "Cloud Run service URL"
+  value       = module.api.cloud_run_url
+}
+
+output "service_account_email" {
+  description = "Cloud Run service account email"
+  value       = module.api.service_account_email
+}
+
+output "firestore_database_id" {
+  description = "Firestore database ID"
+  value       = module.api.firestore_database_id
+}

--- a/infra/environments/prod/terraform.tfvars
+++ b/infra/environments/prod/terraform.tfvars
@@ -6,3 +6,6 @@ apple_key_id  = "TXTX42VXG4"
 # IAP 専用キー (Sign in with Apple とは別物。issuer/key id は環境共通)
 apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
 apple_iap_key_id    = "7W562GZ399"
+
+# APNs Auth Key ID. Empty keeps silent push disabled until the key is issued.
+apple_apns_key_id = ""

--- a/infra/environments/prod/terraform.tfvars
+++ b/infra/environments/prod/terraform.tfvars
@@ -1,0 +1,8 @@
+project_id    = "cycle-journal"
+region        = "asia-northeast1"
+apple_team_id = "AXSR25N22T"
+apple_key_id  = "TXTX42VXG4"
+
+# IAP 専用キー (Sign in with Apple とは別物。issuer/key id は環境共通)
+apple_iap_issuer_id = "c7bb6896-6c4c-42cf-b6aa-29ed753a86bf"
+apple_iap_key_id    = "7W562GZ399"

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -28,3 +28,10 @@ variable "apple_iap_key_id" {
   description = "App Store Connect IAP Key ID"
   type        = string
 }
+
+
+variable "apple_apns_key_id" {
+  description = "Apple Push Notification service Auth Key ID. Empty disables APNs sending."
+  type        = string
+  default     = ""
+}

--- a/infra/environments/prod/variables.tf
+++ b/infra/environments/prod/variables.tf
@@ -1,0 +1,30 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "apple_team_id" {
+  description = "Apple Developer Team ID"
+  type        = string
+}
+
+variable "apple_key_id" {
+  description = "Apple Sign in with Apple Key ID"
+  type        = string
+}
+
+variable "apple_iap_issuer_id" {
+  description = "App Store Connect IAP Key Issuer ID"
+  type        = string
+}
+
+variable "apple_iap_key_id" {
+  description = "App Store Connect IAP Key ID"
+  type        = string
+}

--- a/infra/environments/prod/versions.tf
+++ b/infra/environments/prod/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.5"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "cycle-journal-tfstate"
+    prefix = "terraform/state/prod"
+  }
+}

--- a/infra/environments/shared/.terraform.lock.hcl
+++ b/infra/environments/shared/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "5.45.2"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:iy2Q9VcnMu4z/bH3v/NmI/nEpgYY7bXgJmT/hVTAUS4=",
+    "zh:0d09c8f20b556305192cdbe0efa6d333ceebba963a8ba91f9f1714b5a20c4b7a",
+    "zh:117143fc91be407874568df416b938a6896f94cb873f26bba279cedab646a804",
+    "zh:16ccf77d18dd2c5ef9c0625f9cf546ebdf3213c0a452f432204c69feed55081e",
+    "zh:3e555cf22a570a4bd247964671f421ed7517970cd9765ceb46f335edc2c6f392",
+    "zh:688bd5b05a75124da7ae6e885b2b92bd29f4261808b2b78bd5f51f525c1052ca",
+    "zh:6db3ef37a05010d82900bfffb3261c59a0c247e0692049cb3eb8c2ef16c9d7bf",
+    "zh:70316fde75f6a15d72749f66d994ccbdde5f5ed4311b6d06b99850f698c9bbf9",
+    "zh:84b8e583771a4f2bd514e519d98ed7fd28dce5efe0634e973170e1cfb5556fb4",
+    "zh:9d4b8ef0a9b6677935c604d94495042e68ff5489932cfd1ec41052e094a279d3",
+    "zh:a2089dd9bd825c107b148dd12d6b286f71aa37dfd4ca9c35157f2dcba7bc19d8",
+    "zh:f03d795c0fd9721e59839255ee7ba7414173017dc530b4ce566daf3802a0d6dd",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/infra/environments/shared/main.tf
+++ b/infra/environments/shared/main.tf
@@ -1,0 +1,11 @@
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "shared" {
+  source = "../../modules/shared"
+
+  project_id = var.project_id
+  region     = var.region
+}

--- a/infra/environments/shared/outputs.tf
+++ b/infra/environments/shared/outputs.tf
@@ -1,0 +1,4 @@
+output "artifact_registry_repo" {
+  description = "Artifact Registry repository path"
+  value       = module.shared.artifact_registry_repo
+}

--- a/infra/environments/shared/terraform.tfvars
+++ b/infra/environments/shared/terraform.tfvars
@@ -1,0 +1,2 @@
+project_id = "cycle-journal"
+region     = "asia-northeast1"

--- a/infra/environments/shared/variables.tf
+++ b/infra/environments/shared/variables.tf
@@ -1,0 +1,10 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}

--- a/infra/environments/shared/versions.tf
+++ b/infra/environments/shared/versions.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "gcs" {
+    bucket = "cycle-journal-tfstate"
+    prefix = "terraform/state/shared"
+  }
+}

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -1,0 +1,250 @@
+locals {
+  api_image = "${var.region}-docker.pkg.dev/${var.project_id}/${var.artifact_registry_repository_id}/api:${var.image_tag}"
+}
+
+resource "google_service_account" "cloud_run" {
+  account_id   = "cycle-api-${var.environment}"
+  display_name = "CycleJournal API (${var.environment})"
+  project      = var.project_id
+}
+
+resource "google_project_iam_member" "firestore" {
+  project = var.project_id
+  role    = "roles/datastore.user"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_project_iam_member" "secret_manager" {
+  project = var.project_id
+  role    = "roles/secretmanager.secretAccessor"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_project_iam_member" "vertex_ai" {
+  project = var.project_id
+  role    = "roles/aiplatform.user"
+  member  = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_secret_manager_secret" "apple_auth" {
+  secret_id = "apple-auth-config-${var.environment}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "apple_iap_private_key" {
+  secret_id = "apple-iap-private-key-${var.environment}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "google_secret_manager_secret" "jwt_secret" {
+  secret_id = "jwt-secret-${var.environment}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
+resource "random_password" "jwt_secret" {
+  length  = 64
+  special = false
+}
+
+resource "google_secret_manager_secret_version" "jwt_secret" {
+  secret      = google_secret_manager_secret.jwt_secret.id
+  secret_data = random_password.jwt_secret.result
+}
+
+resource "google_firestore_database" "main" {
+  project     = var.project_id
+  name        = var.firestore_database_id
+  location_id = var.region
+  type        = "FIRESTORE_NATIVE"
+
+  deletion_policy = var.firestore_deletion_policy
+}
+
+resource "google_firestore_index" "sessions_by_created_at" {
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "sessions"
+
+  fields {
+    field_path = "user_id"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+resource "google_firestore_index" "tasks_by_status" {
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "tasks"
+
+  fields {
+    field_path = "user_id"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "status"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+resource "google_cloud_run_v2_service" "api" {
+  name     = "cycle-api-${var.environment}"
+  location = var.region
+
+  template {
+    service_account = google_service_account.cloud_run.email
+
+    scaling {
+      min_instance_count = 0
+      max_instance_count = 2
+    }
+
+    containers {
+      image = local.api_image
+
+      ports {
+        container_port = 8080
+      }
+
+      resources {
+        limits = {
+          cpu    = "1"
+          memory = "512Mi"
+        }
+      }
+
+      env {
+        name  = "ENVIRONMENT"
+        value = var.environment
+      }
+
+      env {
+        name  = "GCP_PROJECT_ID"
+        value = var.project_id
+      }
+
+      env {
+        name  = "GCP_REGION"
+        value = var.region
+      }
+
+      env {
+        name  = "FIRESTORE_DATABASE_ID"
+        value = var.firestore_database_id
+      }
+
+      env {
+        name  = "APPLE_BUNDLE_ID"
+        value = var.apple_bundle_id
+      }
+
+      env {
+        name  = "APPLE_TEAM_ID"
+        value = var.apple_team_id
+      }
+
+      env {
+        name  = "APPLE_KEY_ID"
+        value = var.apple_key_id
+      }
+
+      env {
+        name = "APPLE_PRIVATE_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.apple_auth.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "APPLE_IAP_ISSUER_ID"
+        value = var.apple_iap_issuer_id
+      }
+
+      env {
+        name  = "APPLE_IAP_KEY_ID"
+        value = var.apple_iap_key_id
+      }
+
+      env {
+        name = "APPLE_IAP_PRIVATE_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.apple_iap_private_key.secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name  = "APPLE_IAP_ENV"
+        value = var.apple_iap_env
+      }
+
+      env {
+        name  = "USE_LANGGRAPH"
+        value = var.use_langgraph ? "true" : "false"
+      }
+
+      env {
+        name  = "GOOGLE_CLIENT_ID"
+        value = var.google_client_id
+      }
+
+      env {
+        name = "JWT_SECRET_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = google_secret_manager_secret.jwt_secret.secret_id
+            version = "latest"
+          }
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      template[0].containers[0].image,
+    ]
+  }
+
+  depends_on = [
+    google_firestore_database.main,
+    google_secret_manager_secret_version.jwt_secret,
+    google_secret_manager_secret.apple_auth,
+    google_secret_manager_secret.apple_iap_private_key,
+  ]
+}
+
+resource "google_cloud_run_v2_service_iam_member" "public" {
+  project  = var.project_id
+  location = var.region
+  name     = google_cloud_run_v2_service.api.name
+  role     = "roles/run.invoker"
+  member   = "allUsers"
+}

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -229,6 +229,8 @@ resource "google_cloud_run_v2_service" "api" {
 
   lifecycle {
     ignore_changes = [
+      client,
+      client_version,
       template[0].containers[0].image,
     ]
   }

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -44,6 +44,15 @@ resource "google_secret_manager_secret" "apple_iap_private_key" {
   }
 }
 
+resource "google_secret_manager_secret" "apple_apns_private_key" {
+  secret_id = "apple-apns-private-key-${var.environment}"
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+}
+
 resource "google_secret_manager_secret" "jwt_secret" {
   secret_id = "jwt-secret-${var.environment}"
   project   = var.project_id
@@ -181,6 +190,35 @@ resource "google_cloud_run_v2_service" "api" {
       }
 
       env {
+        name  = "APPLE_APNS_TEAM_ID"
+        value = var.apple_team_id
+      }
+
+      env {
+        name  = "APPLE_APNS_KEY_ID"
+        value = var.apple_apns_key_id
+      }
+
+      dynamic "env" {
+        for_each = var.apple_apns_key_id == "" ? [] : [1]
+
+        content {
+          name = "APPLE_APNS_PRIVATE_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.apple_apns_private_key.secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+
+      env {
+        name  = "APPLE_APNS_ENV"
+        value = var.apple_apns_env
+      }
+
+      env {
         name  = "APPLE_IAP_ISSUER_ID"
         value = var.apple_iap_issuer_id
       }
@@ -238,6 +276,7 @@ resource "google_cloud_run_v2_service" "api" {
     google_secret_manager_secret_version.jwt_secret,
     google_secret_manager_secret.apple_auth,
     google_secret_manager_secret.apple_iap_private_key,
+    google_secret_manager_secret.apple_apns_private_key,
   ]
 }
 

--- a/infra/modules/api/outputs.tf
+++ b/infra/modules/api/outputs.tf
@@ -1,0 +1,14 @@
+output "cloud_run_url" {
+  description = "Cloud Run service URL"
+  value       = google_cloud_run_v2_service.api.uri
+}
+
+output "service_account_email" {
+  description = "Cloud Run service account email"
+  value       = google_service_account.cloud_run.email
+}
+
+output "firestore_database_id" {
+  description = "Firestore database ID used by this environment"
+  value       = google_firestore_database.main.name
+}

--- a/infra/modules/api/variables.tf
+++ b/infra/modules/api/variables.tf
@@ -75,6 +75,23 @@ variable "apple_key_id" {
   type        = string
 }
 
+variable "apple_apns_key_id" {
+  description = "Apple Push Notification service Auth Key ID. Empty disables APNs sending."
+  type        = string
+  default     = ""
+}
+
+variable "apple_apns_env" {
+  description = "APNs environment: Sandbox or Production"
+  type        = string
+  default     = "Sandbox"
+
+  validation {
+    condition     = contains(["Sandbox", "Production"], var.apple_apns_env)
+    error_message = "apple_apns_env must be Sandbox or Production."
+  }
+}
+
 variable "apple_iap_issuer_id" {
   description = "App Store Connect IAP Key Issuer ID"
   type        = string

--- a/infra/modules/api/variables.tf
+++ b/infra/modules/api/variables.tf
@@ -1,0 +1,97 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "environment" {
+  description = "Environment name (dev / prod)"
+  type        = string
+
+  validation {
+    condition     = contains(["dev", "prod"], var.environment)
+    error_message = "environment must be dev or prod."
+  }
+}
+
+variable "firestore_database_id" {
+  description = "Firestore database ID used by the API"
+  type        = string
+}
+
+variable "firestore_deletion_policy" {
+  description = "Deletion behavior for Firestore databases when Terraform destroys the resource"
+  type        = string
+  default     = "ABANDON"
+
+  validation {
+    condition     = contains(["ABANDON", "DELETE"], var.firestore_deletion_policy)
+    error_message = "firestore_deletion_policy must be ABANDON or DELETE."
+  }
+}
+
+variable "artifact_registry_repository_id" {
+  description = "Artifact Registry repository ID for API Docker images"
+  type        = string
+  default     = "cycle-api"
+}
+
+variable "image_tag" {
+  description = "Initial Docker image tag. CD owns later image updates."
+  type        = string
+  default     = "latest"
+}
+
+variable "use_langgraph" {
+  description = "Enable LangGraph coaching flow"
+  type        = bool
+  default     = false
+}
+
+variable "google_client_id" {
+  description = "Google OAuth Client ID for iOS Sign-In"
+  type        = string
+  default     = "1031235624127-6fgcbv1khltu4snpktpdd0cab025coab.apps.googleusercontent.com"
+}
+
+variable "apple_bundle_id" {
+  description = "Apple app bundle ID"
+  type        = string
+  default     = "com.akitoando.CycleJournal"
+}
+
+variable "apple_team_id" {
+  description = "Apple Developer Team ID"
+  type        = string
+}
+
+variable "apple_key_id" {
+  description = "Apple Sign in with Apple Key ID"
+  type        = string
+}
+
+variable "apple_iap_issuer_id" {
+  description = "App Store Connect IAP Key Issuer ID"
+  type        = string
+}
+
+variable "apple_iap_key_id" {
+  description = "App Store Connect IAP Key ID"
+  type        = string
+}
+
+variable "apple_iap_env" {
+  description = "IAP verification Apple environment: Sandbox or Production"
+  type        = string
+  default     = "Sandbox"
+
+  validation {
+    condition     = contains(["Sandbox", "Production"], var.apple_iap_env)
+    error_message = "apple_iap_env must be Sandbox or Production."
+  }
+}

--- a/infra/modules/shared/main.tf
+++ b/infra/modules/shared/main.tf
@@ -1,0 +1,26 @@
+locals {
+  project_services = toset([
+    "run.googleapis.com",
+    "firestore.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "secretmanager.googleapis.com",
+    "aiplatform.googleapis.com",
+  ])
+}
+
+resource "google_project_service" "apis" {
+  for_each = local.project_services
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_artifact_registry_repository" "api" {
+  location      = var.region
+  repository_id = var.artifact_registry_repository_id
+  format        = "DOCKER"
+  description   = "CycleJournal API Docker images"
+
+  depends_on = [google_project_service.apis]
+}

--- a/infra/modules/shared/outputs.tf
+++ b/infra/modules/shared/outputs.tf
@@ -1,0 +1,9 @@
+output "artifact_registry_repository_id" {
+  description = "Artifact Registry repository ID"
+  value       = google_artifact_registry_repository.api.repository_id
+}
+
+output "artifact_registry_repo" {
+  description = "Artifact Registry repository path"
+  value       = "${var.region}-docker.pkg.dev/${var.project_id}/${google_artifact_registry_repository.api.repository_id}"
+}

--- a/infra/modules/shared/variables.tf
+++ b/infra/modules/shared/variables.tf
@@ -1,0 +1,16 @@
+variable "project_id" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP region"
+  type        = string
+  default     = "asia-northeast1"
+}
+
+variable "artifact_registry_repository_id" {
+  description = "Artifact Registry repository ID for API Docker images"
+  type        = string
+  default     = "cycle-api"
+}

--- a/ios/Cycle.xcodeproj/project.pbxproj
+++ b/ios/Cycle.xcodeproj/project.pbxproj
@@ -410,6 +410,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2E0FCB402EBF930000B9081E /* Local.xcconfig */;
 			buildSettings = {
+				APS_ENVIRONMENT = development;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Cycle/Cycle.entitlements;
@@ -420,6 +421,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = "remote-notification";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -443,6 +445,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2E0FCB402EBF930000B9081E /* Local.xcconfig */;
 			buildSettings = {
+				APS_ENVIRONMENT = production;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Cycle/Cycle.entitlements;
@@ -453,6 +456,7 @@
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = "remote-notification";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";

--- a/ios/Cycle.xcodeproj/xcshareddata/xcschemes/Cycle.xcscheme
+++ b/ios/Cycle.xcodeproj/xcshareddata/xcschemes/Cycle.xcscheme
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "2E0FCB112EBF921700B9081E"
+               BuildableName = "Cycle.app"
+               BlueprintName = "Cycle"
+               ReferencedContainer = "container:Cycle.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <StoreKitConfigurationFileReference
+         identifier = "Cycle/Configuration.storekit">
+      </StoreKitConfigurationFileReference>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2E0FCB112EBF921700B9081E"
+            BuildableName = "Cycle.app"
+            BlueprintName = "Cycle"
+            ReferencedContainer = "container:Cycle.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "2E0FCB112EBF921700B9081E"
+            BuildableName = "Cycle.app"
+            BlueprintName = "Cycle"
+            ReferencedContainer = "container:Cycle.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/ios/Cycle/App/CycleApp.swift
+++ b/ios/Cycle/App/CycleApp.swift
@@ -16,7 +16,35 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
         UNUserNotificationCenter.current().delegate = self
+        application.registerForRemoteNotifications()
         return true
+    }
+
+    func application(
+        _ application: UIApplication,
+        didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data
+    ) {
+        let token = deviceToken.map { String(format: "%02x", $0) }.joined()
+        APNsDeviceTokenRegistry.save(token)
+        Task {
+            try? await SubscriptionService().registerAPNsDeviceToken(token)
+        }
+    }
+
+    func application(
+        _ application: UIApplication,
+        didReceiveRemoteNotification userInfo: [AnyHashable: Any],
+        fetchCompletionHandler completionHandler: @escaping (UIBackgroundFetchResult) -> Void
+    ) {
+        guard userInfo["cycle_event"] as? String == "cancel_trial_notifications" else {
+            completionHandler(.noData)
+            return
+        }
+
+        Task { @MainActor in
+            TrialNotificationScheduler.shared.cancelAllTrialNotifications()
+            completionHandler(.newData)
+        }
     }
 
     /// フォアグラウンドで通知を受信した場合にバナーとサウンドで表示

--- a/ios/Cycle/Cycle.entitlements
+++ b/ios/Cycle/Cycle.entitlements
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>aps-environment</key>
+	<string>$(APS_ENVIRONMENT)</string>
 	<key>com.apple.developer.applesignin</key>
 	<array>
 		<string>Default</string>

--- a/ios/Cycle/Features/Auth/Store/AuthStore.swift
+++ b/ios/Cycle/Features/Auth/Store/AuthStore.swift
@@ -280,6 +280,7 @@ class AuthStore: NSObject, ObservableObject {
 
         currentUser = user
         APIClient.shared.setAuthToken(accessToken)
+        Task { await SubscriptionService().registerStoredAPNsDeviceTokenIfAvailable() }
         state = .authenticated(userId: user.userId)
     }
 
@@ -313,6 +314,7 @@ class AuthStore: NSObject, ObservableObject {
         saveUserToKeychain(user)
         deleteFromKeychain(key: legacyTokenKey)
         APIClient.shared.setAuthToken(accessToken)
+        Task { await SubscriptionService().registerStoredAPNsDeviceTokenIfAvailable() }
     }
 
     private func clearLocalAuth() {

--- a/ios/Cycle/Features/Onboarding/Store/OnboardingFlow.swift
+++ b/ios/Cycle/Features/Onboarding/Store/OnboardingFlow.swift
@@ -67,6 +67,7 @@ final class OnboardingFlow: ObservableObject {
 
     func selectGoal(_ goal: OnboardingGoal) {
         selectedGoal = goal
+        UserDefaults.standard.set(goal.rawValue, forKey: "userGoal")
     }
 
     func setFirstJournalText(_ text: String) {

--- a/ios/Cycle/Features/Subscription/Store/SubscriptionStore.swift
+++ b/ios/Cycle/Features/Subscription/Store/SubscriptionStore.swift
@@ -84,6 +84,7 @@ final class SubscriptionStore: ObservableObject {
             switch verification {
             case .verified(let transaction):
                 await refreshEntitlements()
+                await applyTrialNotificationSideEffects(for: transaction)
                 await transaction.finish()
                 return verification.jwsRepresentation
             case .unverified:
@@ -104,8 +105,42 @@ final class SubscriptionStore: ObservableObject {
         for await result in Transaction.updates {
             guard case .verified(let transaction) = result else { continue }
             await refreshEntitlements()
+            await applyTrialNotificationSideEffects(for: transaction)
             await transaction.finish()
         }
+    }
+
+    // MARK: - Trial notification side effects
+
+    private func applyTrialNotificationSideEffects(for transaction: Transaction) async {
+        let scheduler = TrialNotificationScheduler.shared
+
+        if transaction.revocationDate != nil {
+            scheduler.cancelAllTrialNotifications()
+            return
+        }
+
+        if let expirationDate = transaction.expirationDate, expirationDate < Date() {
+            scheduler.cancelAllTrialNotifications()
+            return
+        }
+
+        guard transaction.offerType == .introductory else {
+            scheduler.cancelAllTrialNotifications()
+            return
+        }
+
+        await scheduler.scheduleTrialNotifications(
+            purchaseDate: transaction.purchaseDate,
+            goal: Self.storedOnboardingGoal()
+        )
+    }
+
+    private static func storedOnboardingGoal() -> OnboardingGoal? {
+        guard let rawValue = UserDefaults.standard.string(forKey: "userGoal") else {
+            return nil
+        }
+        return OnboardingGoal(rawValue: rawValue)
     }
 }
 

--- a/ios/Cycle/Services/SubscriptionService.swift
+++ b/ios/Cycle/Services/SubscriptionService.swift
@@ -1,0 +1,62 @@
+//
+//  SubscriptionService.swift
+//  CycleJournal
+//
+//  Backend integration for subscription verification and silent-push token sync.
+//
+
+import Foundation
+
+struct IAPDeviceTokenRequest: Encodable {
+    let deviceToken: String
+    let environment: String
+}
+
+struct IAPDeviceTokenResponse: Decodable {
+    let status: String
+}
+
+enum APNsDeviceTokenRegistry {
+    private static let key = "apnsDeviceToken"
+
+    static func save(_ token: String) {
+        UserDefaults.standard.set(token, forKey: key)
+    }
+
+    static var currentToken: String? {
+        UserDefaults.standard.string(forKey: key)
+    }
+}
+
+final class SubscriptionService {
+    private let apiClient: APIClient
+
+    init(apiClient: APIClient = .shared) {
+        self.apiClient = apiClient
+    }
+
+    func registerAPNsDeviceToken(_ token: String) async throws {
+        let request = IAPDeviceTokenRequest(
+            deviceToken: token,
+            environment: Self.apnsEnvironment
+        )
+        let _: IAPDeviceTokenResponse = try await apiClient.post(
+            path: "/iap/apple/device-token",
+            body: request,
+            requiresAuth: true
+        )
+    }
+
+    func registerStoredAPNsDeviceTokenIfAvailable() async {
+        guard let token = APNsDeviceTokenRegistry.currentToken else { return }
+        try? await registerAPNsDeviceToken(token)
+    }
+
+    private static var apnsEnvironment: String {
+        #if DEBUG
+        return "Sandbox"
+        #else
+        return "Production"
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary
- promote #59 and #65 to production
- enable API CD on `main` and deploy current API image to `cycle-api-prod`
- include dev/prod infrastructure split and Firestore DB separation work for #58

Refs #58
