### PR TITLE
feat: #37 GA4 に Trial→Paid 転換イベントを追加 (B3 追従)

### DIFF
--- a/api/app/routers/iap.py
+++ b/api/app/routers/iap.py
@@ -94,17 +94,37 @@ def _analytics_params(record: dict[str, Any], notification_uuid: str) -> dict[st
     }
 
 
+async def _read_prior_status(
+    db: AsyncClient,
+    uid: str,
+    original_tx_id: str,
+) -> str | None:
+    """書き込み前の subscription status を読む (Trial→Paid 転換検出用)."""
+    snap = (
+        await db.collection("users")
+        .document(uid)
+        .collection("subscription")
+        .document(original_tx_id)
+        .get()
+    )
+    if snap.exists:
+        return (snap.to_dict() or {}).get("status")
+    return None
+
+
 async def _send_ga4_subscription_event(
     *,
     uid: str,
     link: dict[str, Any] | None,
     record: dict[str, Any],
     payload: Any,
+    prior_status: str | None = None,
 ) -> None:
     event_name = ga4_event_name(
         payload.notificationType,
         payload.subtype,
         record["status"],
+        prior_status,
     )
     if event_name is None:
         return
@@ -203,6 +223,9 @@ async def _apply_notification(
         if uid is None:
             return
 
+        # 書き込みで上書きする前に直前 status を読む (転換検出のため)
+        prior_status = await _read_prior_status(db, uid, txn.originalTransactionId)
+
         record = build_subscription_record(
             txn,
             now_ms=_now_ms(),
@@ -215,6 +238,7 @@ async def _apply_notification(
             link=link,
             record=record,
             payload=payload,
+            prior_status=prior_status,
         )
         if should_send_cancel_silent_push(payload.notificationType, payload.subtype):
             await _send_cancel_silent_pushes(db=db, uid=uid, record=record)

--- a/api/app/services/iap_events.py
+++ b/api/app/services/iap_events.py
@@ -11,8 +11,14 @@ def ga4_event_name(
     notification_type: Any | None,
     subtype: Any | None,
     status: str,
+    prior_status: str | None = None,
 ) -> str | None:
-    """Map App Store Server Notifications V2 to GA4 event names."""
+    """Map App Store Server Notifications V2 to GA4 event names.
+
+    `prior_status` は直前に保存していた subscription status。トライアル起点の
+    遷移 (Trial→Paid 転換 / トライアルのまま失効) を区別するために使う。
+    #37 の主要 KPI「Trial→Paid 転換率」計測に必要。
+    """
     nt = normalize_enum(notification_type)
     st = normalize_enum(subtype)
 
@@ -23,7 +29,12 @@ def ga4_event_name(
             else "subscription_started"
         )
     if nt == "DID_RENEW":
-        return "subscription_renewed"
+        # トライアル中の初回更新 = 課金転換 (KPI の肝)
+        return (
+            "trial_converted_to_paid"
+            if prior_status == "trial"
+            else "subscription_renewed"
+        )
     if nt == "DID_CHANGE_RENEWAL_STATUS":
         if st == "AUTO_RENEW_DISABLED":
             return "subscription_cancelled"
@@ -36,9 +47,10 @@ def ga4_event_name(
             else "subscription_refunded"
         )
     if nt == "EXPIRED":
+        # トライアルのまま失効したか、課金後に失効したかを直前状態で区別する
         return (
             "trial_expired_without_conversion"
-            if status == "expired"
+            if prior_status == "trial"
             else "subscription_expired"
         )
     if nt == "DID_FAIL_TO_RENEW":

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -30,6 +30,7 @@ def _make_mock_firestore():
     mock_sub_doc = MagicMock()
     mock_sub_doc.set = AsyncMock()
     mock_sub_doc.delete = AsyncMock()
+    mock_sub_doc.get = AsyncMock(return_value=mock_snapshot)
     mock_subcollection.document.return_value = mock_sub_doc
 
     async def empty_stream():

--- a/api/tests/test_iap_events.py
+++ b/api/tests/test_iap_events.py
@@ -19,6 +19,32 @@ def test_ga4_event_name_maps_subscription_lifecycle():
     assert ga4_event_name("REFUND", None, "revoked") == "subscription_refunded"
 
 
+def test_ga4_event_name_distinguishes_trial_conversion():
+    """#37 KPI: トライアル中の更新は転換、それ以外の更新は通常更新."""
+    assert (
+        ga4_event_name("DID_RENEW", None, "active", "trial")
+        == "trial_converted_to_paid"
+    )
+    assert (
+        ga4_event_name("DID_RENEW", None, "active", "active")
+        == "subscription_renewed"
+    )
+    # prior_status 省略時 (後方互換) は通常更新
+    assert ga4_event_name("DID_RENEW", None, "active") == "subscription_renewed"
+
+
+def test_ga4_event_name_expired_uses_prior_status():
+    """EXPIRED はトライアルのまま失効か課金後失効かを直前状態で区別."""
+    assert (
+        ga4_event_name("EXPIRED", None, "expired", "trial")
+        == "trial_expired_without_conversion"
+    )
+    assert (
+        ga4_event_name("EXPIRED", None, "expired", "active")
+        == "subscription_expired"
+    )
+
+
 def test_cancel_silent_push_only_for_auto_renew_disabled():
     assert should_send_cancel_silent_push(
         "DID_CHANGE_RENEWAL_STATUS",

--- a/api/tests/test_iap_router.py
+++ b/api/tests/test_iap_router.py
@@ -260,6 +260,34 @@ def test_notification_sends_ga4_event_when_uid_resolved(iap_client, mock_firesto
     assert kwargs["params"]["product_id"].endswith("yearly_14400")
 
 
+def test_notification_detects_trial_conversion(iap_client, mock_firestore):
+    """B3+: 直前が trial の DID_RENEW は trial_converted_to_paid として送る."""
+    from unittest.mock import patch
+
+    client, verifier = iap_client
+    verifier.verify_and_decode_notification.return_value = _make_decoded_payload(
+        notification_type="DID_RENEW", notification_uuid="uuid-conv"
+    )
+    verifier.verify_and_decode_signed_transaction.return_value = _make_txn()
+    # iap_links と直前 subscription doc は同じモック snapshot を返すため、
+    # uid と status=trial の両方を持たせる
+    mock_firestore._mock_snapshot.exists = True
+    mock_firestore._mock_snapshot.to_dict.return_value = {
+        "uid": "user-conv",
+        "status": "trial",
+    }
+
+    with patch("app.routers.iap.send_event", new_callable=AsyncMock) as send_event:
+        response = client.post(
+            "/iap/apple/notifications",
+            json={"signedPayload": "valid-jws"},
+        )
+
+    assert response.status_code == 200
+    send_event.assert_awaited_once()
+    assert send_event.await_args.kwargs["event_name"] == "trial_converted_to_paid"
+
+
 def test_notification_sends_cancel_silent_push(iap_client, mock_firestore):
     """B5: 解約予約 ASSN で登録済み端末へ silent push を送る."""
     from unittest.mock import patch


### PR DESCRIPTION
## 概要

協力者が develop に実装した B3/B5 (`iap_events.py`) に、**#37 の主要 KPI「Trial→Paid 転換率 25%」計測に不可欠な転換検出**を最小差分で追加する追従 PR。

（経緯: 私の B3 PR #64 と協力者の B3/B5 が並行実装で衝突。広くカバーする協力者版を正とし、不足していた転換検出のみを足す形に切替。#64 はクローズ済み。）

## 変更内容

- `ga4_event_name` に `prior_status` 引数（**デフォルト None・後方互換**）を追加：
  - `DID_RENEW` (prior=`trial`) → **`trial_converted_to_paid`** / それ以外 → `subscription_renewed`
  - `EXPIRED` を `prior_status=="trial"` 基準に修正
    - ※ 旧実装は `status=="expired"` 判定で、EXPIRED 時の record.status は常に `expired` のため**常に `trial_expired_without_conversion` を返すバグ**だった。これを修正し通常失効と区別
- `iap.py`: 書き込みで上書きする前に直前 status を読み（`_read_prior_status`）GA4 に渡す
- `conftest.py`: サブコレクション doc モックに `get()` を追加（転換検出の読取に必要・追加のみ）

## テスト

- iap 24 / 全 83 pass、変更ファイル ruff clean
- 追加: `trial_converted_to_paid` / EXPIRED prior 区別の純関数テスト + webhook 結合テスト
- **既存の B3/B5 テストは後方互換で全て不変のままパス**

## 効果

これで GA4 ファネル「`subscription_trial_started` → `trial_converted_to_paid`」で **Trial→Paid 転換率**が集計可能に（GA4 secret 投入・#58 本番再デプロイ後に実データ計測）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)