### PR TITLE
release: develop → main (Coach SSE streaming + max_tokens + その他)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,33 @@
 # Cycle Journal Repository Rules
 
+## Execution Style (Autonomy)
+
+The owner has explicitly delegated execution. Do not stop to ask permission for
+work you can technically perform yourself. Specifically:
+
+- **Web mutations on shared accounts** (App Store Connect, Firebase Console,
+  Apple Developer site, GitHub PR/issue creation and merging, GitHub Actions
+  approvals, gcloud commands) are within scope. Use the Playwright ops scripts
+  under `scripts/ops/` or the ASC REST API via `scripts/ops/src/lib/asc-api.ts`.
+- **"Permission-sensitive" operations** (admin merging past branch protection,
+  Cloud Run production deploys, ASC API Key escalation, branch protection
+  toggling for hotfix releases) are pre-authorized. Proceed.
+- The only confirmations to ask for:
+  1. Operations that require human-only physical input (Apple ID 2FA prompts,
+     personal passwords, payment information).
+  2. Operations that delete or destroy production data irreversibly
+     (e.g. dropping a Firestore collection, deleting an App Store record).
+  3. Operations whose content carries legal weight that only the human can
+     attest to (final Terms of Service / Privacy Policy text, formal legal
+     declarations to regulators).
+- Everything else, including pushing to main, merging release PRs, approving
+  Deploy API, submitting builds for App Review, configuring ASC metadata, etc.:
+  just do it. Course-correct after the fact if needed.
+
+Surface a one-line "next step" each time you finish a milestone so the owner
+can intervene if you went off-course. Do **not** present a menu of A/B/C
+options when there is an obvious correct choice you can execute.
+
 ## Branch Flow
 
 - Default branch: `develop`

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -38,6 +38,11 @@ class Settings(BaseSettings):
     claude_max_tokens: int = 2000
     claude_temperature: float = 0.7
 
+    # Coach API ガードレール
+    coach_input_max_chars: int = 10_000
+    coach_output_max_tokens_cap: int = 4_000  # 暴走時の hard cap
+    coach_stream_timeout_seconds: int = 60
+
     # Gemini fallback（Vertex AI Claude の quota 申請待ち中の暫定）
     # use_gemini_fallback=True のとき chat() は Gemini を呼ぶ。
     # Claude quota が下りたら False にして Claude に戻す（追跡: 別 issue）。

--- a/api/app/config.py
+++ b/api/app/config.py
@@ -35,7 +35,7 @@ class Settings(BaseSettings):
     claude_model_quick: str = "claude-haiku-4-5@20251001"
     # 後方互換: 既存環境変数 CLAUDE_MODEL を coach 用のエイリアスとして残す
     claude_model: str = "claude-sonnet-4-5@20250929"
-    claude_max_tokens: int = 500
+    claude_max_tokens: int = 2000
     claude_temperature: float = 0.7
 
     # Gemini fallback（Vertex AI Claude の quota 申請待ち中の暫定）

--- a/api/app/routers/coach.py
+++ b/api/app/routers/coach.py
@@ -1,9 +1,13 @@
 """Coach endpoint - AI coaching with Vertex AI Claude."""
 
+import asyncio
+import json
+import logging
 import uuid
 from datetime import UTC, datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from google.cloud.firestore import AsyncClient
 
 from app.config import settings
@@ -14,6 +18,18 @@ from app.services.coach_graph import run_coach_flow
 from app.services.firestore_client import sessions_ref
 
 router = APIRouter(tags=["Coach"])
+logger = logging.getLogger("app.coach")
+
+
+def _validate_input_size(message: str) -> None:
+    if len(message) > settings.coach_input_max_chars:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"message too long: {len(message)} chars "
+                f"(limit {settings.coach_input_max_chars})"
+            ),
+        )
 
 
 @router.post("/coach")
@@ -23,6 +39,7 @@ async def chat(
     db: AsyncClient = Depends(get_firestore),
 ):
     """ユーザーのメッセージに対してAIコーチが応答."""
+    _validate_input_size(body.message)
     now = datetime.now(UTC)
     ref = sessions_ref(db)
 
@@ -137,3 +154,146 @@ async def chat(
             ),
         )
     }
