### PR TITLE
chore: Playwright で ASC を自動操作する ops 基盤

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,10 @@
         "JAVA_HOME": "/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home",
         "PATH": "/opt/homebrew/opt/openjdk/libexec/openjdk.jdk/Contents/Home/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
       }
+    },
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
     }
   }
 }

--- a/scripts/ops/.env.example
+++ b/scripts/ops/.env.example
@@ -1,0 +1,12 @@
+# App Store Connect
+ASC_APPLE_ID=you@example.com
+ASC_TEAM_ID=XXXXXXXXXX
+ASC_APP_ID=0000000000
+
+# IAP product IDs (must match Configuration.storekit / SubscriptionProduct.swift)
+ASC_PRODUCT_ID_MONTHLY=com.akitoando.CycleJournal.monthly_1800
+ASC_PRODUCT_ID_YEARLY=com.akitoando.CycleJournal.yearly_14400
+
+# Playwright behavior
+HEADLESS=false
+SLOW_MO=0

--- a/scripts/ops/.gitignore
+++ b/scripts/ops/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.auth/
+.inspect/
+.env
+.env.local
+test-results/
+playwright-report/
+*.log

--- a/scripts/ops/README.md
+++ b/scripts/ops/README.md
@@ -1,0 +1,59 @@
+# cycle-journal-ops
+
+App Store Connect / Firebase / GA4 などの Web 管理画面操作を Playwright で自動化するためのスクリプト群。Claude が「クリックを伴う運用作業」まで担保できるようにする。
+
+## 想定読者
+
+- 課金リリース・KPI 計測まわりで Web コンソール作業が残っているとき
+- Claude（または自分）が再現可能な手順で ASC / Firebase / GA4 を操作したいとき
+
+## セットアップ（初回のみ）
+
+```sh
+cd scripts/ops
+npm install
+npx playwright install chromium
+
+cp .env.example .env
+# .env を編集して ASC_APPLE_ID / ASC_APP_ID などを入れる
+```
+
+## ログイン（最初の1回 + 期限切れ時）
+
+```sh
+npm run asc:login
+```
+
+ブラウザが立ち上がるので、画面で Apple ID / パスワード / 2FA を入力。Apps 一覧が表示された状態で、ターミナルで Enter を押すと `.auth/asc.json` に Cookie + localStorage が保存される。
+
+```sh
+# 期限切れ確認 (失敗したら再 login)
+npm run asc:status
+```
+
+## 課金まわりの作業
+
+### 月額に 3日 Introductory Offer を設定（#54 方針反映）
+
+```sh
+npm run asc:set-intro-offer
+```
+
+### 年額をフェーズ1中は Removed from Sale
+
+```sh
+npm run asc:remove-from-sale
+```
+
+## 設計メモ
+
+- 認証 state は `.auth/` にローカル保存（`.gitignore` 済み）
+- ASC の DOM はラベル依存。UI 変更で壊れたらスクリーンショットを取り直してセレクタを更新
+- 公式 API がある操作（ASSN URL 登録など）は将来 App Store Connect API（`.p8` 鍵）に置き換える方が安定
+- 完全に人手必須な操作（Apple ID 2FA / Review 提出ボタン）はスクリプト化しない
+
+## 既知の制約
+
+- Apple ID 2FA の初回承認は人手必須（信頼デバイスのプッシュ通知）
+- ASC の locale は英語想定。日本語表示の場合はセレクタを揃える必要あり
+- ASC 側の DOM 構造は予告なく変わる。壊れたら issue を立てて修正

