### PR TITLE
feat: #90 /coach/stream を SSE で実装 + ガードレール

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -38,6 +38,11 @@ class Settings(BaseSettings):
     claude_max_tokens: int = 2000
     claude_temperature: float = 0.7
 
+    # Coach API ガードレール
+    coach_input_max_chars: int = 10_000
+    coach_output_max_tokens_cap: int = 4_000  # 暴走時の hard cap
+    coach_stream_timeout_seconds: int = 60
+
     # Gemini fallback（Vertex AI Claude の quota 申請待ち中の暫定）
     # use_gemini_fallback=True のとき chat() は Gemini を呼ぶ。
     # Claude quota が下りたら False にして Claude に戻す（追跡: 別 issue）。

--- a/api/app/routers/coach.py
+++ b/api/app/routers/coach.py
@@ -1,9 +1,13 @@
 """Coach endpoint - AI coaching with Vertex AI Claude."""
 
+import asyncio
+import json
+import logging
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from google.cloud.firestore import AsyncClient
 
 from app.config import settings
@@ -14,6 +18,18 @@ from app.services.coach_graph import run_coach_flow
 from app.services.firestore_client import sessions_ref
 
 router = APIRouter(tags=["Coach"])
+logger = logging.getLogger("app.coach")
+
+
+def _validate_input_size(message: str) -> None:
+    if len(message) > settings.coach_input_max_chars:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"message too long: {len(message)} chars "
+                f"(limit {settings.coach_input_max_chars})"
+            ),
+        )
 
 
 @router.post("/coach")
@@ -23,6 +39,7 @@ async def chat(
     db: AsyncClient = Depends(get_firestore),
 ):
     """ユーザーのメッセージに対してAIコーチが応答."""
+    _validate_input_size(body.message)
     now = datetime.now(UTC)
     ref = sessions_ref(db)
 
@@ -137,3 +154,146 @@ async def chat(
             ),
         )
     }
