### PR TITLE
feat: #54 PaywallView の Terms / Privacy URL を本番URLに差し替え

### DIFF
--- a/ios/Cycle/Features/Subscription/Views/PaywallView.swift
+++ b/ios/Cycle/Features/Subscription/Views/PaywallView.swift
@@ -21,8 +21,8 @@ struct PaywallView: View {
     @State private var isPurchasing = false
 
     /// 規約・プライバシーポリシー URL (App Store Connect と同一の URL を入れること)
-    let termsURL = URL(string: "https://cycle-journal.example.com/terms")!
-    let privacyURL = URL(string: "https://cycle-journal.example.com/privacy")!
+    let termsURL = URL(string: "https://akitoando.github.io/cycle-journal/legal/TERMS_OF_SERVICE.html")!
+    let privacyURL = URL(string: "https://akitoando.github.io/cycle-journal/legal/PRIVACY_POLICY.html")!
 
     /// フェーズ1で Paywall に表示するプロダクト。yearly は除外。
     private var visibleProducts: [Product] {


### PR DESCRIPTION
## Summary
- 旧 example.com プレースホルダから GitHub Pages の正式URLへ更新
- Terms: https://akitoando.github.io/cycle-journal/legal/TERMS_OF_SERVICE.html
- Privacy: https://akitoando.github.io/cycle-journal/legal/PRIVACY_POLICY.html

## 依存関係
- 文書本体は PR #73 で develop にマージ済
- 公開には docs の **main 昇格** が必要（`deploy-docs.yml` は `push to main` トリガー）

## ASC 側の対応（手動）
本URLを App Store Connect のアプリ申請時に **Privacy Policy URL** として登録してください（手順10：`docs/guides/37-deployment-setup/10-legal-urls.md` 参照）。

## Test plan
- [ ] docs を main 昇格 → 公開URLにアクセスできる
- [ ] PaywallView 内の「利用規約」「プライバシーポリシー」リンクをタップ → Safari View で開ける
- [ ] ASC のアプリ情報に同URLを登録

🤖 Generated with [Claude Code](https://claude.com/claude-code)