### PR TITLE
feat: #37 Vertex AI Claude を global エンドポイントへ移行

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -25,8 +25,12 @@ class Settings(BaseSettings):
     refresh_token_expire_days: int = 30
 
     # Vertex AI Claude
-    # NOTE: Vertex AI モデル ID は asia-northeast1 の Model Garden で
-    # 提供状況を確認のうえ実環境向けに上書きすること。
+    # NOTE: Sonnet 4.5 / Haiku 4.5 はリージョンエンドポイント (asia-northeast1 等) で
+    # 未提供のため global エンドポイントを使う。global は dynamic routing で可用性が
+    # 高く、Sonnet 4.5 以降のリージョン pricing premium (10%) も避けられる。
+    # quota はベースモデル単位で `aiplatform.googleapis.com/global_online_prediction_requests_per_base_model`
+    # が制御。初期値は 0 のため Cloud Console → IAM & Admin → Quotas で増枠申請が必要。
+    claude_region: str = "global"
     claude_model_coach: str = "claude-sonnet-4-5@20250929"
     claude_model_quick: str = "claude-haiku-4-5@20251001"
     # 後方互換: 既存環境変数 CLAUDE_MODEL を coach 用のエイリアスとして残す

--- a/api/app/services/coach_graph.py
+++ b/api/app/services/coach_graph.py
@@ -37,7 +37,7 @@ class CoachState:
 
 def _get_client() -> anthropic.AnthropicVertex:
     return anthropic.AnthropicVertex(
-        region=settings.gcp_region,
+        region=settings.claude_region,
         project_id=settings.gcp_project_id,
     )
 

--- a/api/app/services/coach_service.py
+++ b/api/app/services/coach_service.py
@@ -98,7 +98,7 @@ SYSTEM_PROMPT = """あなたは「Cycle」というアプリの中で、大き�
 def _get_client() -> anthropic.AnthropicVertex:
     """Vertex AI Claude client (ADC自動認証)."""
     return anthropic.AnthropicVertex(
-        region=settings.gcp_region,
+        region=settings.claude_region,
         project_id=settings.gcp_project_id,
     )
 


### PR DESCRIPTION
## Summary
asia-northeast1 / us-east5 / europe-west1 などのリージョンエンドポイントで Sonnet 4.5 / Haiku 4.5 を rawPredict すると 404 \`not found or your project does not have access\` が返るが、global エンドポイントだと 429 \`Quota exceeded\` が返る → アクセス権はあり quota だけ 0 状態と判明。

global は Sonnet 4.5 以降のリージョン pricing premium (10%) を回避でき、dynamic routing で可用性も高いため、本 PR で global へ切り替える。

## 変更
- \`config.py\`: \`claude_region: str = "global"\` を追加（\`gcp_region\` は asia-northeast1 のまま、Firestore など他のインフラリージョンとして残す）
- \`coach_graph.py\` / \`coach_service.py\`: \`AnthropicVertex\` の region パラメータを新フィールドに切替

## 公式根拠
[Claude on Vertex AI](https://platform.claude.com/docs/en/api/claude-on-vertex-ai):
> Global endpoints (recommended): Provide maximum availability and uptime / No pricing premium
> Regional endpoints: 10% pricing premium (Sonnet 4.5+)

## ユーザー側に残る作業
**quota 増枠申請**: \`global_online_prediction_requests_per_base_model\` (anthropic-claude-sonnet-4-5 / anthropic-claude-haiku-4-5) が 0 のため、Cloud Console → IAM & Admin → Quotas で申請。

## Test plan
- [ ] quota 増枠後、ローカルで \`/coach\` が応答を返す
- [ ] 既存テスト pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)