### PR TITLE
fix: ITSAppUsesNonExemptEncryption=false で Export Compliance を明示

### DIFF
--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
TestFlight 配信前に毎回出る「アプリの暗号化書類」モーダルを Info.plist で省略する。

iOS アプリで使用される暗号化は HTTPS / Sign in with Apple / Keychain / StoreKit などの **iOS 標準暗号化のみ**で、独自暗号化アルゴリズムは未実装。US Export Administration Regulations 上の exempt 対象なので \`ITSAppUsesNonExemptEncryption=false\` で宣言。

## 効果
- TestFlight upload 後の compliance 待ちが無くなる
- 「コンプライアンスがありません」ステータスを経由せず即配信可能に

🤖 Generated with [Claude Code](https://claude.com/claude-code)