### PR TITLE
feat: Claude quota 待ちで Vertex AI Gemini fallback を実装

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -38,6 +38,14 @@ class Settings(BaseSettings):
     claude_max_tokens: int = 500
     claude_temperature: float = 0.7
 
+    # Gemini fallback（Vertex AI Claude の quota 申請待ち中の暫定）
+    # use_gemini_fallback=True のとき chat() は Gemini を呼ぶ。
+    # Claude quota が下りたら False にして Claude に戻す（追跡: 別 issue）。
+    use_gemini_fallback: bool = True
+    gemini_region: str = "global"
+    gemini_model_coach: str = "gemini-2.5-pro"  # Sonnet 相当
+    gemini_model_quick: str = "gemini-2.5-flash"  # Haiku 相当
+
     # LangGraphフローを有効にする（感情分析・Cycle要素判定・安全フィルター）
     use_langgraph: bool = False
 

--- a/api/app/services/coach_service.py
+++ b/api/app/services/coach_service.py
@@ -1,12 +1,15 @@
 # ruff: noqa: E501
-"""Coach service - System prompt (大樹メタファー) + Vertex AI Claude.
+"""Coach service - System prompt (大樹メタファー) + Vertex AI モデル呼び出し.
 
-Ported from api/src/handlers/coach.py (Lambda + Bedrock version).
+通常は Vertex AI Claude (Sonnet) を呼ぶが、quota 申請が下りるまでの暫定で
+settings.use_gemini_fallback=True のとき Vertex AI Gemini に切り替わる。
 
 注: SYSTEM_PROMPT は日本語多行文字列のため行長制限(E501)を本ファイルで無効化している。
 """
 
 import anthropic
+from google import genai
+from google.genai import types as genai_types
 
 from app.config import settings
 
@@ -95,11 +98,20 @@ SYSTEM_PROMPT = """あなたは「Cycle」というアプリの中で、大き�
 急かさず、競わせず、ただそばに在ってください。"""
 
 
-def _get_client() -> anthropic.AnthropicVertex:
+def _get_claude_client() -> anthropic.AnthropicVertex:
     """Vertex AI Claude client (ADC自動認証)."""
     return anthropic.AnthropicVertex(
         region=settings.claude_region,
         project_id=settings.gcp_project_id,
+    )
+
+
+def _get_gemini_client() -> genai.Client:
+    """Vertex AI Gemini client (ADC自動認証)."""
+    return genai.Client(
+        vertexai=True,
+        project=settings.gcp_project_id,
+        location=settings.gemini_region,
     )
 
 
@@ -110,30 +122,25 @@ async def chat(
 ) -> str:
     """コーチの応答を取得.
 
-    Args:
-        user_message: ユーザーのメッセージ
-        history: 過去のメッセージ履歴 [{"role": "user"|"assistant", "content": "..."}]
-        diary_content: 日記の内容（オプション）
-
-    Returns:
-        コーチの応答テキスト
+    settings.use_gemini_fallback=True のとき Gemini を呼ぶ。
+    Claude quota が下りたら False に戻す。
     """
-    client = _get_client()
-
-    # メッセージ履歴を構築
-    messages: list[dict] = []
-    if history:
-        messages.extend(history)
-
-    # ユーザーメッセージを構築
     content = user_message
     if diary_content:
         content = f"【日記の内容】\n{diary_content}\n\n【ユーザーのメッセージ】\n{user_message}"
 
+    if settings.use_gemini_fallback:
+        return _chat_gemini(content, history)
+    return _chat_claude(content, history)
+
+
+def _chat_claude(content: str, history: list[dict] | None) -> str:
+    client = _get_claude_client()
+    messages: list[dict] = []
+    if history:
+        messages.extend(history)
     messages.append({"role": "user", "content": content})
 
-    # SYSTEM_PROMPT を cache_control ephemeral でマークし、連続リクエスト時の
-    # input token コストを削減する (Sonnet caching の最小 prefix を満たす長さで運用)
     response = client.messages.create(
         model=settings.claude_model_coach,
         max_tokens=settings.claude_max_tokens,
@@ -147,5 +154,29 @@ async def chat(
         messages=messages,
         temperature=settings.claude_temperature,
     )
-
     return response.content[0].text
+
+
+def _chat_gemini(content: str, history: list[dict] | None) -> str:
+    client = _get_gemini_client()
+    contents: list[genai_types.Content] = []
+    if history:
+        for m in history:
+            role = "user" if m.get("role") == "user" else "model"
+            contents.append(
+                genai_types.Content(role=role, parts=[genai_types.Part(text=m["content"])])
+            )
+    contents.append(
+        genai_types.Content(role="user", parts=[genai_types.Part(text=content)])
+    )
+
+    response = client.models.generate_content(
+        model=settings.gemini_model_coach,
+        contents=contents,
+        config=genai_types.GenerateContentConfig(
+            system_instruction=SYSTEM_PROMPT,
+            max_output_tokens=settings.claude_max_tokens,
+            temperature=settings.claude_temperature,
+        ),
+    )
+    return response.text or ""

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "pydantic-settings>=2.5.0",
     "google-cloud-firestore>=2.19.0",
     "anthropic[vertex]>=0.42.0",
+    "google-genai>=1.0.0",
     "pyjwt[crypto]>=2.9.0",
     "httpx>=0.27.0",
     "h2>=4.1.0",

--- a/api/tests/test_coach_service.py
+++ b/api/tests/test_coach_service.py
@@ -1,7 +1,7 @@
-"""Coach service tests (B-3: prompt caching + SYSTEM_PROMPT expansion).
+"""Coach service tests.
 
-SYSTEM_PROMPT を Sonnet caching 最小要件(1024 tokens相当)に達するよう拡充し、
-messages.create の system パラメータに cache_control を付与することを確認する。
+通常は Claude path (use_gemini_fallback=False) の動作を検証する。
+Gemini fallback の動作（use_gemini_fallback=True がデフォルト）は別テストで確認。
 """
 
 from unittest.mock import MagicMock, patch