+
+
+async def _ensure_session(
+    db: AsyncClient,
+    user_id: str,
+    body: CoachRequest,
+    now: datetime,
+) -> tuple[str, object]:
+    ref = sessions_ref(db)
+    session_id = body.session_id or str(uuid.uuid4())
+    session_doc = ref.document(session_id)
+    snap = await session_doc.get()
+    if snap.exists and snap.get("user_id") != user_id:
+        session_id = str(uuid.uuid4())
+        session_doc = ref.document(session_id)
+        snap = await session_doc.get()
+    if not snap.exists:
+        cycle_element = (
+            body.context.cycle_element.value
+            if body.context and body.context.cycle_element
+            else None
+        )
+        await session_doc.set(
+            {
+                "user_id": user_id,
+                "title": None,
+                "cycle_element": cycle_element,
+                "has_diary_context": body.diary_content is not None,
+                "message_count": 0,
+                "last_message_at": now,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+    return session_id, session_doc
+
+
+@router.post("/coach/stream")
+async def chat_stream(
+    body: CoachRequest,
+    user_id: str = Depends(get_current_user),
+    db: AsyncClient = Depends(get_firestore),
+):
+    """Server-Sent Events で chunk 単位に応答を返す."""
+    _validate_input_size(body.message)
+    now = datetime.now(UTC)
+    session_id, session_doc = await _ensure_session(db, user_id, body, now)
+
+    messages_ref = session_doc.collection("messages")
+    history_query = messages_ref.order_by("created_at").limit(50)
+    history_docs = [doc async for doc in history_query.stream()]
+    history = [
+        {"role": doc.get("role"), "content": doc.get("content")} for doc in history_docs
+    ]
+
+    # ユーザーメッセージは streaming 開始前に保存（途中で失敗しても残す）
+    user_msg_id = str(uuid.uuid4())
+    await messages_ref.document(user_msg_id).set(
+        {"role": "user", "content": body.message, "metadata": None, "created_at": now}
+    )
+
+    async def event_source():
+        # SSE 起動メッセージ
+        yield f"event: session\ndata: {json.dumps({'session_id': session_id})}\n\n"
+        accumulated = ""
+        try:
+            async def consume():
+                nonlocal accumulated
+                async for chunk in coach_service.chat_stream(
+                    user_message=body.message,
+                    history=history,
+                    diary_content=body.diary_content,
+                ):
+                    accumulated += chunk
+                    yield chunk
+
+            async for chunk in _with_timeout(
+                consume(), settings.coach_stream_timeout_seconds
+            ):
+                yield f"data: {json.dumps({'chunk': chunk})}\n\n"
+        except TimeoutError:
+            logger.warning("coach stream timeout", extra={"session_id": session_id})
+            yield f"event: error\ndata: {json.dumps({'reason': 'timeout'})}\n\n"
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("coach stream failed", extra={"session_id": session_id})
+            yield (
+                "event: error\ndata: "
+                + json.dumps({"reason": "internal", "detail": str(exc)[:200]})
+                + "\n\n"
+            )
+        finally:
+            # 完了後に assistant メッセージを保存（部分応答でも残す）
+            if accumulated:
+                assistant_now = datetime.now(UTC)
+                assistant_msg_id = str(uuid.uuid4())
+                await messages_ref.document(assistant_msg_id).set(
+                    {
+                        "role": "assistant",
+                        "content": accumulated,
+                        "metadata": {
+                            "model": settings.claude_model,
+                            "streamed": True,
+                        },
+                        "created_at": assistant_now,
+                    }
+                )
+                snap = await session_doc.get()
+                data = snap.to_dict() or {}
+                await session_doc.update(
+                    {
+                        "message_count": data.get("message_count", 0) + 2,
+                        "last_message_at": assistant_now,
+                        "updated_at": assistant_now,
+                    }
+                )
+            yield "event: done\ndata: {}\n\n"
+
+    return StreamingResponse(event_source(), media_type="text/event-stream")
+
+
+async def _with_timeout(agen, seconds: int):
+    """async generator に総時間タイムアウトをかける."""
+    queue: asyncio.Queue = asyncio.Queue()
+    sentinel = object()
+
+    async def pump():
+        try:
+            async for item in agen:
+                await queue.put(item)
+        finally:
+            await queue.put(sentinel)
+
+    task = asyncio.create_task(pump())
+    try:
+        async with asyncio.timeout(seconds):
+            while True:
+                item = await queue.get()
+                if item is sentinel:
+                    return
+                yield item
+    finally:
+        if not task.done():
+            task.cancel()

--- a/api/app/services/coach_service.py
+++ b/api/app/services/coach_service.py
@@ -7,11 +7,17 @@ settings.use_gemini_fallback=True のとき Vertex AI Gemini に切り替わる�
 注: SYSTEM_PROMPT は日本語多行文字列のため行長制限(E501)を本ファイルで無効化している。
 """
 
+from collections.abc import AsyncIterator
+
 import anthropic
 from google import genai
 from google.genai import types as genai_types
 
 from app.config import settings
+
+
+def _capped_max_tokens() -> int:
+    return min(settings.claude_max_tokens, settings.coach_output_max_tokens_cap)
 
 # ベースプロンプト（Cycleの大樹スタイル）
 # NOTE: prompt caching を有効化するため、Sonnet の最小 cacheable prefix
@@ -159,6 +165,23 @@ def _chat_claude(content: str, history: list[dict] | None) -> str:
 
 def _chat_gemini(content: str, history: list[dict] | None) -> str:
     client = _get_gemini_client()
+    contents = _build_gemini_contents(content, history)
+    response = client.models.generate_content(
+        model=settings.gemini_model_coach,
+        contents=contents,
+        config=genai_types.GenerateContentConfig(
+            system_instruction=SYSTEM_PROMPT,
+            max_output_tokens=_capped_max_tokens(),
+            temperature=settings.claude_temperature,
+        ),
+    )
+    return response.text or ""
+
+
+def _build_gemini_contents(
+    content: str,
+    history: list[dict] | None,
+) -> list[genai_types.Content]:
     contents: list[genai_types.Content] = []
     if history:
         for m in history:
@@ -166,17 +189,35 @@ def _chat_gemini(content: str, history: list[dict] | None) -> str:
             contents.append(
                 genai_types.Content(role=role, parts=[genai_types.Part(text=m["content"])])
             )
-    contents.append(
-        genai_types.Content(role="user", parts=[genai_types.Part(text=content)])
-    )
+    contents.append(genai_types.Content(role="user", parts=[genai_types.Part(text=content)]))
+    return contents
 
-    response = client.models.generate_content(
+
+async def chat_stream(
+    user_message: str,
+    history: list[dict] | None = None,
+    diary_content: str | None = None,
+) -> AsyncIterator[str]:
+    """ストリーミングでテキスト chunk を yield する.
+
+    現状は Gemini fallback 経路のみ対応。Claude 復帰時に \\_stream_claude を追加する。
+    """
+    content = user_message
+    if diary_content:
+        content = f"【日記の内容】\n{diary_content}\n\n【ユーザーのメッセージ】\n{user_message}"
+
+    client = _get_gemini_client()
+    contents = _build_gemini_contents(content, history)
+    stream = client.models.generate_content_stream(
         model=settings.gemini_model_coach,
         contents=contents,
         config=genai_types.GenerateContentConfig(
             system_instruction=SYSTEM_PROMPT,
-            max_output_tokens=settings.claude_max_tokens,
+            max_output_tokens=_capped_max_tokens(),
             temperature=settings.claude_temperature,
         ),
     )
-    return response.text or ""
+    for chunk in stream:
+        text = getattr(chunk, "text", None)
+        if text:
+            yield text


### PR DESCRIPTION
## Summary
\`/coach\` の応答が長文で途切れる問題（user FB）の根本対応。SSE で chunk 配信し、トークン上限を実質気にしない構造へ。

## 変更
- \`POST /coach/stream\`: \`StreamingResponse\` で \`text/event-stream\`、各 chunk を \`data: {"chunk": "..."}\` で配信
- \`coach_service.chat_stream\`: Gemini の \`generate_content_stream\` を async generator でラップ
- 旧 \`POST /coach\` は後方互換のため残置

## ガードレール
- 入力長 cap: \`coach_input_max_chars=10_000\`、超過は 400
- 出力トークン hard cap: \`coach_output_max_tokens_cap=4_000\`、\`claude_max_tokens\` と min 取る
- 総時間タイムアウト: \`coach_stream_timeout_seconds=60\`、超過時は \`event: error\`
- 部分応答でも assistant message を Firestore に保存（途中まで残す）

## 追跡
- Issue #90