### PR TITLE
fix: Firestore tasks に user_id + created_at index 追加 (500 修正)

### DIFF
--- a/infra/firestore.tf
+++ b/infra/firestore.tf
@@ -24,6 +24,23 @@ resource "google_firestore_index" "sessions_by_created_at" {
   }
 }
 
+# タスク一覧取得用 (status フィルター無し、ユーザー別・作成日降順)
+resource "google_firestore_index" "tasks_by_created_at" {
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "tasks"
+
+  fields {
+    field_path = "user_id"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
 # タスク一覧取得用（ユーザー別・ステータス・作成日降順）
 resource "google_firestore_index" "tasks_by_status" {
   project    = var.project_id


### PR DESCRIPTION
## Summary
タスク一覧画面で 500 が出ていた原因。Cloud Run logs に：
\`\`\`
google.api_core.exceptions.FailedPrecondition: 400 The query requires an index.
\`\`\`
\`list_tasks\` の status 指定なし query が user_id ASC + created_at DESC 複合 index を要求していたが、既存の \`tasks_by_status\` (3 field) しか定義されていなかった。

## 反映方法
- terraform apply で本番反映（即時に index 構築完了するわけではない、build 数分かかる）
- 同時に Firebase Console で手動作成も可（エラーログ内のリンクから 1 クリック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)