### PR TITLE
docs: /legal/ にインデックスページを追加（ASC 既存URL の互換維持）

### DIFF
--- a/docs/legal/index.md
+++ b/docs/legal/index.md
@@ -1,0 +1,15 @@
+---
+title: 法的情報 — Cycle Journal
+description: Cycle Journal の利用規約・プライバシーポリシー
+---
+
+# 法的情報
+
+Cycle Journal の法的文書一覧です。
+
+- [プライバシーポリシー](./PRIVACY_POLICY.html)
+- [利用規約](./TERMS_OF_SERVICE.html)
+
+---
+
+ご質問は [28ww.lo.ol.ww28@gmail.com](mailto:28ww.lo.ol.ww28@gmail.com) までご連絡ください。


### PR DESCRIPTION
## Summary
ASC の Privacy Policy URL が旧 \`https://akitoando.github.io/cycle-journal/legal/\` で登録されたまま。前 PR で旧 \`index.html\` を削除したため、main 昇格後に同 URL が 404 になる。

対策として、Privacy / Terms へのリンクを持つ \`index.md\` を追加して既存 URL の互換を維持する。

## ASC への URL 変更は不要
- 旧URL: \`https://akitoando.github.io/cycle-journal/legal/\` → index.md でPrivacy/Termsへの導線
- 新URL（直接アクセス用）: \`/legal/PRIVACY_POLICY.html\` \`/legal/TERMS_OF_SERVICE.html\`

## Test plan
- [ ] main 昇格後、旧URL でインデックスページが表示される
- [ ] そこから Privacy / Terms ページに遷移できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)