### PR TITLE
feat: #90 iOS で Coach SSE streaming 受信を実装

### DIFF
--- a/ios/Cycle/Features/Coach/Store/CoachStore.swift
+++ b/ios/Cycle/Features/Coach/Store/CoachStore.swift
@@ -122,9 +122,28 @@ class CoachStore: ObservableObject {
         updateSession(session)
     }
 
+    /// streaming 開始時に空のコーチメッセージを挿入する
+    private func addEmptyCoachMessage() {
+        guard var session = currentSession else { return }
+        session.messages.append(CoachMessage(role: .coach, content: ""))
+        session.updatedAt = Date()
+        currentSession = session
+    }
+
+    /// streaming 中、最後のコーチメッセージの content を差し替える
+    private func setLastCoachMessageContent(_ content: String) {
+        guard var session = currentSession,
+              let last = session.messages.last,
+              last.role == .coach
+        else { return }
+        session.messages[session.messages.count - 1].content = content
+        session.updatedAt = Date()
+        currentSession = session
+    }
+
     // MARK: - API Integration
 
-    /// コーチに問いかける（API呼び出し）
+    /// コーチに問いかける（API呼び出し、SSE streaming）
     func sendMessage(_ content: String) async {
         addUserMessage(content)
 
@@ -135,28 +154,39 @@ class CoachStore: ObservableObject {
 
         do {
             if useAPI {
-                // API呼び出し
-                let response = try await coachService.sendMessage(
+                await MainActor.run { addEmptyCoachMessage() }
+
+                let stream = coachService.sendMessageStream(
                     message: content,
                     sessionId: currentSession?.serverId ?? currentSession?.id.uuidString
                 )
 
-                let metadata = MessageMetadata(
-                    cycleElement: response.metadata?.cycleElement,
-                    emotionDetected: response.metadata?.detectedEmotion,
-                    suggestedAction: nil
-                )
+                var accumulated = ""
+                var receivedError: String?
+                for try await event in stream {
+                    switch event {
+                    case .session(let sid):
+                        await MainActor.run {
+                            if currentSession?.serverId == nil {
+                                currentSession?.serverId = sid
+                                if let current = currentSession { updateSession(current) }
+                            }
+                        }
+                    case .chunk(let text):
+                        accumulated += text
+                        await MainActor.run { setLastCoachMessageContent(accumulated) }
+                    case .error(let reason):
+                        receivedError = reason
+                    case .done:
+                        break
+                    }
+                }
 
                 await MainActor.run {
-                    // サーバーから返されたsessionIdを保持
-                    if let serverSessionId = response.sessionId,
-                       currentSession?.serverId == nil {
-                        currentSession?.serverId = serverSessionId
-                        if let current = currentSession {
-                            updateSession(current)
-                        }
+                    if let session = currentSession { updateSession(session) }
+                    if let reason = receivedError {
+                        self.error = "コーチ応答が中断されました (\(reason))"
                     }
-                    addCoachMessage(response.message, metadata: metadata)
                     isLoading = false
                 }
             } else {

--- a/ios/Cycle/Services/APIClient.swift
+++ b/ios/Cycle/Services/APIClient.swift
@@ -282,6 +282,27 @@ class APIClient {
         }
     }
 
+    /// SSE 用に POST URLRequest を組み立てる。リトライ・レスポンス処理は呼び出し側に委譲。
+    func makeStreamingPostRequest<U: Encodable>(
+        path: String,
+        body: U,
+        requiresAuth: Bool = true
+    ) throws -> URLRequest {
+        let url = try buildURL(path: path)
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .iso8601
+        let bodyData = try encoder.encode(body)
+        var request = buildRequest(
+            url: url,
+            method: "POST",
+            body: bodyData,
+            requiresAuth: requiresAuth
+        )
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        return request
+    }
+
     func post<T: Decodable, U: Encodable>(
         path: String,
         body: U,

--- a/ios/Cycle/Services/CoachService.swift
+++ b/ios/Cycle/Services/CoachService.swift
@@ -5,12 +5,19 @@
 
 import Foundation
 
+enum CoachStreamEvent {
+    case session(String)
+    case chunk(String)
+    case error(String)
+    case done
+}
+
 class CoachService {
     private let apiClient = APIClient.shared
 
     // MARK: - Coach Chat
 
-    /// コーチにメッセージを送信
+    /// コーチにメッセージを送信 (legacy 同期版)
     func sendMessage(
         message: String,
         sessionId: String? = nil,
@@ -31,6 +38,91 @@ class CoachService {
         )
 
         return response.data
+    }
+
+    /// `/coach/stream` の SSE を AsyncThrowingStream で配信する
+    func sendMessageStream(
+        message: String,
+        sessionId: String? = nil,
+        diaryContent: String? = nil,
+        cycleElement: String? = nil
+    ) -> AsyncThrowingStream<CoachStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let request = CoachRequest(
+                        message: message,
+                        sessionId: sessionId,
+                        diaryContent: diaryContent,
+                        context: cycleElement != nil ? CoachContext(cycleElement: cycleElement) : nil
+                    )
+                    let urlRequest = try apiClient.makeStreamingPostRequest(
+                        path: "/coach/stream",
+                        body: request
+                    )
+                    let (bytes, response) = try await URLSession.shared.bytes(for: urlRequest)
+                    if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+                        if http.statusCode == 401 {
+                            continuation.finish(throwing: APIError.unauthorized)
+                        } else {
+                            continuation.finish(throwing: APIError.httpError(
+                                statusCode: http.statusCode,
+                                message: nil
+                            ))
+                        }
+                        return
+                    }
+
+                    var currentEvent: String? = nil
+                    var dataLines: [String] = []
+                    for try await line in bytes.lines {
+                        if Task.isCancelled { break }
+                        if line.isEmpty {
+                            if let event = Self.makeEvent(name: currentEvent, dataLines: dataLines) {
+                                continuation.yield(event)
+                                if case .done = event {
+                                    continuation.finish()
+                                    return
+                                }
+                            }
+                            currentEvent = nil
+                            dataLines.removeAll(keepingCapacity: true)
+                        } else if line.hasPrefix("event:") {
+                            currentEvent = String(line.dropFirst(6)).trimmingCharacters(
+                                in: .whitespaces
+                            )
+                        } else if line.hasPrefix("data:") {
+                            dataLines.append(
+                                String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                            )
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private static func makeEvent(name: String?, dataLines: [String]) -> CoachStreamEvent? {
+        let data = dataLines.joined(separator: "\n")
+        guard let jsonData = data.data(using: .utf8) else { return nil }
+        let dict = (try? JSONSerialization.jsonObject(with: jsonData)) as? [String: Any]
+        switch name {
+        case "session":
+            if let sid = dict?["session_id"] as? String { return .session(sid) }
+        case "error":
+            return .error((dict?["reason"] as? String) ?? "unknown")
+        case "done":
+            return .done
+        case nil:
+            if let chunk = dict?["chunk"] as? String { return .chunk(chunk) }
+        default:
+            break
+        }
+        return nil
     }
 
     // MARK: - Sessions


### PR DESCRIPTION
## Summary
backend /coach/stream の text/event-stream を URLSession.bytes(for:).lines で読み、chunk 毎に CoachStore の最後の coach message の content を差し替える。@Published 経由で UI が逐次描画される。

## ガードレール対応
- 401 / 5xx は APIError として throw、CoachStore で reauth or エラー表示
- error イベント (timeout / internal) を受け取ったら「コーチ応答が中断されました」を表示
- AsyncThrowingStream は onTermination で URLSession の Task をキャンセル

## 関連
- Issue #90 / PR #91 (backend SSE)