### PR TITLE
feat: #24 SubscriptionStore.purchase → POST /iap/apple/verify 送信

### DIFF
--- a/ios/Cycle/Features/Subscription/Store/SubscriptionStore.swift
+++ b/ios/Cycle/Features/Subscription/Store/SubscriptionStore.swift
@@ -74,8 +74,12 @@ final class SubscriptionStore: ObservableObject {
 
     // MARK: - Purchase
 
-    /// プロダクトを購入。成功時にエンタイトルメント反映、jwsRepresentation を返す
-    /// (バックエンド検証用; 呼び出し側で API 送信)。
+    /// プロダクトを購入。成功時にエンタイトルメント反映 + サーバー側 verify を実行。
+    ///
+    /// サーバー verify は originalTransactionId を uid に紐付け、ASSN V2 webhook が
+    /// 更新・解約イベントで uid を解決できるようにするために必須。失敗してもクライアント
+    /// 側のエンタイトルメントは StoreKit の `Transaction.currentEntitlements` を信頼
+    /// するため、UX は止めない（ログに残してリトライは後続実装）。
     @discardableResult
     func purchase(_ product: Product) async throws -> String? {
         let result = try await product.purchase()
@@ -83,10 +87,12 @@ final class SubscriptionStore: ObservableObject {
         case .success(let verification):
             switch verification {
             case .verified(let transaction):
+                let jws = verification.jwsRepresentation
+                await sendVerifyToBackend(jws: jws)
                 await refreshEntitlements()
                 await applyTrialNotificationSideEffects(for: transaction)
                 await transaction.finish()
-                return verification.jwsRepresentation
+                return jws
             case .unverified:
                 throw SubscriptionError.unverifiedTransaction
             }
@@ -96,6 +102,18 @@ final class SubscriptionStore: ObservableObject {
             return nil
         @unknown default:
             return nil
+        }
+    }
+
+    private func sendVerifyToBackend(jws: String) async {
+        do {
+            _ = try await SubscriptionService().verifyPurchase(
+                jwsRepresentation: jws
+            )
+        } catch {
+            // verify 失敗はエンタイトルメント反映を止めない（StoreKit が一次情報）。
+            // 後続: pending jws を UserDefaults に積んで起動時リトライする等。
+            print("[SubscriptionStore] verifyPurchase failed: \(error)")
         }
     }
 

--- a/ios/Cycle/Services/SubscriptionService.swift
+++ b/ios/Cycle/Services/SubscriptionService.swift
@@ -16,6 +16,19 @@ struct IAPDeviceTokenResponse: Decodable {
     let status: String
 }
 
+struct IAPVerifyRequest: Encodable {
+    let jwsRepresentation: String
+    let ga4ClientId: String?
+}
+
+struct IAPVerifyResponse: Decodable {
+    let status: String
+    let isActive: Bool
+    let subscriptionStatus: String
+    let productId: String
+    let expiresDateMs: Int64
+}
+
 enum APNsDeviceTokenRegistry {
     private static let key = "apnsDeviceToken"
 
@@ -33,6 +46,23 @@ final class SubscriptionService {
 
     init(apiClient: APIClient = .shared) {
         self.apiClient = apiClient
+    }
+
+    /// StoreKit2 で購入完了した jwsRepresentation をサーバーで検証し、
+    /// originalTransactionId と uid を紐付ける。
+    func verifyPurchase(
+        jwsRepresentation: String,
+        ga4ClientId: String? = nil
+    ) async throws -> IAPVerifyResponse {
+        let request = IAPVerifyRequest(
+            jwsRepresentation: jwsRepresentation,
+            ga4ClientId: ga4ClientId
+        )
+        return try await apiClient.post(
+            path: "/iap/apple/verify",
+            body: request,
+            requiresAuth: true
+        )
     }
 
     func registerAPNsDeviceToken(_ token: String) async throws {


### PR DESCRIPTION
## Summary
#69 のクリティカルパス1：iOS 購入完了直後の jwsRepresentation を \`POST /iap/apple/verify\` でサーバーに送る実装。

これが無いと originalTransactionId → uid のリンクが作られず、ASSN V2 webhook が更新・解約・返金イベントで誰の購入か解決できない。

## 変更
- \`SubscriptionService.verifyPurchase(jwsRepresentation:ga4ClientId:)\` 追加
- \`SubscriptionStore.purchase\` 内で \`sendVerifyToBackend\` を呼ぶ
- verify 失敗時は **非ブロッキング**: StoreKit \`Transaction.currentEntitlements\` が一次情報なのでエンタイトルメント反映は止めない。失敗は print log（後続でリトライキュー実装の余地あり）

## API contract
backend の \`VerifyRequest\` は \`populate_by_name=True\` で snake_case (\`jws_representation\`) と camelCase (\`jwsRepresentation\`) の両方を受け付ける。\`APIClient\` の \`keyEncodingStrategy=.convertToSnakeCase\` で snake_case に変換して送るため互換性 OK。

## 残るクリティカルパス
- 本番 API 再デプロイ（#58 / 協力者）

## Test plan
- [ ] TestFlight + Sandbox で購入 → サーバーログに \`/iap/apple/verify\` 200 が出る
- [ ] Firestore \`iap_links/{originalTransactionId}\` に \`uid\` が記録される
- [ ] その後の ASSN V2 (Apple → サーバー) で同じ uid が解決される

🤖 Generated with [Claude Code](https://claude.com/claude-code)