### PR TITLE
release: develop → main 昇格 (Firestore index 修正 + 構造化ログ)

### DIFF
--- a/api/app/dependencies.py
+++ b/api/app/dependencies.py
@@ -3,6 +3,7 @@
 from fastapi import Depends, Request
 from google.cloud.firestore import AsyncClient
 
+from app.logging_config import uid_var
 from app.middleware.auth_middleware import get_current_user_id
 from app.services.firestore_client import get_db
 
@@ -13,8 +14,10 @@ async def get_firestore() -> AsyncClient:
 
 
 async def get_current_user(request: Request) -> str:
-    """Authenticated user_id dependency."""
-    return await get_current_user_id(request)
+    """Authenticated user_id dependency. uid を log ContextVar に bind する."""
+    uid = await get_current_user_id(request)
+    uid_var.set(uid)
+    return uid
 
 
 # Type aliases for use in Depends()

--- a/api/app/logging_config.py
+++ b/api/app/logging_config.py
@@ -1,0 +1,77 @@
+"""Structured logging for Cloud Run.
+
+Cloud Run は stdout に JSON を吐けば Cloud Logging が jsonPayload として記録し、
+`severity` を level に、`logging.googleapis.com/trace` を Trace と紐付ける。
+ContextVar で request_id / uid をリクエスト単位に持ち回り、すべての log line に
+自動的に付与する（middleware と get_current_user 側で set する）。
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from contextvars import ContextVar
+from typing import Any
+
+request_id_var: ContextVar[str | None] = ContextVar("request_id", default=None)
+uid_var: ContextVar[str | None] = ContextVar("uid", default=None)
+
+_STD_LOG_ATTRS = {
+    "args", "asctime", "created", "exc_info", "exc_text", "filename", "funcName",
+    "levelname", "levelno", "lineno", "message", "module", "msecs", "msg", "name",
+    "pathname", "process", "processName", "relativeCreated", "stack_info", "thread",
+    "threadName", "taskName",
+}
+
+
+class JsonFormatter(logging.Formatter):
+    """Cloud Run friendly JSON formatter."""
+
+    def __init__(self, project_id: str | None = None) -> None:
+        super().__init__()
+        self._project_id = project_id
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, Any] = {
+            "severity": record.levelname,
+            "message": record.getMessage(),
+            "logger": record.name,
+        }
+        rid = request_id_var.get()
+        if rid:
+            payload["request_id"] = rid
+            if self._project_id:
+                payload["logging.googleapis.com/trace"] = (
+                    f"projects/{self._project_id}/traces/{rid}"
+                )
+        uid = uid_var.get()
+        if uid:
+            payload["uid"] = uid
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        # extra=... で渡された任意の key-value を上に乗せる
+        for key, value in record.__dict__.items():
+            if key in _STD_LOG_ATTRS or key.startswith("_"):
+                continue
+            if key in payload:
+                continue
+            payload[key] = value
+        return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+def setup_logging(level: str = "INFO", project_id: str | None = None) -> None:
+    """root logger と uvicorn 系を JSON formatter に揃える."""
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter(project_id=project_id))
+
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)
+
+    # uvicorn は default で stderr に独自 handler を付けるため上書き。
+    for name in ("uvicorn", "uvicorn.access", "uvicorn.error", "fastapi"):
+        logger = logging.getLogger(name)
+        logger.handlers = [handler]
+        logger.propagate = False
+        logger.setLevel(level)

--- a/api/app/main.py
+++ b/api/app/main.py
@@ -5,7 +5,11 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
 from app.exceptions import AppError, app_error_handler
+from app.logging_config import setup_logging
+from app.middleware.request_id import RequestIdMiddleware
 from app.routers import auth, coach, health, iap, sessions, tasks, users
+
+setup_logging(project_id=settings.gcp_project_id)
 
 app = FastAPI(
     title="CycleJournal API",
@@ -13,6 +17,7 @@ app = FastAPI(
     docs_url="/docs" if settings.environment == "dev" else None,
 )
 
+app.add_middleware(RequestIdMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],

--- a/api/app/middleware/request_id.py
+++ b/api/app/middleware/request_id.py
@@ -1,0 +1,57 @@
+"""Request ID middleware.
+
+Cloud Run は X-Cloud-Trace-Context: TRACE_ID/SPAN_ID;o=1 を付ける。
+それがあれば TRACE_ID を request_id として再利用する（Cloud Trace と紐づく）。
+無ければクライアントの X-Request-ID か uuid を使う。
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from collections.abc import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+from app.logging_config import request_id_var
+
+logger = logging.getLogger("app.request")
+
+
+def _extract_request_id(request: Request) -> str:
+    trace = request.headers.get("X-Cloud-Trace-Context", "")
+    if "/" in trace:
+        return trace.split("/", 1)[0]
+    return request.headers.get("X-Request-ID") or uuid.uuid4().hex
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        rid = _extract_request_id(request)
+        token = request_id_var.set(rid)
+        start = time.perf_counter()
+        status = 500
+        try:
+            response = await call_next(request)
+            status = response.status_code
+            response.headers["X-Request-ID"] = rid
+            return response
+        finally:
+            elapsed_ms = (time.perf_counter() - start) * 1000
+            logger.info(
+                "http_request",
+                extra={
+                    "method": request.method,
+                    "path": request.url.path,
+                    "status": status,
+                    "elapsed_ms": round(elapsed_ms, 2),
+                },
+            )
+            request_id_var.reset(token)

