### PR TITLE
feat: 構造化ログ middleware を整備 (Cloud Logging 連携)

### DIFF
--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -3,6 +3,7 @@
 from fastapi import Depends, Request
 from google.cloud.firestore import AsyncClient
 
+from app.logging_config import uid_var
 from app.middleware.auth_middleware import get_current_user_id
 from app.services.firestore_client import get_db
 
@@ -13,8 +14,10 @@ async def get_firestore() -> AsyncClient:
 
 
 async def get_current_user(request: Request) -> str:
-    """Authenticated user_id dependency."""
-    return await get_current_user_id(request)
+    """Authenticated user_id dependency. uid を log ContextVar に bind する."""
+    uid = await get_current_user_id(request)
+    uid_var.set(uid)
+    return uid
 
 
 # Type aliases for use in Depends()

--- a/api/app/logging_config.py
+++ b/api/app/logging_config.py
@@ -1,0 +1,77 @@
+"""Structured logging for Cloud Run.
+
+Cloud Run は stdout に JSON を吐けば Cloud Logging が jsonPayload として記録し、
+`severity` を level に、`logging.googleapis.com/trace` を Trace と紐付ける。
+ContextVar で request_id / uid をリクエスト単位に持ち回り、すべての log line に
+自動的に付与する（middleware と get_current_user 側で set する）。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from contextvars import ContextVar
+from typing import Any
+
+request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+uid_var: ContextVar[str | None] = ContextVar("uid", default=None)
+
+_STD_LOG_ATTRS = {
+    "args", "asctime", "created", "exc_info", "exc_text", "filename", "funcName",
+    "levelname", "levelno", "lineno", "message", "module", "msecs", "msg", "name",
+    "pathname", "process", "processName", "relativeCreated", "stack_info", "thread",
+    "threadName", "taskName",
+}
+
+
+class JsonFormatter(logging.Formatter):
+    """Cloud Run friendly JSON formatter."""
+
+    def __init__(self, project_id: str | None = None) -> None:
+        super().__init__()
+        self._project_id = project_id
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "severity": record.levelname,
+            "message": record.getMessage(),
+            "logger": record.name,
+        }
+        rid = request_id_var.get()
+        if rid:
+            payload["request_id"] = rid
+            if self._project_id:
+                payload["logging.googleapis.com/trace"] = (
+                    f"projects/{self._project_id}/traces/{rid}"
+                )
+        uid = uid_var.get()
+        if uid:
+            payload["uid"] = uid
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        # extra=... で渡された任意の key-value を上に乗せる
+        for key, value in record.__dict__.items():
+            if key in _STD_LOG_ATTRS or key.startswith("_"):
+                continue
+            if key in payload:
+                continue
+            payload[key] = value
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+def setup_logging(level: str = "INFO", project_id: str | None = None) -> None:
+    """root logger と uvicorn 系を JSON formatter に揃える."""
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter(project_id=project_id))
+
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)
+
+    # uvicorn は default で stderr に独自 handler を付けるため上書き。
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "fastapi"):
+        logger = logging.getLogger(name)
+        logger.handlers = [handler]
+        logger.propagate = False
+        logger.setLevel(level)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -5,7 +5,11 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.exceptions import AppError, app_error_handler
+from app.logging_config import setup_logging
+from app.middleware.request_id import RequestIdMiddleware
 from app.routers import auth, coach, health, iap, sessions, tasks, users
+
+setup_logging(project_id=settings.gcp_project_id)
 
 app = FastAPI(
     title="CycleJournal API",
@@ -13,6 +17,7 @@ app = FastAPI(
     docs_url="/docs" if settings.environment == "dev" else None,
 )
 
+app.add_middleware(RequestIdMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/api/app/middleware/request_id.py
+++ b/api/app/middleware/request_id.py
@@ -1,0 +1,57 @@
+"""Request ID middleware.
+
+Cloud Run は X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=1 を付ける。
+それがあれば TRACE_ID を request_id として再利用する（Cloud Trace と紐づく）。
+無ければクライアントの X-Request-ID か uuid を使う。
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.logging_config import request_id_var
+
+logger = logging.getLogger("app.request")
+
+
+def _extract_request_id(request: Request) -> str:
+    trace = request.headers.get("X-Cloud-Trace-Context", "")
+    if "/" in trace:
+        return trace.split("/", 1)[0]
+    return request.headers.get("X-Request-ID") or uuid.uuid4().hex
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        rid = _extract_request_id(request)
+        token = request_id_var.set(rid)
+        start = time.perf_counter()
+        status = 500
+        try:
+            response = await call_next(request)
+            status = response.status_code
+            response.headers["X-Request-ID"] = rid
+            return response
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            logger.info(
+                "http_request",
+                extra={
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status": status,
+                    "elapsed_ms": round(elapsed_ms, 2),
+                },
+            )
+            request_id_var.reset(token)


### PR DESCRIPTION
## Summary
Cloud Run 上で stdout に JSON を吐けば Cloud Logging が jsonPayload として記録 + severity / trace と紐づく。今まで print + uvicorn plain text 混在で「どの uid のどのリクエストか」追えなかった。

## 変更
- \`logging_config.py\`: \`JsonFormatter\` + \`setup_logging()\`、\`request_id_var\` / \`uid_var\` の ContextVar を出力に自動付与
- \`middleware/request_id.py\`: X-Cloud-Trace-Context の TRACE_ID を request_id として再利用、Cloud Trace と紐づく
- \`dependencies.py::get_current_user\`: 解決した uid を ContextVar に bind
- \`main.py\`: setup_logging + middleware 登録

## 関連
- #85 (Firestore index): タスクリスト 500 の原因。これを契機にログ整備

🤖 Generated with [Claude Code](https://claude.com/claude-code)