### PR TITLE
feat: トライアルを Apple 標準 (Intro Offer) に乗せ、Onboarding ハードゲートに

### DIFF
--- a/ios/Cycle/App/ContentView.swift
+++ b/ios/Cycle/App/ContentView.swift
@@ -14,18 +14,48 @@ struct ContentView: View {
     @EnvironmentObject private var journalViewModel: JournalViewModel
     @EnvironmentObject private var authStore: AuthStore
     @EnvironmentObject private var taskViewModel: TaskViewModel
+    @EnvironmentObject private var subscriptionStore: SubscriptionStore
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
+    /// アプリ起動時のフロー:
+    ///
+    ///   1. Onboarding 体験 (登録なし・カード不要) ← user spec ステップ1
+    ///   2. SignIn (Apple/Google) — 課金主体を identify
+    ///   3. Paywall (Apple 標準 Introductory Offer = 3日間無料トライアル) ← user spec ステップ2
+    ///   4. Main (全機能)
+    ///
+    /// 全機能は有料パッケージなので Paywall はハードゲート。
+    /// オンボーディングだけは認証もカードも不要で循環の触り体験を提供する。
     var body: some View {
         Group {
-            switch authStore.state {
-            case .unknown:
-                splashView
-            case .unauthenticated:
-                SignInView()
-            case .authenticated:
-                mainContent
+            if !hasCompletedOnboarding {
+                OnboardingView()
+            } else {
+                switch authStore.state {
+                case .unknown:
+                    splashView
+                case .unauthenticated:
+                    SignInView()
+                case .authenticated:
+                    authenticatedContent
+                }
             }
+        }
+    }
+
+    @ViewBuilder
+    private var authenticatedContent: some View {
+        switch subscriptionStore.state {
+        case .unknown:
+            splashView
+                .task {
+                    await subscriptionStore.loadProducts()
+                    await subscriptionStore.refreshEntitlements()
+                }
+        case .notSubscribed, .expired:
+            PaywallView()
+        case .trial, .active:
+            mainContent
         }
     }
 
@@ -76,12 +106,6 @@ struct ContentView: View {
             coachStore.shouldOpenChat = true
         }
         .ignoresSafeArea(.keyboard)
-        .overlay {
-            if !hasCompletedOnboarding {
-                OnboardingView()
-                    .transition(.opacity)
-            }
-        }
     }
 
 

--- a/ios/Cycle/App/CycleApp.swift
+++ b/ios/Cycle/App/CycleApp.swift
@@ -109,6 +109,7 @@ struct CycleApp: App {
     @StateObject private var coachStore = CoachStore()
     @StateObject private var meditationStore = MeditationStore()
     @StateObject private var authStore = AuthStore()
+    @StateObject private var subscriptionStore = SubscriptionStore()
 
     var body: some Scene {
         WindowGroup {
@@ -123,6 +124,7 @@ struct CycleApp: App {
                     .environmentObject(coachStore)
                     .environmentObject(meditationStore)
                     .environmentObject(authStore)
+                    .environmentObject(subscriptionStore)
                     .onOpenURL { url in
                         GIDSignIn.sharedInstance.handle(url)
                     }

--- a/ios/Cycle/Features/Subscription/Views/PaywallView.swift
+++ b/ios/Cycle/Features/Subscription/Views/PaywallView.swift
@@ -2,23 +2,27 @@
 //  PaywallView.swift
 //  CycleJournal
 //
-//  Issue #54 決定: フェーズ1は月額¥1,800の3日無料トライアルのみ。
-//  年額¥14,400はフェーズ2で追加（App Store Connect で「配信から削除」中）。
+//  Issue #54 / 続: トライアルは Apple 標準 Introductory Offer (3日間無料) に乗せる。
+//  乱用防止は Apple 側で行われるため、サーバー側のトライアル管理は持たない。
 //
 //  Timeline 型 Paywall:
 //  - Day 0「今すぐ全機能」
 //  - Day 2「リマインド」
 //  - Day 3「自動課金開始」
 //
+//  対象 (intro offer eligible) でないユーザーには無料トライアル文言を出さない。
+//
 
 import StoreKit
 import SwiftUI
 
 struct PaywallView: View {
-    @StateObject private var store = SubscriptionStore()
+    @EnvironmentObject private var store: SubscriptionStore
+    @EnvironmentObject private var authStore: AuthStore
     @Environment(\.dismiss) private var dismiss
     @State private var selectedProductID: String = SubscriptionProductID.monthly.rawValue
     @State private var isPurchasing = false
+    @State private var isIntroOfferEligible = true
 
     /// 規約・プライバシーポリシー URL (App Store Connect と同一の URL を入れること)
     let termsURL = URL(string: "https://akitoando.github.io/cycle-journal/legal/TERMS_OF_SERVICE.html")!
@@ -33,7 +37,9 @@ struct PaywallView: View {
         ScrollView {
             VStack(spacing: 28) {
                 header
-                trialTimeline
+                if isIntroOfferEligible {
+                    trialTimeline
+                }
                 planList
                 primaryCTA
                 footer
@@ -45,7 +51,21 @@ struct PaywallView: View {
         .task {
             await store.loadProducts()
             await store.refreshEntitlements()
+            await refreshIntroOfferEligibility()
         }
+    }
+
+    /// Apple Introductory Offer の eligibility を判定する。
+    /// 同一 Apple ID でこのサブスクリプショングループの intro offer を既に消費していた場合、
+    /// Apple が再付与しないため UI からも無料トライアル文言を消す。
+    private func refreshIntroOfferEligibility() async {
+        guard let product = store.products.first(where: { SubscriptionProductID(rawValue: $0.id) == .monthly }),
+              let subscriptionInfo = product.subscription
+        else {
+            isIntroOfferEligible = false
+            return
+        }
+        isIntroOfferEligible = await subscriptionInfo.isEligibleForIntroOffer
     }
 
     // MARK: - Sections
@@ -136,9 +156,15 @@ struct PaywallView: View {
                         .font(.system(size: 18, weight: .semibold))
                     Text(product.displayPrice + "/月")
                         .font(.system(size: 16, weight: .semibold))
-                    Text("最初の 3 日間無料、その後 \(product.displayPrice)/月")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    if isIntroOfferEligible {
+                        Text("最初の 3 日間無料、その後 \(product.displayPrice)/月")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else {
+                        Text("\(product.displayPrice)/月 (無料トライアル対象外)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
                 Spacer()
             }
@@ -157,7 +183,7 @@ struct PaywallView: View {
         } label: {
             HStack {
                 if isPurchasing { ProgressView().tint(.white).padding(.trailing, 8) }
-                Text("3日間無料で始める")
+                Text(isIntroOfferEligible ? "3日間無料で始める" : "月額プランを購読")
                     .font(.system(size: 18, weight: .semibold))
             }
             .frame(maxWidth: .infinity)
@@ -188,6 +214,13 @@ struct PaywallView: View {
                 .font(.caption2)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
+
+            Button("別のアカウントでサインイン") {
+                authStore.signOut()
+            }
+            .font(.caption)
+            .foregroundStyle(.tertiary)
+            .padding(.top, 4)
         }
         .padding(.top, 8)
     }
@@ -210,4 +243,6 @@ struct PaywallView: View {
 
 #Preview {
     PaywallView()
+        .environmentObject(SubscriptionStore())
+        .environmentObject(AuthStore())
 }

--- a/scripts/ops/src/asc/api-check-intro-offer.ts
+++ b/scripts/ops/src/asc/api-check-intro-offer.ts
@@ -1,0 +1,36 @@
+/**
+ * Monthly subscription の Introductory Offer 設定を REST API で確認する。
+ * 実行: cd scripts/ops && npx tsx src/asc/api-check-intro-offer.ts
+ */
+import "dotenv/config";
+import { ascApi } from "../lib/asc-api.js";
+
+const SUB_ID = process.env.ASC_PRODUCT_MONTHLY_SUB_ID || "6775457213";
+
+interface IntroOffer {
+  id: string;
+  attributes: {
+    startDate?: string;
+    endDate?: string;
+    duration?: string;
+    offerMode?: string;
+    territoryCodes?: string[] | null;
+  };
+}
+
+async function main() {
+  const offers = await ascApi<{ data: IntroOffer[] }>(
+    `/v1/subscriptions/${SUB_ID}/introductoryOffers`,
+    {},
+  );
+  console.log(`=== introductory offers for subscription ${SUB_ID} ===`);
+  console.log(JSON.stringify(offers, null, 2));
+  if ((offers.data ?? []).length === 0) {
+    console.log("(no intro offers configured)");
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/api-delete-loc.ts
+++ b/scripts/ops/src/asc/api-delete-loc.ts
@@ -1,0 +1,23 @@
+/**
+ * 指定の subscription localization を REST API で削除。
+ * 実行: cd scripts/ops && npx tsx src/asc/api-delete-loc.ts <locId>
+ */
+import "dotenv/config";
+import { ascApi } from "../lib/asc-api.js";
+
+const LOC_ID = process.argv[2];
+if (!LOC_ID) {
+  console.error("usage: api-delete-loc.ts <locId>");
+  process.exit(1);
+}
+
+async function main() {
+  try {
+    await ascApi(`/v1/subscriptionLocalizations/${LOC_ID}`, { method: "DELETE" });
+    console.log(`✓ deleted ${LOC_ID}`);
+  } catch (e) {
+    console.log("DELETE error:", (e as Error).message.slice(0, 500));
+  }
+}
+
+main().catch(console.error);

--- a/scripts/ops/src/asc/api-loc-detail.ts
+++ b/scripts/ops/src/asc/api-loc-detail.ts
@@ -1,0 +1,38 @@
+/**
+ * subscription の各ローカライゼーション詳細 (id, rejection 情報含む) を確認する。
+ * 実行: cd scripts/ops && npx tsx src/asc/api-loc-detail.ts <subscriptionId>
+ */
+import "dotenv/config";
+import { ascApi } from "../lib/asc-api.js";
+
+const SUB_ID = process.argv[2] || process.env.ASC_PRODUCT_MONTHLY_SUB_ID || "6775457213";
+
+interface Loc {
+  id: string;
+  attributes: Record<string, unknown>;
+}
+
+async function main() {
+  const locs = await ascApi<{ data: Loc[] }>(
+    `/v1/subscriptions/${SUB_ID}/subscriptionLocalizations`,
+    {},
+  );
+  for (const loc of locs.data) {
+    console.log(`\n=== ${loc.id} (${loc.attributes.locale}) ===`);
+    console.log(JSON.stringify(loc.attributes, null, 2));
+
+    // /v1/subscriptionLocalizations/{id} で詳細 (sometimes contains additional fields)
+    try {
+      const detail = await ascApi<{ data: Loc }>(`/v1/subscriptionLocalizations/${loc.id}`, {});
+      console.log("--- detail ---");
+      console.log(JSON.stringify(detail.data.attributes, null, 2));
+    } catch (e) {
+      console.log("(failed to fetch detail)", (e as Error).message.slice(0, 200));
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/api-sub-detail.ts
+++ b/scripts/ops/src/asc/api-sub-detail.ts
@@ -1,0 +1,50 @@
+/**
+ * monthly/yearly subscription の詳細状態 (localizations, screenshot, prices, intro offers) を確認する。
+ * 実行: cd scripts/ops && npx tsx src/asc/api-sub-detail.ts <subscriptionId>
+ */
+import "dotenv/config";
+import { ascApi } from "../lib/asc-api.js";
+
+const SUB_ID = process.argv[2] || process.env.ASC_PRODUCT_MONTHLY_SUB_ID || "6775457213";
+
+async function main() {
+  console.log(`=== subscription ${SUB_ID} ===`);
+
+  const sub = await ascApi<{ data: { attributes: Record<string, unknown> } }>(
+    `/v1/subscriptions/${SUB_ID}`,
+    {},
+  );
+  console.log("\n--- attributes ---");
+  console.log(JSON.stringify(sub.data.attributes, null, 2));
+
+  const locs = await ascApi<{ data: { attributes: Record<string, unknown> }[] }>(
+    `/v1/subscriptions/${SUB_ID}/subscriptionLocalizations`,
+    {},
+  );
+  console.log(`\n--- localizations (${locs.data.length}) ---`);
+  console.log(JSON.stringify(locs.data.map((d) => d.attributes), null, 2));
+
+  const screenshots = await ascApi<{ data: unknown[] }>(
+    `/v1/subscriptions/${SUB_ID}/appStoreReviewScreenshot`,
+    {},
+  ).catch(() => ({ data: [] }));
+  console.log(`\n--- screenshot ---`);
+  console.log(JSON.stringify(screenshots, null, 2));
+
+  const prices = await ascApi<{ data: unknown[] }>(
+    `/v1/subscriptions/${SUB_ID}/prices`,
+    {},
+  ).catch(() => ({ data: [] }));
+  console.log(`\n--- prices count: ${(prices as { data: unknown[] }).data.length} ---`);
+
+  const introOffers = await ascApi<{ data: unknown[] }>(
+    `/v1/subscriptions/${SUB_ID}/introductoryOffers`,
+    {},
+  ).catch(() => ({ data: [] }));
+  console.log(`\n--- intro offers count: ${(introOffers as { data: unknown[] }).data.length} ---`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/src/asc/api-update-monthly-locs.ts
+++ b/scripts/ops/src/asc/api-update-monthly-locs.ts
@@ -1,0 +1,185 @@
+/**
+ * monthly subscription のローカライゼーションを新トライアル方針 (3日間無料 Intro Offer) に合わせて更新する。
+ *
+ * - ja: 既存 (REJECTED) を PATCH で更新
+ * - en-US: 新規追加
+ *
+ * 実行: cd scripts/ops && npx tsx src/asc/api-update-monthly-locs.ts
+ *   DRY_RUN=1 で実際の更新をスキップ
+ */
+import "dotenv/config";
+import { ascApi } from "../lib/asc-api.js";
+
+const SUB_ID = process.env.ASC_PRODUCT_MONTHLY_SUB_ID || "6775457213";
+const DRY_RUN = process.env.DRY_RUN === "1";
+
+interface Loc {
+  id: string;
+  attributes: {
+    locale?: string;
+    name?: string;
+    description?: string;
+    state?: string;
+  };
+}
+
+// 新トライアル方針に合わせた説明文。
+// subscription localization の description は ~45 chars (Apple guideline) に収める。
+// 価格は description には書かず、Apple が表示する localized price に任せる。
+const JA_NAME = "プレミアム（月額）";
+const JA_DESCRIPTION = "全機能の月額プラン。最初の3日間は無料。";
+
+const EN_NAME = "Premium (Monthly)";
+const EN_DESCRIPTION = "All Premium features. 3-day free trial included.";
+
+async function main() {
+  console.log(`DRY_RUN=${DRY_RUN}`);
+
+  const locsResp = await ascApi<{ data: Loc[] }>(
+    `/v1/subscriptions/${SUB_ID}/subscriptionLocalizations`,
+    {},
+  );
+  const ja = locsResp.data.find((l) => l.attributes.locale === "ja");
+  const en = locsResp.data.find((l) => l.attributes.locale === "en-US");
+
+  // 順序重要: REJECTED な ja は直接編集も「最後の1つ」状態での削除も不可。
+  // 先に en-US を POST してから ja を DELETE → POST し直す。
+  // en-US: POST 新規 (or PATCH if exists)
+  if (en) {
+    console.log(`\n→ PATCH en-US (id=${en.id}, state=${en.attributes.state})`);
+    console.log(`  name: ${EN_NAME}`);
+    console.log(`  description: ${EN_DESCRIPTION}`);
+    if (!DRY_RUN) {
+      await ascApi(`/v1/subscriptionLocalizations/${en.id}`, {
+        method: "PATCH",
+        body: {
+          data: {
+            type: "subscriptionLocalizations",
+            id: en.id,
+            attributes: { name: EN_NAME, description: EN_DESCRIPTION },
+          },
+        },
+      });
+      console.log("  ✓ updated");
+    }
+  } else {
+    console.log(`\n→ POST en-US`);
+    console.log(`  name: ${EN_NAME}`);
+    console.log(`  description: ${EN_DESCRIPTION}`);
+    if (!DRY_RUN) {
+      await ascApi(`/v1/subscriptionLocalizations`, {
+        method: "POST",
+        body: {
+          data: {
+            type: "subscriptionLocalizations",
+            attributes: {
+              locale: "en-US",
+              name: EN_NAME,
+              description: EN_DESCRIPTION,
+            },
+            relationships: {
+              subscription: { data: { type: "subscriptions", id: SUB_ID } },
+            },
+          },
+        },
+      });
+      console.log("  ✓ created");
+    }
+  }
+
+  // ja: REJECTED は直接編集不可 (ASC API 409 ENTITY_ERROR.ATTRIBUTE.INVALID.UNMODIFIABLE)。
+  // DELETE → POST で作り直す。それ以外の状態は PATCH。
+  if (ja) {
+    if (ja.attributes.state === "REJECTED") {
+      console.log(`\n→ DELETE ja (id=${ja.id}, state=REJECTED)`);
+      if (!DRY_RUN) {
+        await ascApi(`/v1/subscriptionLocalizations/${ja.id}`, { method: "DELETE" });
+        console.log("  ✓ deleted");
+      }
+      console.log(`→ POST ja (new)`);
+      console.log(`  name: ${JA_NAME}`);
+      console.log(`  description: ${JA_DESCRIPTION}`);
+      if (!DRY_RUN) {
+        await ascApi(`/v1/subscriptionLocalizations`, {
+          method: "POST",
+          body: {
+            data: {
+              type: "subscriptionLocalizations",
+              attributes: {
+                locale: "ja",
+                name: JA_NAME,
+                description: JA_DESCRIPTION,
+              },
+              relationships: {
+                subscription: { data: { type: "subscriptions", id: SUB_ID } },
+              },
+            },
+          },
+        });
+        console.log("  ✓ created");
+      }
+    } else {
+      console.log(`\n→ PATCH ja (id=${ja.id}, state=${ja.attributes.state})`);
+      console.log(`  name: ${JA_NAME}`);
+      console.log(`  description: ${JA_DESCRIPTION}`);
+      if (!DRY_RUN) {
+        await ascApi(`/v1/subscriptionLocalizations/${ja.id}`, {
+          method: "PATCH",
+          body: {
+            data: {
+              type: "subscriptionLocalizations",
+              id: ja.id,
+              attributes: {
+                name: JA_NAME,
+                description: JA_DESCRIPTION,
+              },
+            },
+          },
+        });
+        console.log("  ✓ updated");
+      }
+    }
+  } else {
+    console.log("\n(no ja localization found — will create)");
+    if (!DRY_RUN) {
+      await ascApi(`/v1/subscriptionLocalizations`, {
+        method: "POST",
+        body: {
+          data: {
+            type: "subscriptionLocalizations",
+            attributes: {
+              locale: "ja",
+              name: JA_NAME,
+              description: JA_DESCRIPTION,
+            },
+            relationships: {
+              subscription: {
+                data: { type: "subscriptions", id: SUB_ID },
+              },
+            },
+          },
+        },
+      });
+      console.log("  ✓ created");
+    }
+  }
+
+  // 結果確認
+  console.log("\n--- final state ---");
+  const finalLocs = await ascApi<{ data: Loc[] }>(
+    `/v1/subscriptions/${SUB_ID}/subscriptionLocalizations`,
+    {},
+  );
+  console.log(JSON.stringify(finalLocs.data.map((d) => ({ id: d.id, ...d.attributes })), null, 2));
+
+  const sub = await ascApi<{ data: { attributes: Record<string, unknown> } }>(
+    `/v1/subscriptions/${SUB_ID}`,
+    {},
+  );
+  console.log(`\nsubscription state: ${sub.data.attributes.state}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

トライアル方針を決定し実装:
- **トライアルは Apple 標準 (Introductory Offer / 3日間無料)** に乗せ、乱用防止は Apple に任せる (サーバー側のトライアル管理を持たない)
- **アプリ起動 → Onboarding (登録なし・カード不要)** で循環の触り体験を提供
- **Onboarding 完了後に SignIn → Paywall (Apple Intro Offer) → Main**。Paywall はハードゲートで全機能有料

### 設計の意図
当初検討した「課金情報なし 3日トライアル」は、アカウント作り直しや端末日付改ざんで乱用可能。サーバ側でのトライアル管理は実装/運用コストが高く完全防止は不可能。Apple 標準 Intro Offer に乗せれば Apple ID 単位で eligibility 判定されるため乱用ハードルが上がる。一方で **「価値体験前の課金・登録迫り」** ハードルだけは下げたいので、Onboarding を auth/card 不要の前置きにする。

## Changes

### iOS
- `ContentView`: 最上位ガードを `!hasCompletedOnboarding` → `OnboardingView (auth 不要)` に変更。authenticated 配下で `SubscriptionStore.state` により Main / Paywall を出し分け
- `CycleApp`: `SubscriptionStore` を `EnvironmentObject` として注入
- `PaywallView`:
  - `SubscriptionStore` / `AuthStore` を env 経由で参照（@StateObject 廃止）
  - `Product.subscription.isEligibleForIntroOffer` で eligibility 判定し、対象外ユーザーには無料トライアル文言を出さない
  - フッターに「別アカウントでサインイン」(= signOut) を追加してハードゲートからの脱出路を確保

### ASC (App Store Connect)
- `monthly_1800` の **3日間 FREE_TRIAL Introductory Offer** を REST API で確認、全世界向け設定済み（追加作業不要）
  - `duration: THREE_DAYS / offerMode: FREE_TRIAL / startDate: 2026-06-06`
- monthly subscription の **en-US ローカライゼーション** を新トライアル方針 (`All Premium features. 3-day free trial included.`) で新規追加 → `PREPARE_FOR_SUBMISSION`
- **App Description に EULA URL + サブスクリプション情報を追記して保存** (前回 review rejection 3.1.2(c) の対応)
  - 月額 ¥1,800、3日間無料、自動更新、解約方法、Apple 標準 EULA URL、Privacy Policy URL を追加
- 前回却下されたままだった review submission をキャンセル

### Apple 側の残課題 (次の build 提出時に解消見込み)
- monthly ja localization が `REJECTED` のまま固着 (REST API も Web UI も編集/削除を受け付けない Apple 側の挙動)。次回 review 通過時に自動解消するか、Apple サポートへの連絡が必要
- 前回 rejection 2.1(b) "IAP purchase error" は、PR の paywall フロー明確化 + EULA 追記で解消見込み。Paid Apps Agreement の有効性も次回チェック必要

### Ops scripts 追加
- `scripts/ops/src/asc/api-check-intro-offer.ts`
- `scripts/ops/src/asc/api-loc-detail.ts`
- `scripts/ops/src/asc/api-sub-detail.ts`
- `scripts/ops/src/asc/api-update-monthly-locs.ts`
- `scripts/ops/src/asc/api-delete-loc.ts`

## Test plan
- [x] `xcodebuild build` 成功
- [x] CycleTests 113 tests / 24 suites 全パス
- [x] ASC REST API で intro offer 全世界向け設定確認
- [x] ASC en-US localization 新規追加 (`PREPARE_FOR_SUBMISSION`)
- [x] App description に EULA URL を追加して永続化確認
- [ ] 実機 / シミュレータで以下を確認
  - [ ] 初回起動 → OnboardingView (登録なし) で開始
  - [ ] Onboarding 完了 → SignIn → 認証後に Paywall が表示
  - [ ] Paywall で「3日間無料で始める」→ Apple の購入シートが提示され、購入後 Main に遷移
  - [ ] 既に subscribed なユーザーは認証後すぐ Main に遷移
- [ ] 新 build をアップロード → review submit → ja REJECTED の自動解消を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)