--- a/infra/firestore.tf
+++ b/infra/firestore.tf
@@ -24,6 +24,23 @@ resource "google_firestore_index" "sessions_by_created_at" {
   }
 }
 
+# タスク一覧取得用 (status フィルター無し、ユーザー別・作成日降順)
+resource "google_firestore_index" "tasks_by_created_at" {
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "tasks"
+
+  fields {
+    field_path = "user_id"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
 # タスク一覧取得用（ユーザー別・ステータス・作成日降順）
 resource "google_firestore_index" "tasks_by_status" {
   project    = var.project_id

--- a/ios/Cycle/Features/Settings/Views/SettingsView.swift
+++ b/ios/Cycle/Features/Settings/Views/SettingsView.swift
@@ -11,16 +11,20 @@ struct SettingsView: View {
     @EnvironmentObject var taskViewModel: TaskViewModel
     @EnvironmentObject var coachStore: CoachStore
 
+    @StateObject private var subscriptionStore = SubscriptionStore()
+
     @State private var notificationSettings = NotificationSettingsStore.load()
     @State private var systemPermissionGranted = false
-    @State private var showingPrivacyPolicy = false
-    @State private var showingTerms = false
+    @State private var showingPaywall = false
     @State private var showingDataExport = false
     @State private var showingSignOutAlert = false
     @State private var showingClearDataAlert = false
     @State private var showingComponentCatalog = false
     @State private var showingDeleteAccountAlert = false
     @State private var isDeletingAccount = false
+
+    private let privacyURL = "https://akitoando.github.io/cycle-journal/legal/PRIVACY_POLICY.html"
+    private let termsURL = "https://akitoando.github.io/cycle-journal/legal/TERMS_OF_SERVICE.html"
 
     var body: some View {
         NavigationStack {
@@ -123,6 +127,11 @@ struct SettingsView: View {
                     }
                 }
 
+                // Premium セクション
+                Section("Premium") {
+                    premiumRow
+                }
+
                 // 通知セクション
                 Section("通知") {
                     if !systemPermissionGranted {
@@ -179,25 +188,29 @@ struct SettingsView: View {
 
                 // サポートセクション
                 Section("サポート") {
-                    Button(action: { showingPrivacyPolicy = true }) {
-                        HStack {
-                            Text("プライバシーポリシー")
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .foregroundColor(.secondary)
+                    if let url = URL(string: privacyURL) {
+                        Link(destination: url) {
+                            HStack {
+                                Text("プライバシーポリシー")
+                                Spacer()
+                                Image(systemName: "arrow.up.right.square")
+                                    .foregroundColor(.secondary)
+                            }
                         }
+                        .foregroundColor(.primary)
                     }
-                    .foregroundColor(.primary)
 
-                    Button(action: { showingTerms = true }) {
-                        HStack {
-                            Text("利用規約")
-                            Spacer()
-                            Image(systemName: "chevron.right")
-                                .foregroundColor(.secondary)
+                    if let url = URL(string: termsURL) {
+                        Link(destination: url) {
+                            HStack {
+                                Text("利用規約")
+                                Spacer()
+                                Image(systemName: "arrow.up.right.square")
+                                    .foregroundColor(.secondary)
+                            }
                         }
+                        .foregroundColor(.primary)
                     }
-                    .foregroundColor(.primary)
 
                     HStack {
                         Text("バージョン")
@@ -246,11 +259,8 @@ struct SettingsView: View {
             }
             .navigationTitle("設定")
             .modifier(GlassNavBarModifier())
-            .sheet(isPresented: $showingPrivacyPolicy) {
-                WebDocumentView(title: "プライバシーポリシー", urlString: "https://example.com/privacy")
-            }
-            .sheet(isPresented: $showingTerms) {
-                WebDocumentView(title: "利用規約", urlString: "https://example.com/terms")
+            .sheet(isPresented: $showingPaywall) {
+                PaywallView()
             }
             .sheet(isPresented: $showingDataExport) {
                 DataExportView()
@@ -289,7 +299,50 @@ struct SettingsView: View {
             }
             .task {
                 await checkNotificationPermission()
+                await subscriptionStore.loadProducts()
+                await subscriptionStore.refreshEntitlements()
             }
+        }
+    }
+
+    // MARK: - Premium Row
+
+    @ViewBuilder
+    private var premiumRow: some View {
+        switch subscriptionStore.state {
+        case .active(_, let expiresAt), .trial(_, let expiresAt):
+            HStack {
+                Image(systemName: "checkmark.seal.fill")
+                    .foregroundColor(.green)
+                VStack(alignment: .leading) {
+                    Text("Cycle Premium")
+                        .font(DesignSystem.Fonts.button)
+                    Text(premiumStatusText(expiresAt: expiresAt))
+                        .font(DesignSystem.Fonts.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+            }
+            .padding(.vertical, 4)
+        default:
+            Button(action: { showingPaywall = true }) {
+                HStack {
+                    Image(systemName: "sparkles")
+                        .foregroundColor(.orange)
+                    VStack(alignment: .leading) {
+                        Text("Cycle Premium にアップグレード")
+                            .font(DesignSystem.Fonts.button)
+                        Text("3日間無料で始める")
+                            .font(DesignSystem.Fonts.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+            .foregroundColor(.primary)
         }
     }
 
@@ -352,6 +405,18 @@ struct SettingsView: View {
     }
 
     // MARK: - Helpers
+
+    private func premiumStatusText(expiresAt: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        let prefix: String
+        if case .trial = subscriptionStore.state {
+            prefix = "トライアル中・"
+        } else {
+            prefix = ""
+        }
+        return prefix + "次回更新 \(formatter.string(from: expiresAt))"
+    }
 
     private var appVersion: String {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "1.0"

--- a/ios/Info.plist
+++ b/ios/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
- PR #85: Firestore tasks 用 user_id + created_at 複合インデックス定義 (terraform)
- PR #86: 構造化ログ middleware (Cloud Logging 連携)
- PR #84: 設定画面に Paywall 動線追加

タスクリスト 500 を解消するための急ぎリリース。

## デプロイ後の効果
- \`/tasks\` の 500 が消える（Firebase Console URL で index 即時作成済 or terraform apply 後）
- 全リクエストに request_id / uid 付き JSON ログ
- Cloud Trace と request_id が同一になり、ログから直接 Trace にジャンプ可

🤖 Generated with [Claude Code](https://claude.com/claude-code)