### PR TITLE
fix: coach の max_tokens を 500 → 2000 に引き上げ

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -35,7 +35,7 @@ class Settings(BaseSettings):
     claude_model_quick: str = "claude-haiku-4-5@20251001"
     # 後方互換: 既存環境変数 CLAUDE_MODEL を coach 用のエイリアスとして残す
     claude_model: str = "claude-sonnet-4-5@20250929"
-    claude_max_tokens: int = 500
+    claude_max_tokens: int = 2000
     claude_temperature: float = 0.7
 
     # Gemini fallback（Vertex AI Claude の quota 申請待ち中の暫定）


### PR DESCRIPTION
## Summary
ユーザー FB: 「日記機能（Coach 応答）が会話途中で文章が止まる」。

Gemini fallback の \`max_output_tokens=500\` が thinking tokens を引いた実出力 1〜2 文程度しかなく途切れて見える。2000 に引き上げ。

Cloud Run prod は \`gcloud run services update --update-env-vars=CLAUDE_MAX_TOKENS=2000\` で先行反映済（revision cycle-api-prod-00012-67v）。本 PR は default 値の同期。