### PR TITLE
fix: ruff E501 line-too-long を修正（main CI 復旧）

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -28,8 +28,8 @@ class Settings(BaseSettings):
     # NOTE: Sonnet 4.5 / Haiku 4.5 はリージョンエンドポイント (asia-northeast1 等) で
     # 未提供のため global エンドポイントを使う。global は dynamic routing で可用性が
     # 高く、Sonnet 4.5 以降のリージョン pricing premium (10%) も避けられる。
-    # quota はベースモデル単位で `aiplatform.googleapis.com/global_online_prediction_requests_per_base_model`
-    # が制御。初期値は 0 のため Cloud Console → IAM & Admin → Quotas で増枠申請が必要。
+    # quota はベースモデル単位 (anthropic-claude-sonnet-4-5 等) で制御。初期値は 0 の
+    # ため Cloud Console → IAM & Admin → Quotas で増枠申請が必要。
     claude_region: str = "global"
     claude_model_coach: str = "claude-sonnet-4-5@20250929"
     claude_model_quick: str = "claude-haiku-4-5@20251001"

--- a/api/tests/test_coach_service.py
+++ b/api/tests/test_coach_service.py
@@ -34,7 +34,7 @@ def test_system_prompt_keeps_core_metaphor():
 
 @pytest.mark.asyncio
 async def test_chat_uses_coach_model_in_claude_mode(monkeypatch):
-    """Claude モード (use_gemini_fallback=False) では claude_model_coach (Sonnet) を使う."""
+    """Claude モード (use_gemini_fallback=False) では Sonnet を使う."""
     monkeypatch.setattr(settings, "use_gemini_fallback", False)
 
     with patch("app.services.coach_service._get_claude_client") as mock_get:


### PR DESCRIPTION
## Summary
PR #75 を main 昇格した際、\`api/app/config.py\` と \`api/tests/test_coach_service.py\` で **ruff E501 line-too-long** が 2 件出て API CI が失敗。

CLAUDE.md ルール通り **fix/* → main → develop back-merge** の hotfix。

## 変更
- \`api/app/config.py\`: コメント行を 88 chars 以内に
- \`api/tests/test_coach_service.py\`: docstring 短縮

## Verification
- \`uv run ruff check .\` ローカルで **All checks passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)