### PR TITLE
feat: #54 フェーズ1方針反映 — 月額3日トライアル / 年額はフェーズ2へ

### DIFF
--- a/ios/Cycle/Configuration.storekit
+++ b/ios/Cycle/Configuration.storekit
@@ -49,10 +49,14 @@
           "familyShareable" : false,
           "groupNumber" : 2,
           "internalID" : "4554B31C",
-          "introductoryOffer" : null,
+          "introductoryOffer" : {
+            "internalID" : "B82D7A11",
+            "paymentMode" : "free",
+            "subscriptionPeriod" : "P3D"
+          },
           "localizations" : [
             {
-              "description" : "1ヶ月間のプレミアムアクセス",
+              "description" : "1ヶ月間のプレミアムアクセス（3日間無料トライアル付き）",
               "displayName" : "Monthly Premium",
               "locale" : "ja_JP"
             }

--- a/ios/Cycle/Features/Subscription/Models/SubscriptionProduct.swift
+++ b/ios/Cycle/Features/Subscription/Models/SubscriptionProduct.swift
@@ -9,30 +9,31 @@ import Foundation
 
 /// App Store Connect で作成するサブスクリプション商品。
 ///
-/// - `monthly_1800`: ¥1,800/月 (Intro Offer なし、Calm 型: 月額は即課金)
-/// - `yearly_14400`: ¥14,400/年 (7-day Free Trial Intro Offer 付き)
+/// - `monthly_1800`: ¥1,800/月 (3-day Free Trial Intro Offer 付き)
+/// - `yearly_14400`: ¥14,400/年 (フェーズ1中は ASC で「配信から削除」)
+///
+/// Issue #54 決定 (フェーズ制):
+///   フェーズ1: 月額のみ。3日トライアル。
+///   フェーズ2: 年額追加 (7日トライアル付き)。月額トライアルは3日のまま据え置き。
 ///
 /// 命名は App Store Connect のプロダクト ID と完全一致させること。
-/// 変更時は App Store Connect 側と本 enum の両方を必ずセットで更新。
 enum SubscriptionProductID: String, CaseIterable {
     case monthly = "com.akitoando.CycleJournal.monthly_1800"
     case yearly = "com.akitoando.CycleJournal.yearly_14400"
 
-    /// 7-day Free Trial Intro Offer を持つか。
-    ///
-    /// Issue #37 A-1 決定: yearly のみトライアル付き (LTV の高い年額に集中)。
+    /// Intro Offer を持つか。フェーズ1では monthly のみ。
     var supportsIntroductoryOffer: Bool {
         switch self {
-        case .yearly: return true
-        case .monthly: return false
+        case .monthly: return true
+        case .yearly: return true  // フェーズ2で復活時の7日トライアルを想定
         }
     }
 
-    /// 表示順 (Paywall で年額を上位に出す)。
+    /// 表示順。フェーズ1では monthly を先頭に。
     var displayOrder: Int {
         switch self {
-        case .yearly: return 0
-        case .monthly: return 1
+        case .monthly: return 0
+        case .yearly: return 1
         }
     }
 }

--- a/ios/CycleTests/SubscriptionTests.swift
+++ b/ios/CycleTests/SubscriptionTests.swift
@@ -29,10 +29,15 @@ struct SubscriptionProductTests {
         #expect(all.count == 2)
     }
 
-    @Test func yearlyIsTrialEligible() {
-        // A-1 決定: yearly のみ 7-day Free Trial Intro Offer を設定
+    @Test func bothProductsAreTrialEligible() {
+        // #54 決定 (フェーズ制): monthly は3日、yearly は7日 (フェーズ2で復活時)
+        #expect(SubscriptionProductID.monthly.supportsIntroductoryOffer == true)
         #expect(SubscriptionProductID.yearly.supportsIntroductoryOffer == true)
-        #expect(SubscriptionProductID.monthly.supportsIntroductoryOffer == false)
+    }
+
+    @Test func monthlyIsFirstInPhase1() {
+        // フェーズ1の Paywall は monthly のみ表示。displayOrder で先頭に。
+        #expect(SubscriptionProductID.monthly.displayOrder < SubscriptionProductID.yearly.displayOrder)
     }
 }
 


### PR DESCRIPTION
## Summary
- #54 決定（月額3日無料、年額はフェーズ2まで後ろ倒し）の **データ層** を反映
- `SubscriptionProduct.swift`: フェーズ制を明文化、displayOrder で monthly 優先
- `Configuration.storekit`: monthly に P3D の free Intro Offer を追加
- `SubscriptionTests.swift`: 両プロダクトの Intro Offer 期待値と表示順テストに更新

UI 改修（PaywallView）は次の PR で出します。

## ASC 側との対応
| 項目 | ASC 側（先行反映済） | 本 PR |
|---|---|---|
| 月額 3日無料 | 登録済（2026-06-06〜終了日なし、175か国） | Configuration.storekit に同設定 |
| 年額 配信停止 | Removed from Sale（0か国） | （コード変更なし） |

## Test plan
- [x] `SubscriptionTests.swift` の新規テストが pass する内容で記述
- [ ] Xcode で StoreKit Configuration を選んで Monthly Premium 購入時に「3日無料」が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)