--- a/scripts/ops/package-lock.json
+++ b/scripts/ops/package-lock.json
@@ -1,0 +1,642 @@
+{
+  "name": "cycle-journal-ops",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cycle-journal-ops",
+      "version": "0.1.0",
+      "dependencies": {
+        "@playwright/test": "^1.49.0",
+        "dotenv": "^16.4.7",
+        "playwright": "^1.49.0"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.0.tgz",
+      "integrity": "sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.0.tgz",
+      "integrity": "sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.0.tgz",
+      "integrity": "sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.0.tgz",
+      "integrity": "sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.0.tgz",
+      "integrity": "sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.0.tgz",
+      "integrity": "sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.0.tgz",
+      "integrity": "sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.0.tgz",
+      "integrity": "sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.0.tgz",
+      "integrity": "sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.0.tgz",
+      "integrity": "sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.0.tgz",
+      "integrity": "sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.0.tgz",
+      "integrity": "sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.0.tgz",
+      "integrity": "sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.0.tgz",
+      "integrity": "sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.0.tgz",
+      "integrity": "sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.0.tgz",
+      "integrity": "sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.0.tgz",
+      "integrity": "sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.0.tgz",
+      "integrity": "sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.0.tgz",
+      "integrity": "sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.0.tgz",
+      "integrity": "sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.0.tgz",
+      "integrity": "sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.0.tgz",
+      "integrity": "sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.0.tgz",
+      "integrity": "sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.20.tgz",
+      "integrity": "sha512-6tELRwSDYWW9EdZhbeZmYGZ1/7Djkt+Ah3/ScEYT9cDord7UJzasR/4D3VONg9tQI5CDp+/CZC1AXj2pCFOvpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.0",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
+      "integrity": "sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.0",
+        "@esbuild/android-arm": "0.28.0",
+        "@esbuild/android-arm64": "0.28.0",
+        "@esbuild/android-x64": "0.28.0",
+        "@esbuild/darwin-arm64": "0.28.0",
+        "@esbuild/darwin-x64": "0.28.0",
+        "@esbuild/freebsd-arm64": "0.28.0",
+        "@esbuild/freebsd-x64": "0.28.0",
+        "@esbuild/linux-arm": "0.28.0",
+        "@esbuild/linux-arm64": "0.28.0",
+        "@esbuild/linux-ia32": "0.28.0",
+        "@esbuild/linux-loong64": "0.28.0",
+        "@esbuild/linux-mips64el": "0.28.0",
+        "@esbuild/linux-ppc64": "0.28.0",
+        "@esbuild/linux-riscv64": "0.28.0",
+        "@esbuild/linux-s390x": "0.28.0",
+        "@esbuild/linux-x64": "0.28.0",
+        "@esbuild/netbsd-arm64": "0.28.0",
+        "@esbuild/netbsd-x64": "0.28.0",
+        "@esbuild/openbsd-arm64": "0.28.0",
+        "@esbuild/openbsd-x64": "0.28.0",
+        "@esbuild/openharmony-arm64": "0.28.0",
+        "@esbuild/sunos-x64": "0.28.0",
+        "@esbuild/win32-arm64": "0.28.0",
+        "@esbuild/win32-ia32": "0.28.0",
+        "@esbuild/win32-x64": "0.28.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/scripts/ops/package.json
+++ b/scripts/ops/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "cycle-journal-ops",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Web automation for App Store Connect / Firebase / GA4 etc.",
+  "scripts": {
+    "asc:login": "tsx src/asc/login.ts",
+    "asc:set-intro-offer": "tsx src/asc/iap-set-intro-offer.ts",
+    "asc:remove-from-sale": "tsx src/asc/iap-remove-from-sale.ts",
+    "asc:status": "tsx src/asc/status.ts"
+  },
+  "dependencies": {
+    "@playwright/test": "^1.49.0",
+    "dotenv": "^16.4.7",
+    "playwright": "^1.49.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.0",
+    "tsx": "^4.19.2",
+    "typescript": "^5.7.2"
+  }
+}

--- a/scripts/ops/src/asc/iap-remove-from-sale.ts
+++ b/scripts/ops/src/asc/iap-remove-from-sale.ts
@@ -1,0 +1,66 @@
+/**
+ * Yearly Premium を「配信から削除」する（フェーズ1の間の販売停止）。
+ *
+ * 環境変数:
+ *   DRY_RUN=1     確認ダイアログまでで止める（デフォルト）
+ *   DRY_RUN=0     実際に削除
+ */
+import "dotenv/config";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "playwright";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const SUB_ID = process.env.ASC_PRODUCT_YEARLY_SUB_ID || "6775448821";
+const DRY_RUN = (process.env.DRY_RUN ?? "1") !== "0";
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscriptions/${SUB_ID}`;
+const SHOT_DIR = resolve(OPS_ROOT, ".inspect/remove-from-sale");
+
+async function main() {
+  mkdirSync(SHOT_DIR, { recursive: true });
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+
+  console.log(`→ open yearly subscription page (DRY_RUN=${DRY_RUN ? "1" : "0"})`);
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+  await shot(page, "00-before");
+
+  console.log("→ click 「配信から削除」");
+  await page.getByRole("button", { name: "配信から削除" }).click();
+  await page.waitForTimeout(2000);
+  await shot(page, "01-confirm-dialog");
+
+  const dialog = page.getByRole("dialog");
+  const dialogButtons = await dialog.locator("button").allTextContents();
+  console.log("→ buttons in dialog:", dialogButtons.map((b) => b.trim()).filter(Boolean));
+
+  if (DRY_RUN) {
+    console.log("→ DRY_RUN: not confirming. screenshot in .inspect/remove-from-sale/");
+    await browser.close();
+    return;
+  }
+
+  const confirm = dialog.getByRole("button", { name: /^(削除|確認|OK|配信から削除|はい)$/ });
+  await confirm.click();
+  await page.waitForTimeout(3000);
+  await shot(page, "02-after-confirm");
+  console.log("✓ removed from sale");
+  await browser.close();
+}
+
+async function shot(page: Page, name: string): Promise<void> {
+  await page.screenshot({ path: resolve(SHOT_DIR, `${name}.png`), fullPage: true });
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/iap-set-intro-offer.ts
+++ b/scripts/ops/src/asc/iap-set-intro-offer.ts
@@ -1,0 +1,151 @@
+/**
+ * Monthly Premium に 3日 Introductory Offer (無料) を設定する。
+ *
+ * 環境変数:
+ *   DRY_RUN=1     最後の保存を押さない（デフォルト）
+ *   DRY_RUN=0     実際に登録
+ *
+ * 実行: DRY_RUN=1 npm run asc:set-intro-offer
+ *      DRY_RUN=0 npm run asc:set-intro-offer
+ */
+import "dotenv/config";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "playwright";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const SUB_ID = process.env.ASC_PRODUCT_MONTHLY_SUB_ID || "6775457213";
+const DRY_RUN = (process.env.DRY_RUN ?? "1") !== "0";
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscriptions/${SUB_ID}/pricing/intro-offers`;
+const SHOT_DIR = resolve(OPS_ROOT, ".inspect/intro-flow");
+
+async function main() {
+  mkdirSync(SHOT_DIR, { recursive: true });
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+
+  console.log(`→ open intro-offers page (DRY_RUN=${DRY_RUN ? "1" : "0"})`);
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+  await shot(page, "00-before");
+
+  console.log("→ click 「お試しオファーを設定」");
+  await page.getByRole("button", { name: "お試しオファーを設定" }).click();
+  await page.waitForTimeout(2000);
+  await shot(page, "01-countries");
+
+  console.log("→ countries: keep all selected, 次へ");
+  await clickNext(page);
+  await shot(page, "02-dates-empty");
+
+  console.log("→ start date: today");
+  await selectStartToday(page);
+  await shot(page, "03-start-set");
+
+  console.log("→ end date: 終了日なし");
+  await selectEndNone(page);
+  await shot(page, "04-end-set");
+
+  await clickNext(page);
+  await shot(page, "05-offer-type");
+
+  console.log("→ offer type: 無料 (duration field appears on same screen)");
+  await page.getByText("無料", { exact: true }).click();
+  await page.waitForTimeout(800);
+  await shot(page, "06-offer-type-set");
+
+  console.log("→ duration: 3 日");
+  await selectFreeDuration(page, "3日");
+  await shot(page, "07-duration-set");
+  await clickNext(page);
+  await shot(page, "08-after-duration");
+
+  // 確認画面のボタン候補をログ出力（DRY_RUN 時の調査用）
+  const buttons = await page.locator("button:visible").allTextContents();
+  console.log("→ buttons on confirm:", buttons.map((b) => b.trim()).filter(Boolean));
+
+  if (DRY_RUN) {
+    console.log("→ DRY_RUN: not saving. screenshots in .inspect/intro-flow/");
+    await browser.close();
+    return;
+  }
+
+  console.log("→ save");
+  const saveBtn = page.getByRole("button", { name: /^(確認|保存|完了|確定)$/ });
+  await saveBtn.click();
+  await page.waitForTimeout(3000);
+  await shot(page, "08-after-save");
+  console.log("✓ saved");
+  await browser.close();
+}
+
+async function clickNext(page: Page): Promise<void> {
+  const next = page.getByRole("button", { name: /^次へ$/ });
+  await next.waitFor({ state: "visible", timeout: 15_000 });
+  for (let i = 0; i < 20; i++) {
+    if (!(await next.isDisabled().catch(() => true))) break;
+    await page.waitForTimeout(300);
+  }
+  await next.click();
+  await page.waitForTimeout(2000);
+}
+
+async function selectStartToday(page: Page): Promise<void> {
+  await page.locator(".react-datepicker__input-container input").nth(0).click();
+  await page.waitForTimeout(800);
+  // .react-datepicker__day--today にクリック可能なセルがあるはず
+  const today = page.locator(".react-datepicker__day--today:not(.react-datepicker__day--disabled)");
+  if (await today.count()) {
+    await today.first().click();
+  } else {
+    // フォールバック: 最初の有効な日をクリック
+    await page
+      .locator(
+        ".react-datepicker__day:not(.react-datepicker__day--disabled):not(.react-datepicker__day--outside-month)",
+      )
+      .first()
+      .click();
+  }
+  await page.waitForTimeout(500);
+}
+
+async function selectEndNone(page: Page): Promise<void> {
+  await page.locator(".react-datepicker__input-container input").nth(1).click();
+  await page.waitForTimeout(800);
+  await page.getByText("終了日なし", { exact: true }).click();
+  await page.waitForTimeout(500);
+}
+
+async function selectFreeDuration(page: Page, label: string): Promise<void> {
+  // 「無料期間」ラベル直下の dropdown。まず select を試す
+  const select = page.locator("select").first();
+  if (await select.count()) {
+    try {
+      await select.selectOption({ label });
+      return;
+    } catch {
+      // fall through to custom dropdown
+    }
+  }
+  // カスタムドロップダウン: 「選択する」ボタンをクリックして展開
+  const trigger = page.getByText("選択する", { exact: true }).first();
+  await trigger.click();
+  await page.waitForTimeout(800);
+  await page.getByText(label, { exact: true }).click();
+}
+
+async function shot(page: Page, name: string): Promise<void> {
+  await page.screenshot({ path: resolve(SHOT_DIR, `${name}.png`), fullPage: true });
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-create-intro.ts
+++ b/scripts/ops/src/asc/inspect-create-intro.ts
@@ -1,0 +1,69 @@
+/**
+ * Monthly の「お試しオファーを設定」ボタンを押した先の入力画面を inspect。
+ * モーダルが出るかページ遷移するかを確認する。実際の保存はしない。
+ *
+ * 実行: npx tsx src/asc/inspect-create-intro.ts
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const SUB_ID = required("ASC_PRODUCT_MONTHLY_SUB_ID", "6775457213");
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscriptions/${SUB_ID}/pricing/intro-offers`;
+
+async function main() {
+  const inspectDir = resolve(OPS_ROOT, ".inspect");
+  mkdirSync(inspectDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  console.log("→ clicking 「お試しオファーを設定」");
+  await page.getByRole("button", { name: "お試しオファーを設定" }).click();
+  await page.waitForTimeout(3000);
+
+  await page.screenshot({ path: resolve(inspectDir, "create-intro-step1.png"), fullPage: true });
+  writeFileSync(resolve(inspectDir, "create-intro-step1.html"), await page.content());
+
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; href?: string; tag: string; name?: string; type?: string }[] = [];
+    document
+      .querySelectorAll(
+        "a, button, [role='button'], h1, h2, h3, h4, label, input, select, option, [role='dialog']",
+      )
+      .forEach((el) => {
+        const text = (el.textContent || (el as HTMLInputElement).value || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 200);
+        const inputEl = el as HTMLInputElement;
+        rows.push({
+          text,
+          href: (el as HTMLAnchorElement).href || undefined,
+          tag: el.tagName.toLowerCase(),
+          name: inputEl.name || undefined,
+          type: inputEl.type || undefined,
+        });
+      });
+    return rows;
+  });
+  writeFileSync(resolve(inspectDir, "create-intro-step1-summary.json"), JSON.stringify(summary, null, 2));
+  console.log(`✓ captured step1 (${summary.length} entries) — no save performed`);
+
+  await browser.close();
+}
+
+function required(name: string, fallback?: string): string {
+  const v = process.env[name] ?? fallback;
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-datepicker.ts
+++ b/scripts/ops/src/asc/inspect-datepicker.ts
@@ -1,0 +1,60 @@
+/**
+ * 「開始日」「終了日」のセレクタの選択肢を確認する。
+ * step2 まで進めてから datepicker をクリックして、何が出るか撮る。
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const SUB_ID = process.env.ASC_PRODUCT_MONTHLY_SUB_ID || "6775457213";
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscriptions/${SUB_ID}/pricing/intro-offers`;
+const OUT = resolve(OPS_ROOT, ".inspect/datepicker");
+
+async function main() {
+  mkdirSync(OUT, { recursive: true });
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  await page.getByRole("button", { name: "お試しオファーを設定" }).click();
+  await page.waitForTimeout(2000);
+  await page.getByRole("button", { name: "次へ" }).click();
+  await page.waitForTimeout(2000);
+
+  console.log("→ inspect react-datepicker inputs");
+  const inputs = page.locator(".react-datepicker__input-container input");
+  const count = await inputs.count();
+  console.log(`  found ${count} datepicker inputs`);
+
+  // 開始日ドロップダウンを開く
+  console.log("→ click 開始日 input");
+  await inputs.nth(0).click();
+  await page.waitForTimeout(1500);
+  await page.screenshot({ path: resolve(OUT, "start-open.png"), fullPage: false });
+  writeFileSync(resolve(OUT, "start-open.html"), await page.content());
+
+  // 終了日ドロップダウンを開く（先に開始日を閉じてから）
+  await page.keyboard.press("Escape");
+  await page.waitForTimeout(500);
+  console.log("→ click 終了日 input");
+  await inputs.nth(1).click();
+  await page.waitForTimeout(1500);
+  await page.screenshot({ path: resolve(OUT, "end-open.png"), fullPage: false });
+  writeFileSync(resolve(OUT, "end-open.html"), await page.content());
+
+  await browser.close();
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-intro-flow.ts
+++ b/scripts/ops/src/asc/inspect-intro-flow.ts
@@ -1,0 +1,85 @@
+/**
+ * Introductory Offer 作成フローを「次へ」だけ押しながら各画面の screenshot + summary を撮る。
+ * これでフロー全体の順序と各画面の選択肢を確定する。
+ * 「キャンセル」または最後のステップで終了する（保存はしない）。
+ *
+ * 実行: npx tsx src/asc/inspect-intro-flow.ts
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const SUB_ID = process.env.ASC_PRODUCT_MONTHLY_SUB_ID || "6775457213";
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscriptions/${SUB_ID}/pricing/intro-offers`;
+const OUT = resolve(OPS_ROOT, ".inspect/intro-walk");
+
+async function main() {
+  mkdirSync(OUT, { recursive: true });
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  await page.getByRole("button", { name: "お試しオファーを設定" }).click();
+  await page.waitForTimeout(2000);
+
+  for (let step = 1; step <= 10; step++) {
+    const pad = String(step).padStart(2, "0");
+    await page.screenshot({ path: resolve(OUT, `${pad}.png`), fullPage: true });
+    writeFileSync(resolve(OUT, `${pad}.html`), await page.content());
+    const summary = await page.evaluate(() => {
+      const rows: { text: string; tag: string }[] = [];
+      document
+        .querySelectorAll(
+          "h1, h2, h3, h4, label, input, select, option, button, [role='button']",
+        )
+        .forEach((el) => {
+          const text = (el.textContent || (el as HTMLInputElement).value || "")
+            .replace(/\s+/g, " ")
+            .trim()
+            .slice(0, 200);
+          if (!text) return;
+          rows.push({ text, tag: el.tagName.toLowerCase() });
+        });
+      return rows;
+    });
+    writeFileSync(resolve(OUT, `${pad}.json`), JSON.stringify(summary, null, 2));
+    console.log(`✓ step ${pad}: ${summary.length} entries`);
+
+    // 「次へ」or「保存」or「確認」が押せる状態か確認
+    const next = page.getByRole("button", { name: /^次へ$/ });
+    if (await next.isVisible().catch(() => false)) {
+      const disabled = await next.isDisabled().catch(() => false);
+      if (disabled) {
+        console.log(`  → 「次へ」disabled — likely waiting for input. stop here.`);
+        break;
+      }
+      await next.click();
+      await page.waitForTimeout(2000);
+      continue;
+    }
+    const save = page.getByRole("button", { name: /^(保存|確認|完了)$/ });
+    if (await save.isVisible().catch(() => false)) {
+      console.log(`  → 「保存/確認/完了」detected. NOT clicking. stop here.`);
+      break;
+    }
+    console.log(`  → no 次へ / no 保存. stop here.`);
+    break;
+  }
+
+  await browser.close();
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-intro-offers.ts
+++ b/scripts/ops/src/asc/inspect-intro-offers.ts
@@ -1,0 +1,66 @@
+/**
+ * お試しオファー (Introductory Offers) ページ inspect。
+ * 実行: npx tsx src/asc/inspect-intro-offers.ts <subscriptionId> <label>
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const SUB_ID = process.argv[2];
+const LABEL = process.argv[3] || SUB_ID;
+
+if (!SUB_ID) {
+  console.error("usage: inspect-intro-offers.ts <subscriptionId> [label]");
+  process.exit(1);
+}
+
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscriptions/${SUB_ID}/pricing/intro-offers`;
+
+async function main() {
+  const inspectDir = resolve(OPS_ROOT, ".inspect");
+  mkdirSync(inspectDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  await page.screenshot({ path: resolve(inspectDir, `intro-${LABEL}.png`), fullPage: true });
+  writeFileSync(resolve(inspectDir, `intro-${LABEL}.html`), await page.content());
+
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; href?: string; tag: string }[] = [];
+    document
+      .querySelectorAll("a, button, [role='button'], h1, h2, h3, h4, label, input, select, td, th")
+      .forEach((el) => {
+        const text = (el.textContent || (el as HTMLInputElement).value || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 200);
+        if (!text) return;
+        rows.push({
+          text,
+          href: (el as HTMLAnchorElement).href || undefined,
+          tag: el.tagName.toLowerCase(),
+        });
+      });
+    return rows;
+  });
+  writeFileSync(resolve(inspectDir, `intro-${LABEL}-summary.json`), JSON.stringify(summary, null, 2));
+  console.log(`✓ inspected intro-offers ${LABEL} (${summary.length} entries)`);
+
+  await browser.close();
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-pricing.ts
+++ b/scripts/ops/src/asc/inspect-pricing.ts
@@ -1,0 +1,69 @@
+/**
+ * サブスク価格詳細ページ inspect。Introductory Offer の場所を特定する。
+ * 実行: npx tsx src/asc/inspect-pricing.ts <subscriptionId> <label>
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const SUB_ID = process.argv[2];
+const LABEL = process.argv[3] || SUB_ID;
+
+if (!SUB_ID) {
+  console.error("usage: inspect-pricing.ts <subscriptionId> [label]");
+  process.exit(1);
+}
+
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscriptions/${SUB_ID}/pricing`;
+
+async function main() {
+  const inspectDir = resolve(OPS_ROOT, ".inspect");
+  mkdirSync(inspectDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  await page.screenshot({ path: resolve(inspectDir, `pricing-${LABEL}.png`), fullPage: true });
+  writeFileSync(resolve(inspectDir, `pricing-${LABEL}.html`), await page.content());
+
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; href?: string; tag: string }[] = [];
+    document
+      .querySelectorAll("a, button, [role='button'], h1, h2, h3, h4, label, input, select")
+      .forEach((el) => {
+        const text = (el.textContent || (el as HTMLInputElement).value || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 200);
+        if (!text) return;
+        rows.push({
+          text,
+          href: (el as HTMLAnchorElement).href || undefined,
+          tag: el.tagName.toLowerCase(),
+        });
+      });
+    return rows;
+  });
+  writeFileSync(
+    resolve(inspectDir, `pricing-${LABEL}-summary.json`),
+    JSON.stringify(summary, null, 2),
+  );
+  console.log(`✓ inspected pricing ${LABEL} (${summary.length} entries)`);
+
+  await browser.close();
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-subscription-group.ts
+++ b/scripts/ops/src/asc/inspect-subscription-group.ts
@@ -1,0 +1,59 @@
+/**
+ * サブスクリプショングループ詳細ページの screenshot + DOM ダンプ。
+ * グループ ID と商品行のセレクタを特定する。
+ *
+ * 実行: npx tsx src/asc/inspect-subscription-group.ts <groupId>
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const GROUP_ID = process.argv[2] || "22126843";
+const GROUP_URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscription-groups/${GROUP_ID}`;
+
+async function main() {
+  const inspectDir = resolve(OPS_ROOT, ".inspect");
+  mkdirSync(inspectDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(GROUP_URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  await page.screenshot({ path: resolve(inspectDir, "group.png"), fullPage: true });
+  writeFileSync(resolve(inspectDir, "group.html"), await page.content());
+
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; href?: string; testId?: string; tag: string }[] = [];
+    document
+      .querySelectorAll("a, button, tr, [role='row'], [data-testid], h1, h2, h3, label")
+      .forEach((el) => {
+        const text = (el.textContent || "").replace(/\s+/g, " ").trim().slice(0, 160);
+        if (!text) return;
+        rows.push({
+          text,
+          href: (el as HTMLAnchorElement).href || undefined,
+          testId: (el as HTMLElement).dataset?.testid,
+          tag: el.tagName.toLowerCase(),
+        });
+      });
+    return rows;
+  });
+  writeFileSync(resolve(inspectDir, "group-summary.json"), JSON.stringify(summary, null, 2));
+  console.log(`✓ inspected group ${GROUP_ID} (${summary.length} entries)`);
+
+  await browser.close();
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-subscription.ts
+++ b/scripts/ops/src/asc/inspect-subscription.ts
@@ -1,0 +1,66 @@
+/**
+ * 個別サブスクリプション商品ページの screenshot + DOM ダンプ。
+ * 実行: npx tsx src/asc/inspect-subscription.ts <subscriptionId> <label>
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const SUB_ID = process.argv[2];
+const LABEL = process.argv[3] || SUB_ID;
+
+if (!SUB_ID) {
+  console.error("usage: inspect-subscription.ts <subscriptionId> [label]");
+  process.exit(1);
+}
+
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscriptions/${SUB_ID}`;
+
+async function main() {
+  const inspectDir = resolve(OPS_ROOT, ".inspect");
+  mkdirSync(inspectDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  await page.screenshot({ path: resolve(inspectDir, `sub-${LABEL}.png`), fullPage: true });
+  writeFileSync(resolve(inspectDir, `sub-${LABEL}.html`), await page.content());
+
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; href?: string; tag: string }[] = [];
+    document
+      .querySelectorAll("a, button, [role='button'], h1, h2, h3, h4, label, input, select")
+      .forEach((el) => {
+        const text = (el.textContent || (el as HTMLInputElement).value || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 200);
+        if (!text) return;
+        rows.push({
+          text,
+          href: (el as HTMLAnchorElement).href || undefined,
+          tag: el.tagName.toLowerCase(),
+        });
+      });
+    return rows;
+  });
+  writeFileSync(resolve(inspectDir, `sub-${LABEL}-summary.json`), JSON.stringify(summary, null, 2));
+  console.log(`✓ inspected ${LABEL} (${summary.length} entries)`);
+
+  await browser.close();
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-subscriptions.ts
+++ b/scripts/ops/src/asc/inspect-subscriptions.ts
@@ -1,0 +1,63 @@
+/**
+ * Subscriptions ページの screenshot + 主要 DOM ダンプを取得し、
+ * iap-set-intro-offer / iap-remove-from-sale のセレクタ調整に使う。
+ *
+ * 実行: npx tsx src/asc/inspect-subscriptions.ts
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const SUBSCRIPTIONS_URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/subscriptions`;
+
+async function main() {
+  const inspectDir = resolve(OPS_ROOT, ".inspect");
+  mkdirSync(inspectDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(SUBSCRIPTIONS_URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  const screenshotPath = resolve(inspectDir, "subscriptions.png");
+  await page.screenshot({ path: screenshotPath, fullPage: true });
+  console.log(`✓ screenshot: ${screenshotPath}`);
+
+  const html = await page.content();
+  const htmlPath = resolve(inspectDir, "subscriptions.html");
+  writeFileSync(htmlPath, html);
+  console.log(`✓ html: ${htmlPath}`);
+
+  // テキストノードと href を抽出して、商品行を見つけやすくする
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; href?: string; testId?: string }[] = [];
+    document.querySelectorAll("a, button, tr, [role='row'], [data-testid]").forEach((el) => {
+      const text = (el.textContent || "").replace(/\s+/g, " ").trim().slice(0, 120);
+      if (!text) return;
+      rows.push({
+        text,
+        href: (el as HTMLAnchorElement).href || undefined,
+        testId: (el as HTMLElement).dataset?.testid,
+      });
+    });
+    return rows;
+  });
+  const summaryPath = resolve(inspectDir, "subscriptions-summary.json");
+  writeFileSync(summaryPath, JSON.stringify(summary, null, 2));
+  console.log(`✓ summary: ${summaryPath} (${summary.length} entries)`);
+
+  await browser.close();
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/list-apps.ts
+++ b/scripts/ops/src/asc/list-apps.ts
@@ -1,0 +1,71 @@
+/**
+ * ASC Apps 一覧から App ID を取得して表示する。
+ * Cycle が1個だけならそれを .env の ASC_APP_ID に書き込む。
+ *
+ * 実行: npx tsx src/asc/list-apps.ts
+ */
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APPS_URL = "https://appstoreconnect.apple.com/apps";
+
+interface AppInfo {
+  id: string;
+  name: string;
+}
+
+async function main() {
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(APPS_URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+
+  const apps: AppInfo[] = await page.$$eval('a[href*="/apps/"]', (anchors) => {
+    const seen = new Map<string, string>();
+    for (const a of anchors as HTMLAnchorElement[]) {
+      const m = a.href.match(/\/apps\/(\d+)(\/|$)/);
+      if (!m) continue;
+      const id = m[1];
+      const name = a.textContent?.trim() || "";
+      if (name && !seen.has(id)) seen.set(id, name);
+    }
+    return Array.from(seen, ([id, name]) => ({ id, name }));
+  });
+
+  await browser.close();
+
+  if (apps.length === 0) {
+    console.error("✗ no apps found — session may be expired. run `npm run asc:login`");
+    process.exit(1);
+  }
+
+  console.log("Apps:");
+  for (const a of apps) {
+    console.log(`  ${a.id}  ${a.name}`);
+  }
+
+  const cycle = apps.find((a) => /cycle/i.test(a.name));
+  if (cycle) {
+    await upsertEnv("ASC_APP_ID", cycle.id);
+    console.log(`✓ wrote ASC_APP_ID=${cycle.id} (${cycle.name}) to .env`);
+  } else if (apps.length === 1) {
+    await upsertEnv("ASC_APP_ID", apps[0].id);
+    console.log(`✓ wrote ASC_APP_ID=${apps[0].id} (${apps[0].name}) to .env`);
+  } else {
+    console.log("→ multiple apps found and none match 'cycle'. set ASC_APP_ID manually.");
+  }
+}
+
+async function upsertEnv(key: string, value: string): Promise<void> {
+  const envPath = resolve(OPS_ROOT, ".env");
+  let content = existsSync(envPath) ? readFileSync(envPath, "utf-8") : "";
+  const line = `${key}=${value}`;
+  const re = new RegExp(`^${key}=.*$`, "m");
+  content = re.test(content) ? content.replace(re, line) : `${content.replace(/\n?$/, "\n")}${line}\n`;
+  writeFileSync(envPath, content);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/login.ts
+++ b/scripts/ops/src/asc/login.ts
@@ -1,0 +1,39 @@
+/**
+ * 初回 ASC ログイン: ヘッドフルブラウザで Apple ID + 2FA を通し、storageState を保存する。
+ *
+ * 流れ:
+ *   1. chromium ヘッドフルで appstoreconnect.apple.com/apps を開く
+ *   2. ユーザーが画面で Apple ID / パスワード / 2FA を入力
+ *   3. ログイン完了して /apps に到達したら storageState を保存して終了
+ *
+ * 実行: npm run asc:login
+ */
+import { ASC_STORAGE_STATE, launch, saveState } from "../lib/browser.js";
+
+const APPS_URL = "https://appstoreconnect.apple.com/apps";
+const LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
+
+async function main() {
+  console.log("→ ヘッドフル Chromium を開きます。Apple ID / パスワード / 2FA を画面で入力してください。");
+  console.log("→ 最大 10 分待ちます。ログイン完了（Apps 一覧表示）を検知したら自動で state を保存します。");
+
+  const { browser, context, page } = await launch({ headless: false });
+  await page.goto(APPS_URL);
+
+  await page.waitForURL(/appstoreconnect\.apple\.com\/apps(\/|$|\?)/, {
+    timeout: LOGIN_TIMEOUT_MS,
+  });
+
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {
+    // networkidle に到達しないテナントもあるため失敗は無視
+  });
+
+  await saveState(context, ASC_STORAGE_STATE);
+  console.log(`✓ saved: ${ASC_STORAGE_STATE}`);
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/status.ts
+++ b/scripts/ops/src/asc/status.ts
@@ -1,0 +1,22 @@
+/**
+ * ログイン state が有効か確認。Apps 一覧が表示できれば OK。
+ * 実行: npm run asc:status
+ */
+import { ASC_STORAGE_STATE, launch } from "../lib/browser.js";
+
+async function main() {
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE, headless: true });
+  await page.goto("https://appstoreconnect.apple.com/apps", { waitUntil: "domcontentloaded" });
+  const url = page.url();
+  if (url.includes("/login") || url.includes("idmsa.apple.com")) {
+    console.error("✗ session expired — run `npm run asc:login`");
+    process.exit(1);
+  }
+  console.log("✓ session OK:", url);
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/lib/browser.ts
+++ b/scripts/ops/src/lib/browser.ts
@@ -1,0 +1,40 @@
+import { chromium, type Browser, type BrowserContext, type Page } from "playwright";
+import { existsSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import "dotenv/config";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+export const OPS_ROOT = resolve(__dirname, "../..");
+export const AUTH_DIR = resolve(OPS_ROOT, ".auth");
+export const ASC_STORAGE_STATE = resolve(AUTH_DIR, "asc.json");
+
+if (!existsSync(AUTH_DIR)) {
+  mkdirSync(AUTH_DIR, { recursive: true });
+}
+
+export interface LaunchOptions {
+  storageState?: string;
+  headless?: boolean;
+}
+
+export async function launch(opts: LaunchOptions = {}): Promise<{
+  browser: Browser;
+  context: BrowserContext;
+  page: Page;
+}> {
+  const headless = opts.headless ?? process.env.HEADLESS === "true";
+  const slowMo = Number(process.env.SLOW_MO ?? 0);
+  const browser = await chromium.launch({ headless, slowMo });
+  const context = await browser.newContext(
+    opts.storageState && existsSync(opts.storageState)
+      ? { storageState: opts.storageState }
+      : {},
+  );
+  const page = await context.newPage();
+  return { browser, context, page };
+}
+
+export async function saveState(context: BrowserContext, path: string): Promise<void> {
+  await context.storageState({ path });
+}

--- a/scripts/ops/tsconfig.json
+++ b/scripts/ops/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": true,
+    "lib": ["ES2022", "DOM"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- `scripts/ops/` に Playwright + TypeScript の ASC 自動操作スクリプト群を追加
- `.mcp.json` に Playwright MCP を追加（次セッションから Claude が直接ブラウザ操作可能）
- Issue #54 のフェーズ1 ASC 反映作業（月額3日トライアル登録 / 年額配信停止）の基盤

## 含まれるスクリプト
| スクリプト | 用途 |
|---|---|
| `login.ts` / `status.ts` | ログイン state 保存・検証 |
| `list-apps.ts` | Apps 一覧取得 + .env 自動書き込み |
| `iap-set-intro-offer.ts` | 月額に Introductory Offer 登録（本番反映済） |
| `iap-remove-from-sale.ts` | 商品の配信停止（本番反映済） |
| `inspect-*.ts` | ASC UI 構造確認用（DOM 変化時のセレクタ調整に） |

## Test plan
- [x] `npm install` & `npx playwright install chromium` 成功
- [x] `asc:login` で `.auth/asc.json` 保存
- [x] `asc:set-intro-offer` で月額に3日無料 Intro Offer を ASC に登録（本番反映確認）
- [x] `asc:remove-from-sale` で年額を Removed from Sale（本番反映確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)