### PR TITLE
docs: CLAUDE.md に Gemini fallback 状態を明記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,3 +22,13 @@
   Secret Manager, IAM, and Firestore resources live in `dev` or `prod`.
 - Firestore named database IDs must be at least 4 characters. The dev database
   is `dev-db`; production remains `(default)`.
+
+## AI Provider (Temporary)
+
+`coach_service.chat()` currently routes through **Vertex AI Gemini**
+(`settings.use_gemini_fallback=True`, default) because Vertex AI Claude (Sonnet
+4.5 / Haiku 4.5) is access-OK but **quota 0** on the global endpoint and not
+provisioned on regional endpoints. The Claude path is still in the codebase and
+can be re-enabled by setting `use_gemini_fallback=False` once quota is granted.
+
+Tracking: Issue #79. Do not remove the Gemini path until that issue is closed.


### PR DESCRIPTION
## Summary
PR #78 で coach_service が Vertex AI Claude → Gemini に暫定切替された経緯を CLAUDE.md に追記。Issue #79 で復帰追跡。

将来の Claude / 開発者が前提を見落とさないため。

🤖 Generated with [Claude Code](https://claude.com/claude-code)