### PR TITLE
feat: TestFlight/Sandbox 限定で paywall をスキップできるテスターボタン

### DIFF
--- a/ios/Cycle/App/ContentView.swift
+++ b/ios/Cycle/App/ContentView.swift
@@ -16,6 +16,9 @@ struct ContentView: View {
     @EnvironmentObject private var taskViewModel: TaskViewModel
     @EnvironmentObject private var subscriptionStore: SubscriptionStore
     @AppStorage("hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    /// Sandbox / TestFlight ビルドでのみ意味を持つ「テスター用に paywall を素通り」フラグ。
+    /// 本番ビルドでは PaywallView 側で bypass ボタンが表示されないため、true になることはない。
+    @AppStorage("testerBypass") private var testerBypass = false
 
     /// アプリ起動時のフロー:
     ///
@@ -45,17 +48,23 @@ struct ContentView: View {
 
     @ViewBuilder
     private var authenticatedContent: some View {
-        switch subscriptionStore.state {
-        case .unknown:
-            splashView
-                .task {
-                    await subscriptionStore.loadProducts()
-                    await subscriptionStore.refreshEntitlements()
-                }
-        case .notSubscribed, .expired:
-            PaywallView()
-        case .trial, .active:
+        // Sandbox / TestFlight ビルドで「テスター用にスキップ」を押されたら subscription state を見ない。
+        // SandboxDetector.isSandbox = false の本番ビルドでは testerBypass を立てる経路がないため安全。
+        if testerBypass && SandboxDetector.isSandbox {
             mainContent
+        } else {
+            switch subscriptionStore.state {
+            case .unknown:
+                splashView
+                    .task {
+                        await subscriptionStore.loadProducts()
+                        await subscriptionStore.refreshEntitlements()
+                    }
+            case .notSubscribed, .expired:
+                PaywallView()
+            case .trial, .active:
+                mainContent
+            }
         }
     }
 

--- a/ios/Cycle/Features/Subscription/Views/PaywallView.swift
+++ b/ios/Cycle/Features/Subscription/Views/PaywallView.swift
@@ -23,6 +23,9 @@ struct PaywallView: View {
     @State private var selectedProductID: String = SubscriptionProductID.monthly.rawValue
     @State private var isPurchasing = false
     @State private var isIntroOfferEligible = true
+    /// Sandbox / TestFlight ビルドで「テスター用にスキップ」した状態を ContentView 側で参照する。
+    /// SandboxDetector.isSandbox = false の本番ビルドでは bypass ボタンを描画しないため、true にできない。
+    @AppStorage("testerBypass") private var testerBypass = false
 
     /// 規約・プライバシーポリシー URL (App Store Connect と同一の URL を入れること)
     let termsURL = URL(string: "https://akitoando.github.io/cycle-journal/legal/TERMS_OF_SERVICE.html")!
@@ -221,6 +224,15 @@ struct PaywallView: View {
             .font(.caption)
             .foregroundStyle(.tertiary)
             .padding(.top, 4)
+
+            if SandboxDetector.isSandbox {
+                Divider().padding(.vertical, 8)
+                Button("テスター用にスキップ (Sandbox のみ)") {
+                    testerBypass = true
+                }
+                .font(.caption)
+                .foregroundStyle(.tertiary)
+            }
         }
         .padding(.top, 8)
     }

--- a/ios/Cycle/Shared/Utilities/SandboxDetector.swift
+++ b/ios/Cycle/Shared/Utilities/SandboxDetector.swift
@@ -1,0 +1,30 @@
+//
+//  SandboxDetector.swift
+//  CycleJournal
+//
+//  TestFlight / Sandbox 環境を本番 App Store ビルドと区別するためのヘルパー。
+//  PaywallView の「テスター用にスキップ」ボタン表示判定に使う。
+//
+//  判定は appStoreReceiptURL の末尾パスで行う:
+//   - 本番 App Store ビルド: ".../receipt"
+//   - TestFlight / Sandbox  : ".../sandboxReceipt"
+//   - Xcode から直接実行 (DEBUG): receipt 未取得 → DEBUG flag を fallback
+//
+//  本番ビルドでは isSandbox = false が保証されるため、bypass ボタンが
+//  実ユーザーに表示されることはない。
+//
+
+import Foundation
+
+enum SandboxDetector {
+    static var isSandbox: Bool {
+        #if DEBUG
+        return true
+        #else
+        guard let url = Bundle.main.appStoreReceiptURL?.lastPathComponent else {
+            return false
+        }
+        return url == "sandboxReceipt"
+        #endif
+    }
+}


### PR DESCRIPTION
## Why

PR #103 で paywall をハードゲート化したが、TestFlight テスター (内部/外部) も sandbox 購入を毎回挟まないとアプリを触れなくなった。Apple sandbox は時間加速 (1ヶ月 → 5分、3日 → 約27分) なので、テスト期間中はトライアルがすぐ切れる。

## What

**Sandbox 環境のみで効く `testerBypass` を追加**:

- `SandboxDetector.isSandbox`: `appStoreReceiptURL.lastPathComponent == "sandboxReceipt"` で判定 (`#if DEBUG` も fallback)
- `PaywallView` の footer 末尾に **Sandbox 時のみ**「テスター用にスキップ (Sandbox のみ)」ボタンを追加
- `ContentView.authenticatedContent`: `testerBypass && SandboxDetector.isSandbox` なら subscription state を見ず mainContent を表示

## 本番ユーザーには影響しない理由

本番 App Store ビルドでは `appStoreReceiptURL` の末尾が `"receipt"` になるため、`SandboxDetector.isSandbox = false`。bypass ボタンが描画されず、`testerBypass` フラグが true になる経路が構造的に存在しない。

## Apple Review への影響

Reviewer も sandbox 環境で確認するためボタンは見える。ただし reviewer の主目的は IAP 購入フローの検証 (前回 2.1(b) rejection 対応)。primary CTA「3日間無料で始める」が目立つ位置にあるため、reviewer は通常それを押す。ASC v1.0.5 review notes にも記載済み。

懸念があれば次回提出時の review notes に「reviewer は通常の購入 CTA を使ってください」と追記可能。

## Test plan
- [x] `xcodebuild build` 成功
- [x] CycleTests 113 tests (renameTag は test 順序依存の pre-existing flaky、develop でも同じく fail するため本 PR と無関係)
- [ ] TestFlight に新ビルド配信後、テスターがボタン押下で main 画面に直行できることを確認
- [ ] 本番ビルドでボタンが表示されないことを次回 production リリース時に確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)