@@ -27,17 +27,17 @@ def test_system_prompt_is_long_enough_for_caching():
 def test_system_prompt_keeps_core_metaphor():
     """B-3: 拡張後も大樹メタファーの核となるキーワードを維持する."""
     prompt = coach_service.SYSTEM_PROMPT
-    # Cycle 8 要素
     for element in ["Soil", "Water", "Root", "Trunk", "Branch", "Leaf", "Fruit", "Sky"]:
         assert element in prompt, f"{element} が SYSTEM_PROMPT に含まれていない"
-    # 一人称
     assert "わたし" in prompt
 
 
 @pytest.mark.asyncio
-async def test_chat_uses_coach_model():
-    """B-2 + B-3: chat() は claude_model_coach (Sonnet) を使う."""
-    with patch("app.services.coach_service._get_client") as mock_get:
+async def test_chat_uses_coach_model_in_claude_mode(monkeypatch):
+    """Claude モード (use_gemini_fallback=False) では claude_model_coach (Sonnet) を使う."""
+    monkeypatch.setattr(settings, "use_gemini_fallback", False)
+
+    with patch("app.services.coach_service._get_claude_client") as mock_get:
         client = MagicMock()
         block = MagicMock()
         block.text = "そう感じたんだね。"
@@ -53,9 +53,11 @@ async def test_chat_uses_coach_model():
 
 
 @pytest.mark.asyncio
-async def test_chat_passes_system_with_cache_control():
-    """B-3: chat() は system を list 形式で渡し cache_control ephemeral を付ける."""
-    with patch("app.services.coach_service._get_client") as mock_get:
+async def test_chat_passes_system_with_cache_control_in_claude_mode(monkeypatch):
+    """Claude モードでは system を list 形式で渡し cache_control ephemeral を付ける."""
+    monkeypatch.setattr(settings, "use_gemini_fallback", False)
+
+    with patch("app.services.coach_service._get_claude_client") as mock_get:
         client = MagicMock()
         block = MagicMock()
         block.text = "ok"
@@ -68,10 +70,31 @@ async def test_chat_passes_system_with_cache_control():
 
         call_kwargs = client.messages.create.call_args.kwargs
         system = call_kwargs["system"]
-        # list 形式 (str ではなく構造化された system block)
         assert isinstance(system, list), "system は list で渡されるべき"
         assert len(system) >= 1
         first = system[0]
         assert first["type"] == "text"
         assert first["text"] == coach_service.SYSTEM_PROMPT
         assert first["cache_control"] == {"type": "ephemeral"}
+
+
+@pytest.mark.asyncio
+async def test_chat_uses_gemini_when_fallback_enabled(monkeypatch):
+    """Gemini fallback モードでは Gemini モデルを呼ぶ."""
+    monkeypatch.setattr(settings, "use_gemini_fallback", True)
+
+    with patch("app.services.coach_service._get_gemini_client") as mock_get:
+        client = MagicMock()
+        response = MagicMock()
+        response.text = "そう感じたんだね。"
+        client.models.generate_content.return_value = response
+        mock_get.return_value = client
+
+        result = await coach_service.chat(user_message="今日は疲れた")
+
+        assert result == "そう感じたんだね。"
+        call_kwargs = client.models.generate_content.call_args.kwargs
+        assert call_kwargs["model"] == settings.gemini_model_coach
+        # system_instruction は config 経由で渡される
+        cfg = call_kwargs["config"]
+        assert cfg.system_instruction == coach_service.SYSTEM_PROMPT

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -421,6 +421,8 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "google-cloud-firestore" },
+    { name = "google-genai" },
+    { name = "h2" },
     { name = "httpx" },
     { name = "langchain-core" },
     { name = "langgraph" },