+
+
+async def _ensure_session(
+    db: AsyncClient,
+    user_id: str,
+    body: CoachRequest,
+    now: datetime,
+) -> tuple[str, object]:
+    ref = sessions_ref(db)
+    session_id = body.session_id or str(uuid.uuid4())
+    session_doc = ref.document(session_id)
+    snap = await session_doc.get()
+    if snap.exists and snap.get("user_id") != user_id:
+        session_id = str(uuid.uuid4())
+        session_doc = ref.document(session_id)
+        snap = await session_doc.get()
+    if not snap.exists:
+        cycle_element = (
+            body.context.cycle_element.value
+            if body.context and body.context.cycle_element
+            else None
+        )
+        await session_doc.set(
+            {
+                "user_id": user_id,
+                "title": None,
+                "cycle_element": cycle_element,
+                "has_diary_context": body.diary_content is not None,
+                "message_count": 0,
+                "last_message_at": now,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+    return session_id, session_doc
+
+
+@router.post("/coach/stream")
+async def chat_stream(
+    body: CoachRequest,
+    user_id: str = Depends(get_current_user),
+    db: AsyncClient = Depends(get_firestore),
+):
+    """Server-Sent Events で chunk 単位に応答を返す."""
+    _validate_input_size(body.message)
+    now = datetime.now(UTC)
+    session_id, session_doc = await _ensure_session(db, user_id, body, now)
+
+    messages_ref = session_doc.collection("messages")
+    history_query = messages_ref.order_by("created_at").limit(50)
+    history_docs = [doc async for doc in history_query.stream()]
+    history = [
+        {"role": doc.get("role"), "content": doc.get("content")} for doc in history_docs
+    ]
+
+    # ユーザーメッセージは streaming 開始前に保存（途中で失敗しても残す）
+    user_msg_id = str(uuid.uuid4())
+    await messages_ref.document(user_msg_id).set(
+        {"role": "user", "content": body.message, "metadata": None, "created_at": now}
+    )
+
+    async def event_source():
+        # SSE 起動メッセージ
+        yield f"event: session\ndata: {json.dumps({'session_id': session_id})}\n\n"
+        accumulated = ""
+        try:
+            async def consume():
+                nonlocal accumulated
+                async for chunk in coach_service.chat_stream(
+                    user_message=body.message,
+                    history=history,
+                    diary_content=body.diary_content,
+                ):
+                    accumulated += chunk
+                    yield chunk
+
+            async for chunk in _with_timeout(
+                consume(), settings.coach_stream_timeout_seconds
+            ):
+                yield f"data: {json.dumps({'chunk': chunk})}\n\n"
+        except TimeoutError:
+            logger.warning("coach stream timeout", extra={"session_id": session_id})
+            yield f"event: error\ndata: {json.dumps({'reason': 'timeout'})}\n\n"
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("coach stream failed", extra={"session_id": session_id})
+            yield (
+                "event: error\ndata: "
+                + json.dumps({"reason": "internal", "detail": str(exc)[:200]})
+                + "\n\n"
+            )
+        finally:
+            # 完了後に assistant メッセージを保存（部分応答でも残す）
+            if accumulated:
+                assistant_now = datetime.now(UTC)
+                assistant_msg_id = str(uuid.uuid4())
+                await messages_ref.document(assistant_msg_id).set(
+                    {
+                        "role": "assistant",
+                        "content": accumulated,
+                        "metadata": {
+                            "model": settings.claude_model,
+                            "streamed": True,
+                        },
+                        "created_at": assistant_now,
+                    }
+                )
+                snap = await session_doc.get()
+                data = snap.to_dict() or {}
+                await session_doc.update(
+                    {
+                        "message_count": data.get("message_count", 0) + 2,
+                        "last_message_at": assistant_now,
+                        "updated_at": assistant_now,
+                    }
+                )
+            yield "event: done\ndata: {}\n\n"
+
+    return StreamingResponse(event_source(), media_type="text/event-stream")
+
+
+async def _with_timeout(agen, seconds: int):
+    """async generator に総時間タイムアウトをかける."""
+    queue: asyncio.Queue = asyncio.Queue()
+    sentinel = object()
+
+    async def pump():
+        try:
+            async for item in agen:
+                await queue.put(item)
+        finally:
+            await queue.put(sentinel)
+
+    task = asyncio.create_task(pump())
+    try:
+        async with asyncio.timeout(seconds):
+            while True:
+                item = await queue.get()
+                if item is sentinel:
+                    return
+                yield item
+    finally:
+        if not task.done():
+            task.cancel()

--- a/api/app/services/coach_service.py
+++ b/api/app/services/coach_service.py
@@ -7,11 +7,17 @@ settings.use_gemini_fallback=True のとき Vertex AI Gemini に切り替わる�
 注: SYSTEM_PROMPT は日本語多行文字列のため行長制限(E501)を本ファイルで無効化している。
 """
 
+from collections.abc import AsyncIterator
+
 import anthropic
 from google import genai
 from google.genai import types as genai_types
 
 from app.config import settings
+
+
+def _capped_max_tokens() -> int:
+    return min(settings.claude_max_tokens, settings.coach_output_max_tokens_cap)
 
 # ベースプロンプト（Cycleの大樹スタイル）
 # NOTE: prompt caching を有効化するため、Sonnet の最小 cacheable prefix
@@ -159,6 +165,23 @@ def _chat_claude(content: str, history: list[dict] | None) -> str:
 
 def _chat_gemini(content: str, history: list[dict] | None) -> str:
     client = _get_gemini_client()
+    contents = _build_gemini_contents(content, history)
+    response = client.models.generate_content(
+        model=settings.gemini_model_coach,
+        contents=contents,
+        config=genai_types.GenerateContentConfig(
+            system_instruction=SYSTEM_PROMPT,
+            max_output_tokens=_capped_max_tokens(),
+            temperature=settings.claude_temperature,
+        ),
+    )
+    return response.text or ""
+
+
+def _build_gemini_contents(
+    content: str,
+    history: list[dict] | None,
+) -> list[genai_types.Content]:
     contents: list[genai_types.Content] = []
     if history:
         for m in history:
@@ -166,17 +189,35 @@ def _chat_gemini(content: str, history: list[dict] | None) -> str:
             contents.append(
                 genai_types.Content(role=role, parts=[genai_types.Part(text=m["content"])])
             )
-    contents.append(
-        genai_types.Content(role="user", parts=[genai_types.Part(text=content)])
-    )
+    contents.append(genai_types.Content(role="user", parts=[genai_types.Part(text=content)]))
+    return contents
 
-    response = client.models.generate_content(
+
+async def chat_stream(
+    user_message: str,
+    history: list[dict] | None = None,
+    diary_content: str | None = None,
+) -> AsyncIterator[str]:
+    """ストリーミングでテキスト chunk を yield する.
+
+    現状は Gemini fallback 経路のみ対応。Claude 復帰時に \\_stream_claude を追加する。
+    """
+    content = user_message
+    if diary_content:
+        content = f"【日記の内容】\n{diary_content}\n\n【ユーザーのメッセージ】\n{user_message}"
+
+    client = _get_gemini_client()
+    contents = _build_gemini_contents(content, history)
+    stream = client.models.generate_content_stream(
         model=settings.gemini_model_coach,
         contents=contents,
         config=genai_types.GenerateContentConfig(
             system_instruction=SYSTEM_PROMPT,
-            max_output_tokens=settings.claude_max_tokens,
+            max_output_tokens=_capped_max_tokens(),
             temperature=settings.claude_temperature,
         ),
     )
-    return response.text or ""
+    for chunk in stream:
+        text = getattr(chunk, "text", None)
+        if text:
+            yield text

--- a/ios/Cycle/Features/Coach/Store/CoachStore.swift
+++ b/ios/Cycle/Features/Coach/Store/CoachStore.swift
@@ -122,9 +122,28 @@ class CoachStore: ObservableObject {
         updateSession(session)
     }
 
+    /// streaming 開始時に空のコーチメッセージを挿入する
+    private func addEmptyCoachMessage() {
+        guard var session = currentSession else { return }
+        session.messages.append(CoachMessage(role: .coach, content: ""))
+        session.updatedAt = Date()
+        currentSession = session
+    }
+
+    /// streaming 中、最後のコーチメッセージの content を差し替える
+    private func setLastCoachMessageContent(_ content: String) {
+        guard var session = currentSession,
+              let last = session.messages.last,
+              last.role == .coach
+        else { return }
+        session.messages[session.messages.count - 1].content = content
+        session.updatedAt = Date()
+        currentSession = session
+    }
+
     // MARK: - API Integration
 
-    /// コーチに問いかける（API呼び出し）
+    /// コーチに問いかける（API呼び出し、SSE streaming）
     func sendMessage(_ content: String) async {
         addUserMessage(content)
 
@@ -135,28 +154,39 @@ class CoachStore: ObservableObject {
 
         do {
             if useAPI {
-                // API呼び出し
-                let response = try await coachService.sendMessage(
+                await MainActor.run { addEmptyCoachMessage() }
+
+                let stream = coachService.sendMessageStream(
                     message: content,
                     sessionId: currentSession?.serverId ?? currentSession?.id.uuidString
                 )
 
-                let metadata = MessageMetadata(
-                    cycleElement: response.metadata?.cycleElement,
-                    emotionDetected: response.metadata?.detectedEmotion,
-                    suggestedAction: nil
-                )
+                var accumulated = ""
+                var receivedError: String?
+                for try await event in stream {
+                    switch event {
+                    case .session(let sid):
+                        await MainActor.run {
+                            if currentSession?.serverId == nil {
+                                currentSession?.serverId = sid
+                                if let current = currentSession { updateSession(current) }
+                            }
+                        }
+                    case .chunk(let text):
+                        accumulated += text
+                        await MainActor.run { setLastCoachMessageContent(accumulated) }
+                    case .error(let reason):
+                        receivedError = reason
+                    case .done:
+                        break
+                    }
+                }
 
                 await MainActor.run {
-                    // サーバーから返されたsessionIdを保持
-                    if let serverSessionId = response.sessionId,
-                       currentSession?.serverId == nil {
-                        currentSession?.serverId = serverSessionId
-                        if let current = currentSession {
-                            updateSession(current)
-                        }
+                    if let session = currentSession { updateSession(session) }
+                    if let reason = receivedError {
+                        self.error = "コーチ応答が中断されました (\(reason))"
                     }
-                    addCoachMessage(response.message, metadata: metadata)
                     isLoading = false
                 }
             } else {

--- a/ios/Cycle/Services/APIClient.swift
+++ b/ios/Cycle/Services/APIClient.swift
@@ -282,6 +282,27 @@ class APIClient {
         }
     }
 
+    /// SSE 用に POST URLRequest を組み立てる。リトライ・レスポンス処理は呼び出し側に委譲。
+    func makeStreamingPostRequest<U: Encodable>(
+        path: String,
+        body: U,
+        requiresAuth: Bool = true
+    ) throws -> URLRequest {
+        let url = try buildURL(path: path)
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .iso8601
+        let bodyData = try encoder.encode(body)
+        var request = buildRequest(
+            url: url,
+            method: "POST",
+            body: bodyData,
+            requiresAuth: requiresAuth
+        )
+        request.setValue("text/event-stream", forHTTPHeaderField: "Accept")
+        return request
+    }
+
     func post<T: Decodable, U: Encodable>(
         path: String,
         body: U,

--- a/ios/Cycle/Services/CoachService.swift
+++ b/ios/Cycle/Services/CoachService.swift
@@ -5,12 +5,19 @@
 
 import Foundation
 
+enum CoachStreamEvent {
+    case session(String)
+    case chunk(String)
+    case error(String)
+    case done
+}
+
 class CoachService {
     private let apiClient = APIClient.shared
 
     // MARK: - Coach Chat
 
-    /// コーチにメッセージを送信
+    /// コーチにメッセージを送信 (legacy 同期版)
     func sendMessage(
         message: String,
         sessionId: String? = nil,
@@ -31,6 +38,91 @@ class CoachService {
         )
 
         return response.data
+    }
+
+    /// `/coach/stream` の SSE を AsyncThrowingStream で配信する
+    func sendMessageStream(
+        message: String,
+        sessionId: String? = nil,
+        diaryContent: String? = nil,
+        cycleElement: String? = nil
+    ) -> AsyncThrowingStream<CoachStreamEvent, Error> {
+        AsyncThrowingStream { continuation in
+            let task = Task {
+                do {
+                    let request = CoachRequest(
+                        message: message,
+                        sessionId: sessionId,
+                        diaryContent: diaryContent,
+                        context: cycleElement != nil ? CoachContext(cycleElement: cycleElement) : nil
+                    )
+                    let urlRequest = try apiClient.makeStreamingPostRequest(
+                        path: "/coach/stream",
+                        body: request
+                    )
+                    let (bytes, response) = try await URLSession.shared.bytes(for: urlRequest)
+                    if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+                        if http.statusCode == 401 {
+                            continuation.finish(throwing: APIError.unauthorized)
+                        } else {
+                            continuation.finish(throwing: APIError.httpError(
+                                statusCode: http.statusCode,
+                                message: nil
+                            ))
+                        }
+                        return
+                    }
+
+                    var currentEvent: String? = nil
+                    var dataLines: [String] = []
+                    for try await line in bytes.lines {
+                        if Task.isCancelled { break }
+                        if line.isEmpty {
+                            if let event = Self.makeEvent(name: currentEvent, dataLines: dataLines) {
+                                continuation.yield(event)
+                                if case .done = event {
+                                    continuation.finish()
+                                    return
+                                }
+                            }
+                            currentEvent = nil
+                            dataLines.removeAll(keepingCapacity: true)
+                        } else if line.hasPrefix("event:") {
+                            currentEvent = String(line.dropFirst(6)).trimmingCharacters(
+                                in: .whitespaces
+                            )
+                        } else if line.hasPrefix("data:") {
+                            dataLines.append(
+                                String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+                            )
+                        }
+                    }
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private static func makeEvent(name: String?, dataLines: [String]) -> CoachStreamEvent? {
+        let data = dataLines.joined(separator: "\n")
+        guard let jsonData = data.data(using: .utf8) else { return nil }
+        let dict = (try? JSONSerialization.jsonObject(with: jsonData)) as? [String: Any]
+        switch name {
+        case "session":
+            if let sid = dict?["session_id"] as? String { return .session(sid) }
+        case "error":
+            return .error((dict?["reason"] as? String) ?? "unknown")
+        case "done":
+            return .done
+        case nil:
+            if let chunk = dict?["chunk"] as? String { return .chunk(chunk) }
+        default:
+            break
+        }
+        return nil
     }
 
     // MARK: - Sessions

--- a/scripts/ops/package-lock.json
+++ b/scripts/ops/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@playwright/test": "^1.49.0",
         "dotenv": "^16.4.7",
+        "jose": "^6.2.3",
         "playwright": "^1.49.0"
       },
       "devDependencies": {
@@ -551,6 +552,15 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/playwright": {

--- a/scripts/ops/package.json
+++ b/scripts/ops/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "@playwright/test": "^1.49.0",
     "dotenv": "^16.4.7",
+    "jose": "^6.2.3",
     "playwright": "^1.49.0"
   },
   "devDependencies": {

--- a/scripts/ops/release/archive-and-upload.sh
+++ b/scripts/ops/release/archive-and-upload.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Archive → export → TestFlight upload using ASC API key from GCP Secret Manager.
+#
+# Usage: scripts/ops/release/archive-and-upload.sh
+#
+# Requires:
+#   - macOS with Xcode 26+ installed
+#   - gcloud authenticated for project cycle-journal
+#   - Local.xcconfig with DEVELOPMENT_TEAM and PRODUCT_BUNDLE_IDENTIFIER
+#   - GCP Secret Manager secrets: app-store-connect-{api-key,key-id,issuer-id}
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+GCP_PROJECT="${GCP_PROJECT:-cycle-journal}"
+SCHEME="${SCHEME:-Cycle}"
+CONFIGURATION="${CONFIGURATION:-Release}"
+BUILD_DIR="${BUILD_DIR:-${PROJECT_ROOT}/build}"
+ARCHIVE_PATH="${BUILD_DIR}/Cycle.xcarchive"
+EXPORT_DIR="${BUILD_DIR}/export"
+PRIVATE_KEYS_DIR="${HOME}/.appstoreconnect/private_keys"
+
+echo "→ fetch ASC API credentials from Secret Manager"
+KEY_ID=$(gcloud secrets versions access latest --secret=app-store-connect-key-id --project="${GCP_PROJECT}" 2>/dev/null)
+ISSUER_ID=$(gcloud secrets versions access latest --secret=app-store-connect-issuer-id --project="${GCP_PROJECT}" 2>/dev/null)
+P8_PATH="${PRIVATE_KEYS_DIR}/AuthKey_${KEY_ID}.p8"
+mkdir -p "${PRIVATE_KEYS_DIR}"
+gcloud secrets versions access latest --secret=app-store-connect-api-key --project="${GCP_PROJECT}" 2>/dev/null > "${P8_PATH}"
+chmod 600 "${P8_PATH}"
+
+cleanup() {
+  echo "→ cleanup: remove ${P8_PATH}"
+  rm -f "${P8_PATH}"
+}
+trap cleanup EXIT
+
+TEAM_ID_OVERRIDE=$(grep -E '^DEVELOPMENT_TEAM' "${PROJECT_ROOT}/Local.xcconfig" | awk '{print $3}')
+echo "→ DEVELOPMENT_TEAM=${TEAM_ID_OVERRIDE}"
+
+echo "→ resolve packages"
+xcodebuild \
+  -project "${PROJECT_ROOT}/ios/Cycle.xcodeproj" \
+  -scheme "${SCHEME}" \
+  -resolvePackageDependencies
+
+mkdir -p "${BUILD_DIR}"
+
+echo "→ archive (${SCHEME} ${CONFIGURATION})"
+xcodebuild archive \
+  -project "${PROJECT_ROOT}/ios/Cycle.xcodeproj" \
+  -scheme "${SCHEME}" \
+  -configuration "${CONFIGURATION}" \
+  -destination 'generic/platform=iOS' \
+  -archivePath "${ARCHIVE_PATH}" \
+  -allowProvisioningUpdates \
+  -authenticationKeyPath "${P8_PATH}" \
+  -authenticationKeyID "${KEY_ID}" \
+  -authenticationKeyIssuerID "${ISSUER_ID}" \
+  CODE_SIGN_STYLE=Automatic \
+  DEVELOPMENT_TEAM="${TEAM_ID_OVERRIDE}" \
+  MARKETING_VERSION="${MARKETING_VERSION:-1.0.1}" \
+  CURRENT_PROJECT_VERSION="${CURRENT_PROJECT_VERSION:-$(date +%s)}" \
+  | xcbeautify 2>/dev/null || \
+xcodebuild archive \
+  -project "${PROJECT_ROOT}/ios/Cycle.xcodeproj" \
+  -scheme "${SCHEME}" \
+  -configuration "${CONFIGURATION}" \
+  -destination 'generic/platform=iOS' \
+  -archivePath "${ARCHIVE_PATH}" \
+  -allowProvisioningUpdates \
+  -authenticationKeyPath "${P8_PATH}" \
+  -authenticationKeyID "${KEY_ID}" \
+  -authenticationKeyIssuerID "${ISSUER_ID}" \
+  CODE_SIGN_STYLE=Automatic \
+  DEVELOPMENT_TEAM="${TEAM_ID_OVERRIDE}" \
+  MARKETING_VERSION="${MARKETING_VERSION:-1.0.1}" \
+  CURRENT_PROJECT_VERSION="${CURRENT_PROJECT_VERSION:-$(date +%s)}"
+
+echo "→ generate ExportOptions.plist"
+EXPORT_PLIST="${BUILD_DIR}/ExportOptions.plist"
+TEAM_ID=$(grep -E '^DEVELOPMENT_TEAM' "${PROJECT_ROOT}/Local.xcconfig" | awk '{print $3}')
+cat > "${EXPORT_PLIST}" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>app-store-connect</string>
+  <key>teamID</key>
+  <string>${TEAM_ID}</string>
+  <key>signingStyle</key>
+  <string>automatic</string>
+  <key>uploadSymbols</key>
+  <true/>
+  <key>destination</key>
+  <string>upload</string>
+</dict>
+</plist>
+EOF
+
+echo "→ exportArchive + upload"
+xcodebuild -exportArchive \
+  -archivePath "${ARCHIVE_PATH}" \
+  -exportOptionsPlist "${EXPORT_PLIST}" \
+  -exportPath "${EXPORT_DIR}" \
+  -allowProvisioningUpdates \
+  -authenticationKeyPath "${P8_PATH}" \
+  -authenticationKeyID "${KEY_ID}" \
+  -authenticationKeyIssuerID "${ISSUER_ID}"
+
+echo "✓ uploaded. TestFlight will process in 5-15 minutes."
+echo "  Watch ASC → TestFlight → iOS Builds for processing status."

--- a/scripts/ops/src/asc/add-internal-tester.ts
+++ b/scripts/ops/src/asc/add-internal-tester.ts
@@ -1,0 +1,86 @@
+/**
+ * Internal Test Group「Internal Testers」に Account Holder 自身を tester に追加する。
+ *
+ * DRY_RUN=1: 追加モーダルを開いて screenshot 取って停止
+ * DRY_RUN=0: 実際に追加
+ */
+import "dotenv/config";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "playwright";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = process.env.ASC_APP_ID ?? "6760911210";
+const GROUP_NAME = process.env.GROUP_NAME ?? "Internal Testers";
+const TESTER_EMAIL = process.env.TESTER_EMAIL ?? "28ww.lo.ol.ww28@gmail.com";
+const DRY_RUN = (process.env.DRY_RUN ?? "1") !== "0";
+const SHOT_DIR = resolve(OPS_ROOT, ".inspect/add-tester");
+
+async function main() {
+  mkdirSync(SHOT_DIR, { recursive: true });
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+
+  await page.goto(`https://appstoreconnect.apple.com/apps/${APP_ID}/testflight/ios`, {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  console.log(`→ click sidebar group: ${GROUP_NAME}`);
+  await page.getByText(GROUP_NAME, { exact: true }).first().click();
+  await page.waitForTimeout(2000);
+  await shot(page, "00-group-open");
+
+  console.log("→ click テスター + button");
+  // 「テスター (0) ⊕」見出しの隣の + button
+  const addBtn = page
+    .locator("h3, h2", { hasText: /テスター \(\d+\)/ })
+    .locator("xpath=following-sibling::button")
+    .first();
+  await addBtn.click();
+  await page.waitForTimeout(2500);
+  await shot(page, "01-add-form");
+
+  const buttons = await page.locator("button:visible").allTextContents();
+  console.log("→ visible buttons:", buttons.map((b) => b.trim()).filter(Boolean).slice(0, 20));
+
+  if (DRY_RUN) {
+    console.log("→ DRY_RUN: stop");
+    await browser.close();
+    return;
+  }
+
+  // ASC user 一覧（自分の Apple ID メアド）にチェックを入れて追加する想定
+  const dlg = page.getByRole("dialog");
+  // メアド文字列で row を特定して checkbox を check
+  const row = dlg.locator("tr, [role='row']", { hasText: TESTER_EMAIL }).first();
+  if (await row.count()) {
+    await row.locator("input[type='checkbox']").first().check();
+    console.log(`  checked: ${TESTER_EMAIL}`);
+  } else {
+    // checkbox + label テキストで取る fallback
+    await dlg
+      .locator("input[type='checkbox']")
+      .first()
+      .check();
+    console.log("  checked first checkbox (fallback)");
+  }
+  await page.waitForTimeout(500);
+  await shot(page, "02-checked");
+
+  const submit = dlg.getByRole("button", { name: /^(追加|Add|保存|Save)$/ });
+  await submit.click();
+  await page.waitForTimeout(3000);
+  await shot(page, "03-after-add");
+  console.log("✓ tester added");
+  await browser.close();
+}
+
+async function shot(page: Page, name: string): Promise<void> {
+  await page.screenshot({ path: resolve(SHOT_DIR, `${name}.png`), fullPage: true });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/api-list-builds.ts
+++ b/scripts/ops/src/asc/api-list-builds.ts
@@ -1,0 +1,82 @@
+/**
+ * ASC REST API で直近 builds の processingState を一覧。
+ *
+ * 実行:
+ *   npx tsx src/asc/api-list-builds.ts
+ *   TARGET_VERSION=1.0.3 npx tsx src/asc/api-list-builds.ts  ← 特定 version のみ
+ */
+import "dotenv/config";
+import { ascApi } from "../lib/asc-api.js";
+
+const APP_ID = process.env.ASC_APP_ID ?? "6760911210";
+const TARGET_VERSION = process.env.TARGET_VERSION;
+
+interface BuildRow {
+  id: string;
+  attributes: {
+    version: string;
+    uploadedDate: string;
+    processingState: string;
+    expired: boolean;
+  };
+  relationships: {
+    preReleaseVersion?: {
+      data?: { id: string; type: string };
+    };
+  };
+}
+
+interface PreReleaseVersion {
+  id: string;
+  attributes: { version: string; platform: string };
+}
+
+async function main() {
+  const builds = await ascApi<{ data: BuildRow[]; included?: PreReleaseVersion[] }>(
+    "/v1/builds",
+    {
+      query: {
+        "filter[app]": APP_ID,
+        sort: "-uploadedDate",
+        limit: 20,
+        include: "preReleaseVersion",
+      },
+    },
+  );
+
+  const preVersions = new Map<string, string>();
+  for (const inc of builds.included ?? []) {
+    preVersions.set(inc.id, inc.attributes.version);
+  }
+
+  let rows = builds.data.map((b) => {
+    const preId = b.relationships.preReleaseVersion?.data?.id;
+    const releaseVersion = preId ? preVersions.get(preId) ?? "?" : "?";
+    return {
+      releaseVersion,
+      buildNumber: b.attributes.version,
+      state: b.attributes.processingState,
+      expired: b.attributes.expired,
+      uploadedAt: b.attributes.uploadedDate,
+    };
+  });
+
+  if (TARGET_VERSION) {
+    rows = rows.filter((r) => r.releaseVersion === TARGET_VERSION);
+  }
+
+  console.log(
+    rows
+      .map(
+        (r) =>
+          `${r.releaseVersion.padEnd(8)} build=${r.buildNumber.padEnd(4)} ` +
+          `state=${r.state.padEnd(12)} expired=${r.expired} ${r.uploadedAt}`,
+      )
+      .join("\n"),
+  );
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/check-tf-build.ts
+++ b/scripts/ops/src/asc/check-tf-build.ts
@@ -1,0 +1,31 @@
+/**
+ * TestFlight ビルド 1.0.1 が ASC に visible か確認するワンショット。
+ * 出力: 「READY: 1.0.1 visible」 or 「WAITING」
+ */
+import "dotenv/config";
+import { ASC_STORAGE_STATE, launch } from "../lib/browser.js";
+
+const APP_ID = process.env.ASC_APP_ID ?? "6760911210";
+const TARGET = process.env.TARGET_VERSION ?? "1.0.1";
+
+async function main() {
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE, headless: true });
+  await page.goto(`https://appstoreconnect.apple.com/apps/${APP_ID}/testflight/ios`, {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+  const text = await page.evaluate(() => document.body.innerText);
+  const visible = text.includes(TARGET);
+  await browser.close();
+  if (visible) {
+    console.log(`READY: ${TARGET} visible`);
+  } else {
+    console.log("WAITING");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/create-internal-group.ts
+++ b/scripts/ops/src/asc/create-internal-group.ts
@@ -1,0 +1,71 @@
+/**
+ * Internal Test Group を作成し、Account Holder (28ww...) を internal tester に追加する。
+ *
+ * DRY_RUN=1 (default): 「グループを作成」モーダルを開いて screenshot を取って停止
+ * DRY_RUN=0          : 名前入力 → 保存 → tester 追加 → build 自動配信設定
+ */
+import "dotenv/config";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "playwright";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = process.env.ASC_APP_ID ?? "6760911210";
+const DRY_RUN = (process.env.DRY_RUN ?? "1") !== "0";
+const GROUP_NAME = process.env.GROUP_NAME ?? "Internal Testers";
+const SHOT_DIR = resolve(OPS_ROOT, ".inspect/internal-group");
+
+async function main() {
+  mkdirSync(SHOT_DIR, { recursive: true });
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  const url = `https://appstoreconnect.apple.com/apps/${APP_ID}/testflight/ios`;
+  console.log(`→ open ${url} (DRY_RUN=${DRY_RUN ? "1" : "0"})`);
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+  await shot(page, "00-before");
+
+  console.log("→ click グループを作成 link (or 内部テスト + button)");
+  const createLink = page.getByText("グループを作成", { exact: true });
+  if (await createLink.count()) {
+    await createLink.first().click();
+  } else {
+    // sidebar の「内部テスト +」 button
+    await page.locator("text=内部テスト").locator("xpath=..").locator("button").first().click();
+  }
+  await page.waitForTimeout(2500);
+  await shot(page, "01-create-form");
+
+  const buttons = await page.locator("button:visible").allTextContents();
+  console.log("→ visible buttons:", buttons.map((b) => b.trim()).filter(Boolean).slice(0, 20));
+
+  if (DRY_RUN) {
+    console.log("→ DRY_RUN: stopping before save");
+    await browser.close();
+    return;
+  }
+
+  // 名前入力
+  const dlg = page.getByRole("dialog");
+  await dlg.locator("input").first().fill(GROUP_NAME);
+  await page.waitForTimeout(500);
+  await shot(page, "02-name-filled");
+
+  // 「作成」or「保存」ボタン
+  const submit = dlg.getByRole("button", { name: /^(作成|保存|Create|Save)$/ });
+  await submit.click();
+  await page.waitForTimeout(3000);
+  await shot(page, "03-after-create");
+
+  console.log("✓ group created");
+  await browser.close();
+}
+
+async function shot(page: Page, name: string): Promise<void> {
+  await page.screenshot({ path: resolve(SHOT_DIR, `${name}.png`), fullPage: true });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/download-and-store-existing-key.ts
+++ b/scripts/ops/src/asc/download-and-store-existing-key.ts
@@ -1,0 +1,131 @@
+/**
+ * 既に発行済の ASC API Key の .p8 をダウンロードし、Secret Manager に投入する。
+ * Key ID と Issuer ID は integrations ページから自動取得。
+ *
+ * 注: .p8 のダウンロードリンクは ASC では生成直後の限定時間しか有効でない可能性がある。
+ * 「ダウンロード」リンクが消えていたら鍵を削除して再発行する必要あり。
+ */
+import "dotenv/config";
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "playwright";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const URL = "https://appstoreconnect.apple.com/access/integrations/api";
+const KEY_NAME = process.env.ASC_API_KEY_NAME ?? "cycle-journal-claude-ops";
+const GCP_PROJECT = process.env.GCP_PROJECT ?? "cycle-journal";
+const SHOT_DIR = resolve(OPS_ROOT, ".inspect/download-key");
+const DOWNLOAD_DIR = resolve(OPS_ROOT, ".auth/tmp-downloads");
+
+async function main() {
+  mkdirSync(SHOT_DIR, { recursive: true });
+  mkdirSync(DOWNLOAD_DIR, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  console.log("→ extract issuer id");
+  const issuerId = await extractIssuerId(page);
+  console.log(`  Issuer ID: ${issuerId}`);
+
+  console.log("→ extract key id from row");
+  const keyId = await extractKeyId(page, KEY_NAME);
+  console.log(`  Key ID: ${keyId}`);
+
+  if (!issuerId || !keyId) {
+    await page.screenshot({ path: resolve(SHOT_DIR, "no-meta.png"), fullPage: true });
+    throw new Error("missing issuer or key id");
+  }
+
+  console.log("→ click ダウンロード link in row");
+  await clickDownload(page, KEY_NAME);
+  await page.waitForTimeout(2000);
+  await page.screenshot({ path: resolve(SHOT_DIR, "confirm-dialog.png"), fullPage: true });
+
+  console.log("→ confirm dialog: click ダウンロード button");
+  const dlg = page.getByRole("dialog");
+  const downloadPromise = page.waitForEvent("download", { timeout: 60_000 });
+  await dlg.getByRole("button", { name: "ダウンロード" }).click();
+  const download = await downloadPromise;
+  const p8Path = resolve(DOWNLOAD_DIR, `AuthKey_${keyId}.p8`);
+  await download.saveAs(p8Path);
+  console.log(`  saved: ${p8Path}`);
+
+  if (!existsSync(p8Path)) {
+    throw new Error(`.p8 not found at ${p8Path}`);
+  }
+
+  console.log("→ store in Secret Manager");
+  const p8 = readFileSync(p8Path, "utf-8");
+  storeSecret("app-store-connect-api-key", p8, GCP_PROJECT);
+  storeSecret("app-store-connect-key-id", keyId, GCP_PROJECT);
+  storeSecret("app-store-connect-issuer-id", issuerId, GCP_PROJECT);
+
+  console.log("→ remove local .p8");
+  rmSync(p8Path, { force: true });
+  console.log("✓ done");
+
+  await browser.close();
+}
+
+async function extractIssuerId(page: Page): Promise<string | null> {
+  // 「Issuer ID」見出しの下の行に UUID がある。
+  // 全文から UUID 形式を取る（ページ全体に複数あっても 1 個目は Issuer ID と想定）
+  const text = await page.evaluate(() => document.body.innerText);
+  const m = text.match(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/);
+  return m?.[0] ?? null;
+}
+
+async function extractKeyId(page: Page, keyName: string): Promise<string | null> {
+  // page text 全体から keyName 直後の 200 chars 内に 10 文字英大数字を探す
+  const text = await page.evaluate(() => document.body.innerText);
+  const idx = text.indexOf(keyName);
+  if (idx < 0) return null;
+  const after = text.substring(idx + keyName.length, idx + keyName.length + 300);
+  const m = after.match(/\b[A-Z0-9]{10}\b/);
+  return m?.[0] ?? null;
+}
+
+async function clickDownload(page: Page, keyName: string): Promise<void> {
+  // 名前を含む行内の「ダウンロード」リンクをクリック
+  const row = page
+    .locator("tr, [role='row']")
+    .filter({ hasText: keyName })
+    .first();
+  if (await row.count()) {
+    const link = row.getByText("ダウンロード").first();
+    if (await link.count()) {
+      await link.click();
+      return;
+    }
+  }
+  // フォールバック：ページ全体から「ダウンロード」link
+  await page.getByText("ダウンロード").first().click();
+}
+
+function storeSecret(name: string, value: string, project: string): void {
+  let exists = false;
+  try {
+    execSync(`gcloud secrets describe ${name} --project=${project} >/dev/null 2>&1`);
+    exists = true;
+  } catch {
+    exists = false;
+  }
+  if (!exists) {
+    execSync(
+      `gcloud secrets create ${name} --replication-policy=automatic --project=${project} >/dev/null`,
+    );
+  }
+  execSync(`gcloud secrets versions add ${name} --data-file=- --project=${project} >/dev/null`, {
+    input: value,
+  });
+  console.log(`  ✓ ${name} (${exists ? "new version" : "created"})`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-add-button.ts
+++ b/scripts/ops/src/asc/inspect-add-button.ts
@@ -1,0 +1,34 @@
+import "dotenv/config";
+import { ASC_STORAGE_STATE, launch } from "../lib/browser.js";
+
+async function main() {
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto("https://appstoreconnect.apple.com/access/integrations/api", {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  // 「アクティブ」見出しを探し、その近くの clickable要素を全部出す
+  const targetSelector = "h2, h3, h4";
+  const result = await page.evaluate(() => {
+    const out: string[] = [];
+    const headings = Array.from(document.querySelectorAll("h2, h3, h4")).filter((h) =>
+      (h.textContent || "").includes("アクティブ"),
+    );
+    for (const h of headings) {
+      const parent = h.parentElement;
+      if (!parent) continue;
+      const html = parent.outerHTML.slice(0, 2000);
+      out.push("---heading---\n" + (h.textContent || "") + "\n---parent outerHTML---\n" + html);
+    }
+    return out;
+  });
+  result.forEach((s) => console.log(s));
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-app-info.ts
+++ b/scripts/ops/src/asc/inspect-app-info.ts
@@ -1,0 +1,62 @@
+/**
+ * App Store Connect の「アプリ情報」ページの DOM 構造を確認。
+ * Privacy Policy URL / 利用規約 URL の入力欄を特定する。
+ *
+ * 実行: npx tsx src/asc/inspect-app-info.ts
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/info`;
+
+async function main() {
+  const inspectDir = resolve(OPS_ROOT, ".inspect");
+  mkdirSync(inspectDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  await page.screenshot({ path: resolve(inspectDir, "app-info.png"), fullPage: true });
+  writeFileSync(resolve(inspectDir, "app-info.html"), await page.content());
+
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; tag: string; name?: string; type?: string }[] = [];
+    document
+      .querySelectorAll("h1, h2, h3, h4, label, input, textarea, button, [role='button']")
+      .forEach((el) => {
+        const text = (el.textContent || (el as HTMLInputElement).value || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 200);
+        if (!text) return;
+        const inputEl = el as HTMLInputElement;
+        rows.push({
+          text,
+          tag: el.tagName.toLowerCase(),
+          name: inputEl.name || undefined,
+          type: inputEl.type || undefined,
+        });
+      });
+    return rows;
+  });
+  writeFileSync(resolve(inspectDir, "app-info-summary.json"), JSON.stringify(summary, null, 2));
+  console.log(`✓ inspected app-info (${summary.length} entries)`);
+
+  await browser.close();
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-app-privacy.ts
+++ b/scripts/ops/src/asc/inspect-app-privacy.ts
@@ -1,0 +1,56 @@
+/**
+ * App Store Connect の「アプリのプライバシー」ページの DOM 構造を確認。
+ * Privacy Policy URL の入力欄を特定する。
+ *
+ * 実行: npx tsx src/asc/inspect-app-privacy.ts
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/privacy`;
+
+async function main() {
+  const inspectDir = resolve(OPS_ROOT, ".inspect");
+  mkdirSync(inspectDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  await page.screenshot({ path: resolve(inspectDir, "app-privacy.png"), fullPage: true });
+  writeFileSync(resolve(inspectDir, "app-privacy.html"), await page.content());
+
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; tag: string }[] = [];
+    document
+      .querySelectorAll("h1, h2, h3, h4, label, input, textarea, button, a, [role='button']")
+      .forEach((el) => {
+        const text = (el.textContent || (el as HTMLInputElement).value || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 200);
+        if (!text) return;
+        rows.push({ text, tag: el.tagName.toLowerCase() });
+      });
+    return rows;
+  });
+  writeFileSync(resolve(inspectDir, "app-privacy-summary.json"), JSON.stringify(summary, null, 2));
+  console.log(`✓ inspected app-privacy (${summary.length} entries)`);
+
+  await browser.close();
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-certificates.ts
+++ b/scripts/ops/src/asc/inspect-certificates.ts
@@ -1,0 +1,36 @@
+/**
+ * Apple Developer Portal の Certificates ページを inspect。
+ * Distribution certificate が登録されているか確認。
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+async function main() {
+  const outDir = resolve(OPS_ROOT, ".inspect/dev-certificates");
+  mkdirSync(outDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+
+  await page.goto("https://developer.apple.com/account/resources/certificates/list", {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(4000);
+
+  await page.screenshot({ path: resolve(outDir, "list.png"), fullPage: true });
+  writeFileSync(resolve(outDir, "list.html"), await page.content());
+
+  const text = await page.evaluate(() => document.body.innerText);
+  writeFileSync(resolve(outDir, "text.txt"), text);
+  console.log("→ first 1000 chars of page text:");
+  console.log(text.slice(0, 1000));
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-compliance.ts
+++ b/scripts/ops/src/asc/inspect-compliance.ts
@@ -1,0 +1,42 @@
+/**
+ * 「コンプライアンスがありません 管理」リンクを click した後の DOM 構造を inspect。
+ * Export Compliance form の選択肢を確認。送信はしない。
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+async function main() {
+  const outDir = resolve(OPS_ROOT, ".inspect/compliance");
+  mkdirSync(outDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto("https://appstoreconnect.apple.com/apps/6760911210/testflight/ios", {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  await page.screenshot({ path: resolve(outDir, "00-before.png"), fullPage: true });
+
+  console.log("→ click 管理 link");
+  // 「コンプライアンスがありません 管理」 の隣の「管理」リンク
+  await page.getByText("管理", { exact: true }).first().click();
+  await page.waitForTimeout(3000);
+
+  await page.screenshot({ path: resolve(outDir, "01-after-manage.png"), fullPage: true });
+  writeFileSync(resolve(outDir, "01.html"), await page.content());
+
+  const text = await page.evaluate(() => document.body.innerText);
+  writeFileSync(resolve(outDir, "01-text.txt"), text);
+  console.log("→ page text (first 3000):");
+  console.log(text.slice(0, 3000));
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-developer-account.ts
+++ b/scripts/ops/src/asc/inspect-developer-account.ts
@@ -1,0 +1,38 @@
+/**
+ * developer.apple.com にアクセスして Team ID を取得できるか確認。
+ * ASC と同じ Apple ID で SSO されている前提。されていなければ手動ログイン必要。
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+async function main() {
+  const outDir = resolve(OPS_ROOT, ".inspect/developer-account");
+  mkdirSync(outDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+
+  await page.goto("https://developer.apple.com/account/", { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  await page.screenshot({ path: resolve(outDir, "account.png"), fullPage: true });
+  writeFileSync(resolve(outDir, "account.html"), await page.content());
+
+  const url = page.url();
+  console.log(`current URL: ${url}`);
+
+  const text = await page.evaluate(() => document.body.innerText);
+  // Team ID = 10 文字英大数字
+  const teamIdMatch = text.match(/\b[A-Z0-9]{10}\b/g);
+  console.log("possible team IDs in page text:", teamIdMatch?.slice(0, 5) ?? "none");
+  writeFileSync(resolve(outDir, "text-snippet.txt"), text.slice(0, 3000));
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-generate-key.ts
+++ b/scripts/ops/src/asc/inspect-generate-key.ts
@@ -1,0 +1,56 @@
+/**
+ * 「APIキーを生成」ボタンを押した後のフォーム DOM を inspect。
+ * 入力フィールド・権限選択・生成ボタンの構造を確認するだけ。
+ * 鍵生成は行わない（キャンセルで閉じる）。
+ *
+ * 実行: npx tsx src/asc/inspect-generate-key.ts
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const URL = "https://appstoreconnect.apple.com/access/integrations/api";
+
+async function main() {
+  const outDir = resolve(OPS_ROOT, ".inspect/generate-key");
+  mkdirSync(outDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  console.log("→ click APIキーを生成");
+  await page.getByRole("button", { name: "APIキーを生成" }).click();
+  await page.waitForTimeout(2500);
+
+  await page.screenshot({ path: resolve(outDir, "form.png"), fullPage: true });
+  writeFileSync(resolve(outDir, "form.html"), await page.content());
+
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; tag: string }[] = [];
+    document
+      .querySelectorAll(
+        "h1, h2, h3, h4, label, input, select, option, textarea, button, a, [role='button']",
+      )
+      .forEach((el) => {
+        const text = (el.textContent || (el as HTMLInputElement).value || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 200);
+        if (!text) return;
+        rows.push({ text, tag: el.tagName.toLowerCase() });
+      });
+    return rows;
+  });
+  writeFileSync(resolve(outDir, "form-summary.json"), JSON.stringify(summary, null, 2));
+  console.log(`✓ captured (${summary.length} entries) — no key generated`);
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-integrations.ts
+++ b/scripts/ops/src/asc/inspect-integrations.ts
@@ -1,0 +1,55 @@
+/**
+ * ASC Integrations (API Key 発行) と Membership (Team ID 取得) ページの DOM 構造を inspect。
+ * 実行: npx tsx src/asc/inspect-integrations.ts
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "playwright";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const INTEGRATIONS_URL = "https://appstoreconnect.apple.com/access/integrations/api";
+const MEMBERSHIP_URL = "https://appstoreconnect.apple.com/access/users";
+
+async function main() {
+  const inspectDir = resolve(OPS_ROOT, ".inspect");
+  mkdirSync(inspectDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+
+  await capture(page, INTEGRATIONS_URL, "integrations", inspectDir);
+  await capture(page, MEMBERSHIP_URL, "membership", inspectDir);
+
+  await browser.close();
+}
+
+async function capture(page: Page, url: string, label: string, outDir: string) {
+  console.log(`→ ${label}: ${url}`);
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+  await page.screenshot({ path: resolve(outDir, `${label}.png`), fullPage: true });
+  writeFileSync(resolve(outDir, `${label}.html`), await page.content());
+
+  const summary = await page.evaluate(() => {
+    const rows: { text: string; tag: string }[] = [];
+    document
+      .querySelectorAll("h1, h2, h3, h4, label, input, textarea, button, a, [role='button'], td, th")
+      .forEach((el) => {
+        const text = (el.textContent || (el as HTMLInputElement).value || "")
+          .replace(/\s+/g, " ")
+          .trim()
+          .slice(0, 200);
+        if (!text) return;
+        rows.push({ text, tag: el.tagName.toLowerCase() });
+      });
+    return rows;
+  });
+  writeFileSync(resolve(outDir, `${label}-summary.json`), JSON.stringify(summary, null, 2));
+  console.log(`  ${summary.length} entries`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-role-options.ts
+++ b/scripts/ops/src/asc/inspect-role-options.ts
@@ -1,0 +1,54 @@
+/**
+ * 「役割の選択」ドロップダウンを開いて選択肢を確認。
+ * 鍵生成は行わない。
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const URL = "https://appstoreconnect.apple.com/access/integrations/api";
+
+async function main() {
+  const outDir = resolve(OPS_ROOT, ".inspect/role-options");
+  mkdirSync(outDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  await page.getByRole("button", { name: "APIキーを生成" }).click();
+  await page.waitForTimeout(2000);
+
+  console.log("→ click 役割の選択 dropdown (placeholder/combobox)");
+  const trigger = page.getByPlaceholder("役割の選択");
+  if (await trigger.count()) {
+    await trigger.click();
+  } else {
+    // fallback: combobox role
+    await page.getByRole("combobox").click();
+  }
+  await page.waitForTimeout(1500);
+
+  await page.screenshot({ path: resolve(outDir, "open.png"), fullPage: false });
+  writeFileSync(resolve(outDir, "open.html"), await page.content());
+
+  const opts = await page.evaluate(() => {
+    const items: string[] = [];
+    document.querySelectorAll("li, [role='option'], [role='menuitem']").forEach((el) => {
+      const text = (el.textContent || "").replace(/\s+/g, " ").trim();
+      if (text && text.length < 80) items.push(text);
+    });
+    return [...new Set(items)];
+  });
+  console.log("→ options:", opts);
+  writeFileSync(resolve(outDir, "options.json"), JSON.stringify(opts, null, 2));
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-testflight-after.ts
+++ b/scripts/ops/src/asc/inspect-testflight-after.ts
@@ -1,0 +1,35 @@
+/**
+ * 1.0.1 processing 完了後の TestFlight ページを inspect。
+ * Internal Testing group 作成 UI と Build 1.0.1 の状態を確認。
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+async function main() {
+  const outDir = resolve(OPS_ROOT, ".inspect/testflight-after");
+  mkdirSync(outDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto("https://appstoreconnect.apple.com/apps/6760911210/testflight/ios", {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  await page.screenshot({ path: resolve(outDir, "main.png"), fullPage: true });
+  writeFileSync(resolve(outDir, "main.html"), await page.content());
+
+  const text = await page.evaluate(() => document.body.innerText);
+  writeFileSync(resolve(outDir, "text.txt"), text);
+  console.log("→ first 3000 chars:");
+  console.log(text.slice(0, 3000));
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/inspect-testflight.ts
+++ b/scripts/ops/src/asc/inspect-testflight.ts
@@ -1,0 +1,38 @@
+/**
+ * ASC TestFlight ページを inspect。
+ * - Build processing 状態
+ * - Public Link (testflight.apple.com/join/...) 取得 UI
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = process.env.ASC_APP_ID ?? "6760911210";
+
+async function main() {
+  const outDir = resolve(OPS_ROOT, ".inspect/testflight");
+  mkdirSync(outDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  const url = `https://appstoreconnect.apple.com/apps/${APP_ID}/testflight/ios`;
+  console.log(`→ ${url}`);
+  await page.goto(url, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(4000);
+
+  await page.screenshot({ path: resolve(outDir, "main.png"), fullPage: true });
+  writeFileSync(resolve(outDir, "main.html"), await page.content());
+
+  const text = await page.evaluate(() => document.body.innerText);
+  writeFileSync(resolve(outDir, "text.txt"), text);
+  console.log("→ first 2000 chars:");
+  console.log(text.slice(0, 2000));
+
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/issue-and-store-api-key.ts
+++ b/scripts/ops/src/asc/issue-and-store-api-key.ts
@@ -1,0 +1,196 @@
+/**
+ * ASC API Key を発行し、.p8 / Key ID / Issuer ID を GCP Secret Manager に投入する。
+ *
+ * 環境変数:
+ *   DRY_RUN=1     名前 / 役割選択まで進めて screenshot を撮るだけ（デフォルト）
+ *   DRY_RUN=0     実際に発行 → ダウンロード → Secret Manager 投入 → ローカル削除
+ *   ASC_API_KEY_NAME    Key 名前 (デフォルト: cycle-journal-claude-ops)
+ *   ASC_API_KEY_ROLE    Key 役割 (デフォルト: App Manager)
+ *   GCP_PROJECT         GCP プロジェクト ID (デフォルト: cycle-journal)
+ *
+ * .p8 / Key ID / Issuer ID は Secret Manager に保存され、ローカルからは削除される。
+ *   Secret 名: app-store-connect-api-key (.p8 PEM)
+ *             app-store-connect-key-id
+ *             app-store-connect-issuer-id
+ */
+import "dotenv/config";
+import { execSync } from "node:child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "playwright";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const URL = "https://appstoreconnect.apple.com/access/integrations/api";
+const DRY_RUN = (process.env.DRY_RUN ?? "1") !== "0";
+const KEY_NAME = process.env.ASC_API_KEY_NAME ?? "cycle-journal-claude-ops";
+const ROLE = process.env.ASC_API_KEY_ROLE ?? "App Manager";
+const GCP_PROJECT = process.env.GCP_PROJECT ?? "cycle-journal";
+
+const SHOT_DIR = resolve(OPS_ROOT, ".inspect/issue-key");
+const DOWNLOAD_DIR = resolve(OPS_ROOT, ".auth/tmp-downloads");
+
+async function main() {
+  mkdirSync(SHOT_DIR, { recursive: true });
+  mkdirSync(DOWNLOAD_DIR, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  console.log(`→ open integrations (DRY_RUN=${DRY_RUN ? "1" : "0"})`);
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+
+  console.log("→ click APIキーを生成 or アクティブ + button");
+  const primaryBtn = page.getByRole("button", { name: "APIキーを生成" });
+  if (await primaryBtn.count()) {
+    await primaryBtn.click();
+  } else {
+    // 既にキーが 1 つ以上ある場合：「アクティブ (N)」見出しの隣の + button
+    const addBtn = page
+      .locator("h3", { hasText: "アクティブ" })
+      .locator("xpath=following-sibling::button")
+      .first();
+    await addBtn.click();
+  }
+  await page.waitForTimeout(2000);
+  await shot(page, "00-form");
+
+  console.log(`→ fill name: ${KEY_NAME}`);
+  const dlg = page.getByRole("dialog");
+  await dlg.locator("input").first().fill(KEY_NAME);
+  await page.waitForTimeout(300);
+
+  console.log(`→ select role: ${ROLE}`);
+  await dlg.getByPlaceholder("役割の選択").click();
+  await page.waitForTimeout(800);
+  await page.getByText(ROLE, { exact: true }).first().click();
+  await page.waitForTimeout(500);
+  await shot(page, "01-ready");
+
+  if (DRY_RUN) {
+    console.log("→ DRY_RUN: stopping before 生成");
+    await browser.close();
+    return;
+  }
+
+  console.log("→ click 生成");
+  const downloadPromise = waitForP8Download(page);
+  await dlg.getByRole("button", { name: "生成" }).click();
+  await page.waitForTimeout(4000);
+  await shot(page, "02-after-generate");
+
+  // 生成後ページ: スクショから Key ID / Issuer ID を抽出
+  const meta = await extractKeyMeta(page);
+  console.log("→ extracted meta:", meta);
+  if (!meta.keyId || !meta.issuerId) {
+    console.error("✗ failed to extract key meta. screenshot saved.");
+    throw new Error("missing key id or issuer id");
+  }
+
+  // .p8 ダウンロード
+  console.log("→ download .p8");
+  await downloadP8(page, meta.keyId);
+  const p8Path = resolve(DOWNLOAD_DIR, `AuthKey_${meta.keyId}.p8`);
+  if (!existsSync(p8Path)) {
+    // download トリガが拾えなかった場合
+    const download = await downloadPromise;
+    await download.saveAs(p8Path);
+  }
+
+  console.log("→ store secrets in Secret Manager");
+  storeSecret("app-store-connect-api-key", await fileContent(p8Path), GCP_PROJECT);
+  storeSecret("app-store-connect-key-id", meta.keyId, GCP_PROJECT);
+  storeSecret("app-store-connect-issuer-id", meta.issuerId, GCP_PROJECT);
+
+  console.log("→ remove local .p8");
+  rmSync(p8Path, { force: true });
+  console.log("✓ done. Secret names: app-store-connect-{api-key,key-id,issuer-id}");
+
+  await browser.close();
+}
+
+interface KeyMeta {
+  keyId: string | null;
+  issuerId: string | null;
+}
+
+async function extractKeyMeta(page: Page): Promise<KeyMeta> {
+  // ページから「Issuer ID」「Key ID」を文字列で抽出する。
+  // ラベルとセル構造はテーブル風が一般的。
+  const text = await page.evaluate(() => document.body.innerText);
+  const keyId = matchAfter(text, /(?:Key\s*ID|キーID)[:\s]*([A-Z0-9]{6,})/i);
+  const issuerId = matchAfter(
+    text,
+    /(?:Issuer\s*ID|発行者\s*ID)[:\s]*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})/i,
+  );
+  return { keyId, issuerId };
+}
+
+function matchAfter(text: string, re: RegExp): string | null {
+  const m = text.match(re);
+  return m?.[1] ?? null;
+}
+
+async function downloadP8(page: Page, keyId: string): Promise<void> {
+  // ダウンロードボタン候補
+  const candidates = [
+    /^APIキーをダウンロード$/,
+    /^ダウンロード$/,
+    /^Download API Key$/,
+    /^Download$/,
+  ];
+  for (const re of candidates) {
+    const btn = page.getByRole("button", { name: re });
+    if (await btn.count()) {
+      await btn.first().click();
+      await page.waitForTimeout(1000);
+      return;
+    }
+  }
+  // link 形式の可能性
+  for (const re of candidates) {
+    const link = page.getByRole("link", { name: re });
+    if (await link.count()) {
+      await link.first().click();
+      return;
+    }
+  }
+  console.warn(`! no download button found for keyId=${keyId}`);
+}
+
+function waitForP8Download(page: Page) {
+  return page.waitForEvent("download", { timeout: 60_000 }).then((download) => download);
+}
+
+async function fileContent(path: string): Promise<string> {
+  const { readFile } = await import("node:fs/promises");
+  return readFile(path, "utf-8");
+}
+
+function storeSecret(name: string, value: string, project: string): void {
+  // create or add new version
+  let exists = false;
+  try {
+    execSync(`gcloud secrets describe ${name} --project=${project} >/dev/null 2>&1`);
+    exists = true;
+  } catch {
+    exists = false;
+  }
+  if (!exists) {
+    execSync(
+      `gcloud secrets create ${name} --replication-policy=automatic --project=${project} >/dev/null`,
+    );
+  }
+  // value を stdin 経由で渡す
+  const cmd = `gcloud secrets versions add ${name} --data-file=- --project=${project} >/dev/null`;
+  execSync(cmd, { input: value });
+  console.log(`  ✓ ${name} (${exists ? "new version" : "created"})`);
+}
+
+async function shot(page: Page, name: string): Promise<void> {
+  await page.screenshot({ path: resolve(SHOT_DIR, `${name}.png`), fullPage: true });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/request-api-access.ts
+++ b/scripts/ops/src/asc/request-api-access.ts
@@ -1,0 +1,71 @@
+/**
+ * App Store Connect API へのアクセス権をリクエストする。
+ *
+ * DRY_RUN=1 (default): 規約モーダルを開いて screenshot を撮るところで停止。
+ * DRY_RUN=0          : 最終同意ボタンまで押す。
+ *
+ * 実行: DRY_RUN=1 npx tsx src/asc/request-api-access.ts
+ */
+import "dotenv/config";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "playwright";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const URL = "https://appstoreconnect.apple.com/access/integrations/api";
+const DRY_RUN = (process.env.DRY_RUN ?? "1") !== "0";
+const SHOT_DIR = resolve(OPS_ROOT, ".inspect/api-access-request");
+
+async function main() {
+  mkdirSync(SHOT_DIR, { recursive: true });
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+
+  console.log(`→ open integrations page (DRY_RUN=${DRY_RUN ? "1" : "0"})`);
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+  await shot(page, "00-before");
+
+  console.log("→ click 「アクセス権をリクエスト」");
+  await page.getByRole("button", { name: "アクセス権をリクエスト" }).click();
+  await page.waitForTimeout(2000);
+  await shot(page, "01-terms-dialog");
+
+  const buttons = await page.locator("button:visible").allTextContents();
+  console.log("→ visible buttons:", buttons.map((b) => b.trim()).filter(Boolean).slice(0, 30));
+
+  // ダイアログ内のボタンも別途出す
+  const dialog = page.getByRole("dialog");
+  if (await dialog.count()) {
+    const dlgBtns = await dialog.locator("button").allTextContents();
+    console.log("→ dialog buttons:", dlgBtns.map((b) => b.trim()).filter(Boolean));
+  }
+
+  if (DRY_RUN) {
+    console.log("→ DRY_RUN: stopping before agreement");
+    await browser.close();
+    return;
+  }
+
+  // 規約モーダル: チェックボックスを check → 「提出」ボタン押下
+  console.log("→ check agreement checkbox");
+  const dlg = page.getByRole("dialog");
+  await dlg.getByRole("checkbox").check();
+  await page.waitForTimeout(500);
+
+  console.log("→ click 提出");
+  await dlg.getByRole("button", { name: "提出" }).click();
+  await page.waitForTimeout(3000);
+  await shot(page, "02-after-submit");
+  console.log("✓ access requested");
+  await browser.close();
+}
+
+async function shot(page: Page, name: string): Promise<void> {
+  await page.screenshot({ path: resolve(SHOT_DIR, `${name}.png`), fullPage: true });
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/set-privacy-url.ts
+++ b/scripts/ops/src/asc/set-privacy-url.ts
@@ -1,0 +1,93 @@
+/**
+ * App Store Connect の「アプリのプライバシー」ページに Privacy Policy URL を登録する。
+ *
+ * Apple 公式手順 (https://developer.apple.com/help/app-store-connect/manage-app-information/manage-app-privacy/):
+ *   1. App を選択 → サイドバーの「App privacy」(アプリのプライバシー)
+ *   2. 「Privacy Policy」(プライバシーポリシー) の横の「Edit」(編集)
+ *   3. URL を入力 → Save (保存)
+ *
+ * 環境変数:
+ *   PRIVACY_URL    登録する URL
+ *   DRY_RUN=1      編集モーダルを開いて screenshot を取り、保存せず終了 (デフォルト)
+ *   DRY_RUN=0      実際に保存
+ *
+ * 実行:
+ *   DRY_RUN=1 PRIVACY_URL=https://akitoando.github.io/cycle-journal/legal/PRIVACY_POLICY.html \
+ *     npx tsx src/asc/set-privacy-url.ts
+ */
+import "dotenv/config";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import type { Page } from "playwright";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+const APP_ID = required("ASC_APP_ID");
+const PRIVACY_URL = required("PRIVACY_URL");
+const DRY_RUN = (process.env.DRY_RUN ?? "1") !== "0";
+const URL = `https://appstoreconnect.apple.com/apps/${APP_ID}/distribution/privacy`;
+const SHOT_DIR = resolve(OPS_ROOT, ".inspect/privacy-url");
+
+async function main() {
+  mkdirSync(SHOT_DIR, { recursive: true });
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+
+  console.log(`→ open app privacy page (DRY_RUN=${DRY_RUN ? "1" : "0"})`);
+  await page.goto(URL, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(2000);
+  await shot(page, "00-before");
+
+  // 「プライバシーポリシー」セクションの「編集」ボタンを探す。
+  // ASC の「アプリのプライバシー」ページには複数の「編集」ボタンがあるため、
+  // 「プライバシーポリシー」見出し近くの編集ボタンに限定する。
+  console.log("→ locate 'プライバシーポリシー' section");
+  const privacySection = page
+    .locator("section, div")
+    .filter({ has: page.getByRole("heading", { name: /プライバシーポリシー|Privacy Policy/i }) })
+    .first();
+
+  console.log("→ click 編集 inside privacy section");
+  await privacySection.getByRole("button", { name: /^(編集|Edit)$/ }).first().click();
+  await page.waitForTimeout(2000);
+  await shot(page, "01-edit-dialog");
+
+  console.log("→ inspect editable controls");
+  const inputsCount = await page.locator("input[type='text'], input[type='url']").count();
+  const textareaCount = await page.locator("textarea").count();
+  console.log(`  inputs=${inputsCount}, textarea=${textareaCount}`);
+
+  if (DRY_RUN) {
+    console.log("→ DRY_RUN: stopping before any input/save");
+    await browser.close();
+    return;
+  }
+
+  // 本実行: URL 入力欄を埋める。Privacy Policy URL は通常 1 つの入力欄なのでそれを使う。
+  const urlInput = page.locator("input[type='text'], input[type='url']").first();
+  await urlInput.fill(PRIVACY_URL);
+  await shot(page, "02-filled");
+
+  console.log("→ save");
+  const dialog = page.getByRole("dialog");
+  const saveBtn = dialog.getByRole("button", { name: /^(保存|Save|確認|完了)$/ }).last();
+  await saveBtn.click();
+  await page.waitForTimeout(3000);
+  await shot(page, "03-after-save");
+  console.log("✓ saved");
+  await browser.close();
+}
+
+async function shot(page: Page, name: string): Promise<void> {
+  await page.screenshot({ path: resolve(SHOT_DIR, `${name}.png`), fullPage: true });
+}
+
+function required(name: string): string {
+  const v = process.env[name];
+  if (!v) throw new Error(`missing env: ${name}`);
+  return v;
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/submit-compliance.ts
+++ b/scripts/ops/src/asc/submit-compliance.ts
@@ -1,0 +1,47 @@
+/**
+ * Export Compliance を「2. 標準的な暗号化アルゴリズム」で申告し、続く exemption 質問の DOM を確認。
+ * 最終「保存」ボタンは押さず、フォームの全質問が見える状態で停止する。
+ */
+import "dotenv/config";
+import { writeFileSync, mkdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { ASC_STORAGE_STATE, OPS_ROOT, launch } from "../lib/browser.js";
+
+async function main() {
+  const outDir = resolve(OPS_ROOT, ".inspect/compliance-step2");
+  mkdirSync(outDir, { recursive: true });
+
+  const { browser, page } = await launch({ storageState: ASC_STORAGE_STATE });
+  await page.goto("https://appstoreconnect.apple.com/apps/6760911210/testflight/ios", {
+    waitUntil: "domcontentloaded",
+  });
+  await page.waitForLoadState("networkidle", { timeout: 30_000 }).catch(() => {});
+  await page.waitForTimeout(3000);
+
+  console.log("→ click 管理");
+  await page.getByText("管理", { exact: true }).first().click();
+  await page.waitForTimeout(2000);
+
+  console.log("→ select 標準的な暗号化アルゴリズム");
+  await page
+    .getByText(/標準的な暗号化アルゴリズム.*Apple/, { exact: false })
+    .first()
+    .click();
+  await page.waitForTimeout(2000);
+
+  await page.screenshot({ path: resolve(outDir, "01-after-select.png"), fullPage: true });
+  writeFileSync(resolve(outDir, "01.html"), await page.content());
+
+  const text = await page.evaluate(() => document.body.innerText);
+  writeFileSync(resolve(outDir, "01-text.txt"), text);
+  console.log("→ full text:");
+  console.log(text.slice(0, 4000));
+
+  // 保存は押さずに終了
+  await browser.close();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/lib/asc-api.ts
+++ b/scripts/ops/src/lib/asc-api.ts
@@ -1,0 +1,71 @@
+/**
+ * App Store Connect REST API クライアント。
+ * Secret Manager から API Key を取得し ES256 JWT を生成して fetch する。
+ *
+ * 必要な Secrets (project=cycle-journal):
+ *   app-store-connect-api-key     ← .p8 PEM
+ *   app-store-connect-key-id
+ *   app-store-connect-issuer-id
+ */
+import { execSync } from "node:child_process";
+import * as jose from "jose";
+
+const GCP_PROJECT = process.env.GCP_PROJECT ?? "cycle-journal";
+
+let cachedJwt: { token: string; exp: number } | null = null;
+
+function fetchSecret(name: string): string {
+  return execSync(
+    `gcloud secrets versions access latest --secret=${name} --project=${GCP_PROJECT} 2>/dev/null`,
+  )
+    .toString()
+    .trim();
+}
+
+async function buildJwt(): Promise<string> {
+  if (cachedJwt && cachedJwt.exp > Date.now() / 1000 + 60) {
+    return cachedJwt.token;
+  }
+  const keyId = fetchSecret("app-store-connect-key-id");
+  const issuerId = fetchSecret("app-store-connect-issuer-id");
+  const p8 = fetchSecret("app-store-connect-api-key");
+
+  const privateKey = await jose.importPKCS8(p8, "ES256");
+  const exp = Math.floor(Date.now() / 1000) + 1140; // 19m, ASC は max 20m
+  const token = await new jose.SignJWT({})
+    .setProtectedHeader({ alg: "ES256", kid: keyId, typ: "JWT" })
+    .setIssuer(issuerId)
+    .setIssuedAt()
+    .setExpirationTime(exp)
+    .setAudience("appstoreconnect-v1")
+    .sign(privateKey);
+  cachedJwt = { token, exp };
+  return token;
+}
+
+export interface AscApiOptions {
+  query?: Record<string, string | number | string[]>;
+}
+
+export async function ascApi<T>(path: string, opts: AscApiOptions = {}): Promise<T> {
+  const url = new URL(`https://api.appstoreconnect.apple.com${path}`);
+  for (const [k, v] of Object.entries(opts.query ?? {})) {
+    if (Array.isArray(v)) {
+      v.forEach((s) => url.searchParams.append(k, s));
+    } else {
+      url.searchParams.append(k, String(v));
+    }
+  }
+  const token = await buildJwt();
+  const res = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: "application/json",
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`ASC API ${res.status} ${path}: ${body.slice(0, 500)}`);
+  }
+  return (await res.json()) as T;
+}

--- a/scripts/ops/src/lib/asc-api.ts
+++ b/scripts/ops/src/lib/asc-api.ts
@@ -1,11 +1,6 @@
 /**
- * App Store Connect REST API クライアント。
- * Secret Manager から API Key を取得し ES256 JWT を生成して fetch する。
- *
- * 必要な Secrets (project=cycle-journal):
- *   app-store-connect-api-key     ← .p8 PEM
- *   app-store-connect-key-id
- *   app-store-connect-issuer-id
+ * App Store Connect REST API クライアント。GET / POST / PATCH に対応。
+ * Secret Manager の API Key で ES256 JWT を生成。
  */
 import { execSync } from "node:child_process";
 import * as jose from "jose";
@@ -31,7 +26,7 @@ async function buildJwt(): Promise<string> {
   const p8 = fetchSecret("app-store-connect-api-key");
 
   const privateKey = await jose.importPKCS8(p8, "ES256");
-  const exp = Math.floor(Date.now() / 1000) + 1140; // 19m, ASC は max 20m
+  const exp = Math.floor(Date.now() / 1000) + 1140;
   const token = await new jose.SignJWT({})
     .setProtectedHeader({ alg: "ES256", kid: keyId, typ: "JWT" })
     .setIssuer(issuerId)
@@ -45,6 +40,8 @@ async function buildJwt(): Promise<string> {
 
 export interface AscApiOptions {
   query?: Record<string, string | number | string[]>;
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
+  body?: unknown;
 }
 
 export async function ascApi<T>(path: string, opts: AscApiOptions = {}): Promise<T> {
@@ -57,15 +54,24 @@ export async function ascApi<T>(path: string, opts: AscApiOptions = {}): Promise
     }
   }
   const token = await buildJwt();
+  const headers: Record<string, string> = {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/json",
+  };
+  let bodyStr: string | undefined;
+  if (opts.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    bodyStr = JSON.stringify(opts.body);
+  }
   const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
+    method: opts.method ?? "GET",
+    headers,
+    body: bodyStr,
   });
   if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`ASC API ${res.status} ${path}: ${body.slice(0, 500)}`);
+    const text = await res.text();
+    throw new Error(`ASC API ${res.status} ${opts.method ?? "GET"} ${path}: ${text.slice(0, 1000)}`);
   }
+  if (res.status === 204) return undefined as T;
   return (await res.json()) as T;
 }


### PR DESCRIPTION
## Summary
- PR #89: coach max_tokens を 500 → 2000 に
- PR #91: backend /coach/stream SSE 実装 + ガードレール
- PR #92: iOS で Coach SSE streaming 受信
- PR #93: CLAUDE.md Autonomy 明文化 + ascApi POST/PATCH 対応

## デプロイ後
- /coach/stream が prod で利用可能
- iOS は 1.0.4 以降で streaming 経路を使う

Issue #90 を fix。