@@ -446,6 +448,8 @@ requires-dist = [
     { name = "cryptography", specifier = ">=42.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "google-cloud-firestore", specifier = ">=2.19.0" },
+    { name = "google-genai", specifier = ">=1.0.0" },
+    { name = "h2", specifier = ">=4.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
@@ -575,6 +579,27 @@ wheels = [
 ]
 
 [[package]]
+name = "google-genai"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/52/0244e310812f3063d09d60b30ae29ab7df9343bd005744cd5eeaa6ba39b4/google_genai-2.8.0.tar.gz", hash = "sha256:37a9b3cb127d763e7f4ca47452ae3562c87728773bd1b149f7b559c239da2bc1", size = 564955, upload-time = "2026-06-03T22:55:38.397Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/de/747ad1aa49e902da9a4699081c282a1ed8ceed3b4d295fd99a6d286e09e4/google_genai-2.8.0-py3-none-any.whl", hash = "sha256:4da0a223a100f4b37f609a68b835e3326ab0fa313314dc0fd9d34e76ee293844", size = 832497, upload-time = "2026-06-03T22:55:36.598Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.73.0"
 source = { registry = "https://pypi.org/simple" }
@@ -651,6 +676,28 @@ wheels = [
 ]
 
 [[package]]
+name = "h2"
+version = "4.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hpack" },
+    { name = "hyperframe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/17/afa56379f94ad0fe8defd37d6eb3f89a25404ffc71d4d848893d270325fc/h2-4.3.0.tar.gz", hash = "sha256:6c59efe4323fa18b47a632221a1888bd7fde6249819beda254aeca909f221bf1", size = 2152026, upload-time = "2025-08-23T18:12:19.778Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl", hash = "sha256:c438f029a25f7945c69e0ccf0fb951dc3f73a5f6412981daee861431b70e2bdd", size = 61779, upload-time = "2025-08-23T18:12:17.779Z" },
+]
+
+[[package]]
+name = "hpack"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/48/71de9ed269fdae9c8057e5a4c0aa7402e8bb16f2c6e90b3aa53327b113f8/hpack-4.1.0.tar.gz", hash = "sha256:ec5eca154f7056aa06f196a557655c5b009b382873ac8d1e66e79e87535f1dca", size = 51276, upload-time = "2025-01-22T21:44:58.347Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl", hash = "sha256:157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496", size = 34357, upload-time = "2025-01-22T21:44:56.92Z" },
+]
+
+[[package]]
 name = "httpcore"
 version = "1.0.9"
 source = { registry = "https://pypi.org/simple" }
@@ -705,6 +752,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "hyperframe"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/02/e7/94f8232d4a74cc99514c13a9f995811485a6903d48e5d952771ef6322e30/hyperframe-6.1.0.tar.gz", hash = "sha256:f630908a00854a7adeabd6382b43923a4c4cd4b821fcb527e6ab9e15382a3b08", size = 26566, upload-time = "2025-01-22T21:41:49.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/30/47d0bf6072f7252e6521f3447ccfa40b421b6824517f82854703d0f5a98b/hyperframe-6.1.0-py3-none-any.whl", hash = "sha256:b03380493a519fce58ea5af42e4a42317bf9bd425596f7a0835ffce80f1a42e5", size = 13007, upload-time = "2025-01-22T21:41:47.295Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Vertex AI Claude (Sonnet 4.5 / Haiku 4.5) のリージョン未提供 + global quota 0 のため、Claude quota が下りるまでの暫定で **Gemini fallback** を実装。

- \`settings.use_gemini_fallback=True\`（デフォルト）→ \`coach_service.chat()\` が Gemini 2.5 Pro を呼ぶ
- \`False\` に戻すと Claude path（既存）に復帰
- SYSTEM_PROMPT は両方で共通

## 動作確認
- Gemini 2.5 Flash で疎通済（rawPredict HTTP 200）
- 既存 Claude path テスト pass（monkeypatch で \`use_gemini_fallback=False\` 固定）
- Gemini path の新規テスト pass
- ローカル \`uv run pytest tests/test_coach_service.py tests/test_config.py\` 11/11 pass

## 制限
- LangGraph (\`coach_graph.py\`) は未対応（\`use_langgraph=False\` がデフォルトのため運用影響なし）。Claude 復帰時に Cleanup する想定
- Gemini モードでは Claude の prompt caching (\`cache_control\`) が効かない

## 関連
- Claude 復帰追跡 issue: 別途作成予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)