### PR TITLE
Add coach context memory

### DIFF
--- a/api/app/config.py
+++ b/api/app/config.py
@@ -44,6 +44,16 @@ class Settings(BaseSettings):
     coach_input_max_chars: int = 10_000
     coach_output_max_tokens_cap: int = 4_000  # 暴走時の hard cap
     coach_stream_timeout_seconds: int = 60
+    coach_context_history_max_messages: int = 50
+    coach_context_history_max_chars: int = 24_000
+    coach_context_summary_limit: int = 5
+    coach_context_summary_max_chars: int = 600
+    coach_context_diary_max_chars: int = 8_000
+    coach_summary_generation_enabled: bool = True
+    coach_summary_min_user_messages: int = 1
+    coach_summary_refresh_message_interval: int = 4
+    coach_summary_source_max_messages: int = 40
+    coach_summary_max_chars: int = 360
 
     # AI monthly usage budget guardrail
     # MVP の上限は 1 user あたり月 1,000 円程度。価格・為替は変わるため env で上書き可。

--- a/api/app/models/session.py
+++ b/api/app/models/session.py
@@ -18,6 +18,7 @@ class MessageData(BaseModel):
 class SessionSummary(BaseModel):
     session_id: str
     title: str | None = None
+    summary: str | None = None
     cycle_element: CycleElement | None = None
     message_count: int = 0
     last_message_at: datetime | None = None
@@ -27,6 +28,8 @@ class SessionSummary(BaseModel):
 class SessionDetail(BaseModel):
     session_id: str
     title: str | None = None
+    summary: str | None = None
+    summary_generated_at: datetime | None = None
     cycle_element: CycleElement | None = None
     has_diary_context: bool = False
     messages: list[MessageData] = []

--- a/api/app/routers/coach.py
+++ b/api/app/routers/coach.py
@@ -13,7 +13,12 @@ from google.cloud.firestore import AsyncClient
 from app.config import settings
 from app.dependencies import get_current_user, get_firestore
 from app.models.coach import CoachData, CoachMetadata, CoachRequest
-from app.services import ai_usage_service, coach_service, prompt_service
+from app.services import (
+    ai_usage_service,
+    coach_service,
+    context_service,
+    prompt_service,
+)
 from app.services.coach_graph import run_coach_flow
 from app.services.firestore_client import sessions_ref
 
@@ -41,56 +46,40 @@ async def chat(
     """ユーザーのメッセージに対してAIコーチが応答."""
     _validate_input_size(body.message)
     now = datetime.now(UTC)
-    ref = sessions_ref(db)
-
-    # セッション取得 or 新規作成
-    if body.session_id:
-        session_doc = ref.document(body.session_id)
-        session_snap = await session_doc.get()
-        if not session_snap.exists or session_snap.get("user_id") != user_id:
-            # セッションが存在しないか別ユーザーの場合は新規作成
-            session_id = str(uuid.uuid4())
-            session_doc = ref.document(session_id)
-        else:
-            session_id = body.session_id
-    else:
-        session_id = str(uuid.uuid4())
-        session_doc = ref.document(session_id)
-
-    # セッションが未作成の場合は作成
-    session_snap = await session_doc.get()
-    if not session_snap.exists:
-        cycle_element = (
-            body.context.cycle_element.value
-            if body.context and body.context.cycle_element
-            else None
-        )
-        await session_doc.set(
-            {
-                "user_id": user_id,
-                "title": None,
-                "cycle_element": cycle_element,
-                "has_diary_context": body.diary_content is not None,
-                "message_count": 0,
-                "last_message_at": now,
-                "created_at": now,
-                "updated_at": now,
-            }
-        )
+    session_id, session_doc, session_data = await _ensure_session(
+        db, user_id, body, now
+    )
+    effective_diary_content = await _remember_diary_context(
+        session_doc,
+        session_data,
+        body.diary_content,
+        now,
+    )
 
     # 過去のメッセージ履歴を取得
     messages_ref = session_doc.collection("messages")
-    history_query = messages_ref.order_by("created_at").limit(50)
+    history_query = messages_ref.order_by("created_at").limit(
+        settings.coach_context_history_max_messages
+    )
     history_docs = [doc async for doc in history_query.stream()]
-    history = [
-        {"role": doc.get("role"), "content": doc.get("content")}
-        for doc in history_docs
-    ]
+    history = context_service.trim_history(
+        [
+            {"role": doc.get("role"), "content": doc.get("content")}
+            for doc in history_docs
+        ]
+    )
+
+    context_block = await context_service.build_context_block(
+        db,
+        user_id=user_id,
+        current_session_id=session_id,
+    )
 
     estimate = ai_usage_service.estimate_coach_request(
         message=body.message,
         history=history,
-        diary_content=body.diary_content,
+        diary_content=effective_diary_content,
+        context_block=context_block,
     )
     await ai_usage_service.reserve_monthly_budget(
         db,
@@ -109,7 +98,8 @@ async def chat(
         flow_result = await run_coach_flow(
             user_message=body.message,
             history=history,
-            diary_content=body.diary_content,
+            diary_content=effective_diary_content,
+            context_block=context_block,
             system_prompt=system_prompt,
             config=prompt_config,
         )
@@ -120,45 +110,65 @@ async def chat(
         response_text = await coach_service.chat(
             user_message=body.message,
             history=history,
-            diary_content=body.diary_content,
+            diary_content=effective_diary_content,
+            context_block=context_block,
             system_prompt=system_prompt,
             config=prompt_config,
         )
 
     # ユーザーメッセージを保存
     user_msg_id = str(uuid.uuid4())
-    await messages_ref.document(user_msg_id).set({
-        "role": "user",
-        "content": body.message,
-        "metadata": None,
-        "created_at": now,
-    })
+    await messages_ref.document(user_msg_id).set(
+        {
+            "role": "user",
+            "content": body.message,
+            "metadata": None,
+            "created_at": now,
+        }
+    )
 
     # アシスタント応答を保存
     assistant_msg_id = str(uuid.uuid4())
     assistant_now = datetime.now(UTC)
-    await messages_ref.document(assistant_msg_id).set({
-        "role": "assistant",
-        "content": response_text,
-        "metadata": {
-            "model": settings.claude_model,
-            "prompt_version_id": prompt_version_id,
-        },
-        "created_at": assistant_now,
-    })
+    await messages_ref.document(assistant_msg_id).set(
+        {
+            "role": "assistant",
+            "content": response_text,
+            "metadata": {
+                "model": settings.claude_model,
+                "prompt_version_id": prompt_version_id,
+            },
+            "created_at": assistant_now,
+        }
+    )
 
     # セッションのメッセージ数を更新
-    session_data = (await session_doc.get()).to_dict() or {}
-    await session_doc.update({
-        "message_count": session_data.get("message_count", 0) + 2,
-        "last_message_at": assistant_now,
-        "updated_at": assistant_now,
-    })
+    base_message_count = int(session_data.get("message_count", 0) or 0)
+    next_message_count = base_message_count + 2
+    await session_doc.update(
+        {
+            "message_count": next_message_count,
+            "last_message_at": assistant_now,
+            "updated_at": assistant_now,
+        }
+    )
+    summary_session_data = {**session_data, "message_count": next_message_count}
+    await _try_update_summary(
+        session_doc=session_doc,
+        session_data=summary_session_data,
+        messages=[
+            *history,
+            {"role": "user", "content": body.message},
+            {"role": "assistant", "content": response_text},
+        ],
+        diary_context=effective_diary_content,
+        prompt_config=prompt_config,
+        now=assistant_now,
+    )
 
     # Cycle要素: LangGraphの判定結果 > リクエストの指定
-    final_cycle_element = (
-        response_cycle_element
-        or (body.context.cycle_element if body.context else None)
+    final_cycle_element = response_cycle_element or (
+        body.context.cycle_element if body.context else None
     )
 
     return {
@@ -180,7 +190,7 @@ async def _ensure_session(
     user_id: str,
     body: CoachRequest,
     now: datetime,
-) -> tuple[str, object]:
+) -> tuple[str, object, dict]:
     ref = sessions_ref(db)
     session_id = body.session_id or str(uuid.uuid4())
     session_doc = ref.document(session_id)
@@ -195,19 +205,68 @@ async def _ensure_session(
             if body.context and body.context.cycle_element
             else None
         )
-        await session_doc.set(
-            {
-                "user_id": user_id,
-                "title": None,
-                "cycle_element": cycle_element,
-                "has_diary_context": body.diary_content is not None,
-                "message_count": 0,
-                "last_message_at": now,
-                "created_at": now,
-                "updated_at": now,
-            }
+        diary_context = context_service.sanitize_diary_context(body.diary_content)
+        session_data = {
+            "user_id": user_id,
+            "title": None,
+            "cycle_element": cycle_element,
+            "diary_context": diary_context,
+            "has_diary_context": diary_context is not None,
+            "message_count": 0,
+            "last_message_at": now,
+            "created_at": now,
+            "updated_at": now,
+        }
+        await session_doc.set(session_data)
+        return session_id, session_doc, session_data
+    return session_id, session_doc, snap.to_dict() or {}
+
+
+async def _remember_diary_context(
+    session_doc,
+    session_data: dict,
+    diary_content: str | None,
+    now: datetime,
+) -> str | None:
+    if diary_content is None:
+        return session_data.get("diary_context")
+
+    diary_context = context_service.sanitize_diary_context(diary_content)
+    if diary_context == session_data.get("diary_context"):
+        return diary_context
+
+    await session_doc.update(
+        {
+            "diary_context": diary_context,
+            "has_diary_context": diary_context is not None,
+            "updated_at": now,
+        }
+    )
+    session_data["diary_context"] = diary_context
+    session_data["has_diary_context"] = diary_context is not None
+    return diary_context
+
+
+async def _try_update_summary(
+    *,
+    session_doc,
+    session_data: dict,
+    messages: list[dict[str, str]],
+    diary_context: str | None,
+    prompt_config: dict,
+    now: datetime,
+) -> None:
+    try:
+        await context_service.maybe_update_session_summary(
+            session_doc,
+            session_data=session_data,
+            messages=messages,
+            diary_context=diary_context,
+            config=prompt_config,
+            now=now,
         )
-    return session_id, session_doc
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("coach summary update failed: %s", exc)
 
 
 @router.post("/coach/stream")
@@ -219,21 +278,40 @@ async def chat_stream(
     """Server-Sent Events で chunk 単位に応答を返す."""
     _validate_input_size(body.message)
     now = datetime.now(UTC)
-    session_id, session_doc = await _ensure_session(db, user_id, body, now)
+    session_id, session_doc, session_data = await _ensure_session(
+        db, user_id, body, now
+    )
+    effective_diary_content = await _remember_diary_context(
+        session_doc,
+        session_data,
+        body.diary_content,
+        now,
+    )
 
     messages_ref = session_doc.collection("messages")
-    history_query = messages_ref.order_by("created_at").limit(50)
+    history_query = messages_ref.order_by("created_at").limit(
+        settings.coach_context_history_max_messages
+    )
     history_docs = [doc async for doc in history_query.stream()]
-    history = [
-        {"role": doc.get("role"), "content": doc.get("content")} for doc in history_docs
-    ]
+    history = context_service.trim_history(
+        [
+            {"role": doc.get("role"), "content": doc.get("content")}
+            for doc in history_docs
+        ]
+    )
+    context_block = await context_service.build_context_block(
+        db,
+        user_id=user_id,
+        current_session_id=session_id,
+    )
     prompt_config, prompt_version_id = await prompt_service.get_active_config(db)
     system_prompt = str(prompt_config["system_prompt"])
 
     estimate = ai_usage_service.estimate_coach_request(
         message=body.message,
         history=history,
-        diary_content=body.diary_content,
+        diary_content=effective_diary_content,
+        context_block=context_block,
     )
     await ai_usage_service.reserve_monthly_budget(
         db,
@@ -252,12 +330,14 @@ async def chat_stream(
         yield f"event: session\ndata: {json.dumps({'session_id': session_id})}\n\n"
         accumulated = ""
         try:
+
             async def consume():
                 nonlocal accumulated
                 async for chunk in coach_service.chat_stream(
                     user_message=body.message,
                     history=history,
-                    diary_content=body.diary_content,
+                    diary_content=effective_diary_content,
+                    context_block=context_block,
                     system_prompt=system_prompt,
                     config=prompt_config,
                 ):
@@ -295,14 +375,30 @@ async def chat_stream(
                         "created_at": assistant_now,
                     }
                 )
-                snap = await session_doc.get()
-                data = snap.to_dict() or {}
+                base_message_count = int(session_data.get("message_count", 0) or 0)
+                next_message_count = base_message_count + 2
                 await session_doc.update(
                     {
-                        "message_count": data.get("message_count", 0) + 2,
+                        "message_count": next_message_count,
                         "last_message_at": assistant_now,
                         "updated_at": assistant_now,
                     }
+                )
+                summary_session_data = {
+                    **session_data,
+                    "message_count": next_message_count,
+                }
+                await _try_update_summary(
+                    session_doc=session_doc,
+                    session_data=summary_session_data,
+                    messages=[
+                        *history,
+                        {"role": "user", "content": body.message},
+                        {"role": "assistant", "content": accumulated},
+                    ],
+                    diary_context=effective_diary_content,
+                    prompt_config=prompt_config,
+                    now=assistant_now,
                 )
             yield "event: done\ndata: {}\n\n"
 

--- a/api/app/routers/sessions.py
+++ b/api/app/routers/sessions.py
@@ -15,6 +15,7 @@ from app.models.session import (
     SessionListData,
     SessionSummary,
 )
+from app.services import context_service
 from app.services.firestore_client import sessions_ref
 
 router = APIRouter(prefix="/sessions", tags=["Sessions"])
@@ -29,9 +30,8 @@ async def list_sessions(
 ):
     """ユーザーの会話セッション一覧を取得."""
     ref = sessions_ref(db)
-    query = (
-        ref.where("user_id", "==", user_id)
-        .order_by("created_at", direction="DESCENDING")
+    query = ref.where("user_id", "==", user_id).order_by(
+        "created_at", direction="DESCENDING"
     )
 
     # 全件数を取得
@@ -48,6 +48,7 @@ async def list_sessions(
             SessionSummary(
                 session_id=doc.id,
                 title=data.get("title"),
+                summary=data.get("summary"),
                 cycle_element=data.get("cycle_element"),
                 message_count=data.get("message_count", 0),
                 last_message_at=data.get("last_message_at"),
@@ -75,12 +76,14 @@ async def create_session(
     ref = sessions_ref(db)
     session_id = str(uuid.uuid4())
     now = datetime.now(UTC)
+    diary_context = context_service.sanitize_diary_context(body.diary_content)
 
     session_data = {
         "user_id": user_id,
         "title": body.title,
         "cycle_element": body.cycle_element.value if body.cycle_element else None,
-        "has_diary_context": body.diary_content is not None,
+        "diary_context": diary_context,
+        "has_diary_context": diary_context is not None,
         "message_count": 0,
         "last_message_at": now,
         "created_at": now,
@@ -92,6 +95,7 @@ async def create_session(
         "data": SessionSummary(
             session_id=session_id,
             title=body.title,
+            summary=None,
             cycle_element=body.cycle_element,
             message_count=0,
             last_message_at=now,
@@ -138,6 +142,8 @@ async def get_session(
         "data": SessionDetail(
             session_id=session_id,
             title=data.get("title"),
+            summary=data.get("summary"),
+            summary_generated_at=data.get("summary_generated_at"),
             cycle_element=data.get("cycle_element"),
             has_diary_context=data.get("has_diary_context", False),
             messages=messages,

--- a/api/app/services/ai_usage_service.py
+++ b/api/app/services/ai_usage_service.py
@@ -55,6 +55,7 @@ def estimate_coach_request(
     message: str,
     history: list[dict] | None = None,
     diary_content: str | None = None,
+    context_block: str | None = None,
     period: str | None = None,
 ) -> UsageEstimate:
     """Estimate cost before the model call.
@@ -65,6 +66,8 @@ def estimate_coach_request(
     input_chars = len(coach_service.SYSTEM_PROMPT) + len(message)
     if diary_content:
         input_chars += len(diary_content)
+    if context_block:
+        input_chars += len(context_block)
     if history:
         input_chars += sum(len(str(item.get("content") or "")) for item in history)
 

--- a/api/app/services/coach_graph.py
+++ b/api/app/services/coach_graph.py
@@ -16,7 +16,7 @@ import anthropic
 from langgraph.graph import END, StateGraph
 
 from app.config import settings
-from app.services.coach_service import SYSTEM_PROMPT
+from app.services.coach_service import SYSTEM_PROMPT, build_user_content
 
 # Cycle要素
 CYCLE_ELEMENTS = ["Soil", "Water", "Root", "Trunk", "Branch", "Leaf", "Fruit", "Sky"]
@@ -56,6 +56,7 @@ class CoachState:
 
     user_message: str = ""
     diary_content: str | None = None
+    context_block: str | None = None
     history: list[dict[str, str]] = field(default_factory=list)
     detected_emotion: str | None = None
     cycle_element: str | None = None
@@ -138,12 +139,11 @@ def generate_response(state: CoachState) -> dict:
         cycle_element=state.cycle_element,
     )
 
-    body = state.user_message
-    if state.diary_content:
-        body = (
-            f"【日記の内容】\n{state.diary_content}\n\n"
-            f"【ユーザーのメッセージ】\n{state.user_message}"
-        )
+    body = build_user_content(
+        state.user_message,
+        diary_content=state.diary_content,
+        context_block=state.context_block,
+    )
 
     messages.append({"role": "user", "content": analysis_block + body})
 
@@ -187,6 +187,7 @@ def _state_to_dict(state: CoachState) -> dict:
     return {
         "user_message": state.user_message,
         "diary_content": state.diary_content,
+        "context_block": state.context_block,
         "history": state.history,
         "detected_emotion": state.detected_emotion,
         "cycle_element": state.cycle_element,
@@ -210,9 +211,7 @@ def build_coach_graph() -> StateGraph:
 
     graph.add_node("analyze_emotion", lambda s: analyze_emotion(_dict_to_state(s)))
     graph.add_node("determine_cycle", lambda s: determine_cycle(_dict_to_state(s)))
-    graph.add_node(
-        "generate_response", lambda s: generate_response(_dict_to_state(s))
-    )
+    graph.add_node("generate_response", lambda s: generate_response(_dict_to_state(s)))
     graph.add_node("safety_filter", lambda s: safety_filter(_dict_to_state(s)))
 
     graph.set_entry_point("analyze_emotion")
@@ -228,6 +227,7 @@ def _dict_to_state(d: dict) -> CoachState:
     return CoachState(
         user_message=d.get("user_message", ""),
         diary_content=d.get("diary_content"),
+        context_block=d.get("context_block"),
         history=d.get("history", []),
         detected_emotion=d.get("detected_emotion"),
         cycle_element=d.get("cycle_element"),
@@ -264,6 +264,7 @@ async def run_coach_flow(
     user_message: str,
     history: list[dict] | None = None,
     diary_content: str | None = None,
+    context_block: str | None = None,
     system_prompt: str | None = None,
     config: dict | None = None,
 ) -> dict:
@@ -278,6 +279,7 @@ async def run_coach_flow(
     initial_state = {
         "user_message": user_message,
         "diary_content": diary_content,
+        "context_block": context_block,
         "history": history or [],
         "detected_emotion": None,
         "cycle_element": None,

--- a/api/app/services/coach_service.py
+++ b/api/app/services/coach_service.py
@@ -38,6 +38,25 @@ def _config_max_tokens(config: dict | None) -> int:
     )
     return min(max_tokens, cap)
 
+
+def build_user_content(
+    user_message: str,
+    diary_content: str | None = None,
+    context_block: str | None = None,
+) -> str:
+    """Build the dynamic user message without changing the cacheable system prefix."""
+    if not diary_content and not context_block:
+        return user_message
+
+    parts: list[str] = []
+    if context_block:
+        parts.append(f"【参考コンテキスト】\n{context_block.strip()}")
+    if diary_content:
+        parts.append(f"【日記の内容】\n{diary_content.strip()}")
+    parts.append(f"【ユーザーのメッセージ】\n{user_message}")
+    return "\n\n".join(parts)
+
+
 # ベースプロンプト（Cycleの大樹スタイル）
 # NOTE: prompt caching を有効化するため、Sonnet の最小 cacheable prefix
 # (約 1024 tokens) を上回るよう Cycle 要素詳細・口調例・few-shot を拡充している。
@@ -144,6 +163,7 @@ async def chat(
     user_message: str,
     history: list[dict] | None = None,
     diary_content: str | None = None,
+    context_block: str | None = None,
     system_prompt: str | None = None,
     config: dict | None = None,
 ) -> str:
@@ -152,9 +172,11 @@ async def chat(
     settings.use_gemini_fallback=True のとき Gemini を呼ぶ。
     Claude quota が下りたら False に戻す。
     """
-    content = user_message
-    if diary_content:
-        content = f"【日記の内容】\n{diary_content}\n\n【ユーザーのメッセージ】\n{user_message}"
+    content = build_user_content(
+        user_message,
+        diary_content=diary_content,
+        context_block=context_block,
+    )
 
     if bool(_config_value(config, "use_gemini_fallback", settings.use_gemini_fallback)):
         return _chat_gemini(content, history, system_prompt, config)
@@ -184,7 +206,9 @@ def _chat_claude(
             }
         ],
         messages=messages,
-        temperature=float(_config_value(config, "temperature", settings.claude_temperature)),
+        temperature=float(
+            _config_value(config, "temperature", settings.claude_temperature)
+        ),
     )
     return response.content[0].text
 
@@ -203,7 +227,9 @@ def _chat_gemini(
         config=genai_types.GenerateContentConfig(
             system_instruction=system_prompt or SYSTEM_PROMPT,
             max_output_tokens=_config_max_tokens(config),
-            temperature=float(_config_value(config, "temperature", settings.claude_temperature)),
+            temperature=float(
+                _config_value(config, "temperature", settings.claude_temperature)
+            ),
         ),
     )
     return response.text or ""
@@ -218,9 +244,13 @@ def _build_gemini_contents(
         for m in history:
             role = "user" if m.get("role") == "user" else "model"
             contents.append(
-                genai_types.Content(role=role, parts=[genai_types.Part(text=m["content"])])
+                genai_types.Content(
+                    role=role, parts=[genai_types.Part(text=m["content"])]
+                )
             )
-    contents.append(genai_types.Content(role="user", parts=[genai_types.Part(text=content)]))
+    contents.append(
+        genai_types.Content(role="user", parts=[genai_types.Part(text=content)])
+    )
     return contents
 
 
@@ -228,6 +258,7 @@ async def chat_stream(
     user_message: str,
     history: list[dict] | None = None,
     diary_content: str | None = None,
+    context_block: str | None = None,
     system_prompt: str | None = None,
     config: dict | None = None,
 ) -> AsyncIterator[str]:
@@ -235,9 +266,11 @@ async def chat_stream(
 
     現状は Gemini fallback 経路のみ対応。Claude 復帰時に \\_stream_claude を追加する。
     """
-    content = user_message
-    if diary_content:
-        content = f"【日記の内容】\n{diary_content}\n\n【ユーザーのメッセージ】\n{user_message}"
+    content = build_user_content(
+        user_message,
+        diary_content=diary_content,
+        context_block=context_block,
+    )
 
     client = _get_gemini_client()
     contents = _build_gemini_contents(content, history)
@@ -247,10 +280,56 @@ async def chat_stream(
         config=genai_types.GenerateContentConfig(
             system_instruction=system_prompt or SYSTEM_PROMPT,
             max_output_tokens=_config_max_tokens(config),
-            temperature=float(_config_value(config, "temperature", settings.claude_temperature)),
+            temperature=float(
+                _config_value(config, "temperature", settings.claude_temperature)
+            ),
         ),
     )
     for chunk in stream:
         text = getattr(chunk, "text", None)
         if text:
             yield text
+
+
+async def quick_text(
+    prompt: str,
+    *,
+    max_tokens: int = 400,
+    system_prompt: str | None = None,
+    config: dict | None = None,
+) -> str:
+    """Run a short extraction/summarization task on the quick model."""
+    if bool(_config_value(config, "use_gemini_fallback", settings.use_gemini_fallback)):
+        client = _get_gemini_client()
+        response = client.models.generate_content(
+            model=_config_value(
+                config,
+                "gemini_model_quick",
+                settings.gemini_model_quick,
+            ),
+            contents=[
+                genai_types.Content(role="user", parts=[genai_types.Part(text=prompt)])
+            ],
+            config=genai_types.GenerateContentConfig(
+                system_instruction=system_prompt,
+                max_output_tokens=max_tokens,
+                temperature=0.0,
+            ),
+        )
+        return response.text or ""
+
+    client = _get_claude_client()
+    kwargs = {
+        "model": _config_value(
+            config,
+            "claude_model_quick",
+            settings.claude_model_quick,
+        ),
+        "max_tokens": max_tokens,
+        "messages": [{"role": "user", "content": prompt}],
+        "temperature": 0.0,
+    }
+    if system_prompt:
+        kwargs["system"] = system_prompt
+    response = client.messages.create(**kwargs)
+    return response.content[0].text

--- a/api/app/services/context_service.py
+++ b/api/app/services/context_service.py
@@ -1,0 +1,225 @@
+"""Coach context memory helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+from google.cloud.firestore import AsyncClient
+
+from app.config import settings
+from app.services import coach_service
+from app.services.firestore_client import sessions_ref
+
+
+@dataclass(frozen=True)
+class PastSessionSummary:
+    session_id: str
+    summary: str
+    last_message_at: datetime | None = None
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    text = text.strip()
+    if len(text) <= max_chars:
+        return text
+    return text[: max(0, max_chars - 4)].rstrip() + "\n..."
+
+
+def sanitize_diary_context(diary_content: str | None) -> str | None:
+    """Keep diary context bounded before persisting or prompting with it."""
+    if not diary_content:
+        return None
+    return _truncate(diary_content, settings.coach_context_diary_max_chars)
+
+
+def trim_history(history: list[dict] | None) -> list[dict[str, str]]:
+    """Keep recent same-session messages within message and character budgets."""
+    if not history:
+        return []
+
+    normalized: list[dict[str, str]] = []
+    for item in history:
+        role = item.get("role")
+        content = str(item.get("content") or "").strip()
+        if role not in {"user", "assistant"} or not content:
+            continue
+        normalized.append({"role": role, "content": content})
+
+    recent = normalized[-settings.coach_context_history_max_messages :]
+    total = 0
+    kept_reversed: list[dict[str, str]] = []
+    for item in reversed(recent):
+        length = len(item["content"])
+        if kept_reversed and total + length > settings.coach_context_history_max_chars:
+            break
+        kept_reversed.append(item)
+        total += length
+    return list(reversed(kept_reversed))
+
+
+async def get_past_session_summaries(
+    db: AsyncClient,
+    *,
+    user_id: str,
+    current_session_id: str | None,
+    limit: int | None = None,
+) -> list[PastSessionSummary]:
+    """Fetch recent saved summaries for the same user, excluding this session."""
+    max_items = limit or settings.coach_context_summary_limit
+    if max_items <= 0:
+        return []
+
+    summaries: list[PastSessionSummary] = []
+    query = sessions_ref(db).where("user_id", "==", user_id)
+    async for doc in query.stream():
+        if doc.id == current_session_id:
+            continue
+        data = doc.to_dict() or {}
+        raw_summary = data.get("summary") or data.get("title")
+        if not raw_summary:
+            continue
+        summaries.append(
+            PastSessionSummary(
+                session_id=doc.id,
+                summary=_truncate(
+                    str(raw_summary),
+                    settings.coach_context_summary_max_chars,
+                ),
+                last_message_at=data.get("last_message_at"),
+            )
+        )
+
+    summaries.sort(
+        key=lambda item: (
+            item.last_message_at.timestamp() if item.last_message_at else 0.0
+        ),
+        reverse=True,
+    )
+    return summaries[:max_items]
+
+
+def format_context_block(summaries: list[PastSessionSummary]) -> str | None:
+    """Build the dynamic memory block injected into the next coach turn."""
+    if not summaries:
+        return None
+
+    lines = [
+        "【過去セッション要約】",
+        "これは参考情報です。断定せず、必要な時だけユーザーの言葉として扱ってください。",
+    ]
+    for item in summaries:
+        prefix = ""
+        if item.last_message_at:
+            prefix = item.last_message_at.date().isoformat() + " "
+        lines.append(f"- {prefix}{item.summary}")
+    return "\n".join(lines)
+
+
+async def build_context_block(
+    db: AsyncClient,
+    *,
+    user_id: str,
+    current_session_id: str | None,
+) -> str | None:
+    summaries = await get_past_session_summaries(
+        db,
+        user_id=user_id,
+        current_session_id=current_session_id,
+    )
+    return format_context_block(summaries)
+
+
+def _user_messages_text(messages: list[dict[str, str]]) -> str:
+    user_lines: list[str] = []
+    for item in messages[-settings.coach_summary_source_max_messages :]:
+        if item.get("role") != "user":
+            continue
+        content = str(item.get("content") or "").strip()
+        if content:
+            user_lines.append(f"- {content}")
+    return "\n".join(user_lines)
+
+
+async def generate_session_summary(
+    messages: list[dict[str, str]],
+    *,
+    diary_context: str | None = None,
+    config: dict | None = None,
+) -> str | None:
+    """Summarize a session from user utterances only."""
+    user_text = _user_messages_text(messages)
+    if not user_text:
+        return None
+
+    diary_part = ""
+    if diary_context:
+        diary_part = (
+            "【日記コンテキスト】\n"
+            + _truncate(diary_context, settings.coach_context_summary_max_chars)
+            + "\n\n"
+        )
+
+    prompt = (
+        "あなたはCycleの会話要約器です。\n"
+        "コーチ発話は解釈材料にせず、ユーザー発話だけから短い記憶メモを作ってください。\n"
+        "評価、診断、助言、重要度の説明は禁止です。\n"
+        "ユーザーが実際に使った言葉をできるだけ残し、1〜3文の日本語で返してください。\n\n"
+        f"{diary_part}"
+        "【ユーザー発話】\n"
+        f"{user_text}"
+    )
+    summary = await coach_service.quick_text(
+        prompt,
+        max_tokens=240,
+        config=config,
+    )
+    summary = summary.strip()
+    if not summary:
+        return None
+    return _truncate(summary, settings.coach_summary_max_chars)
+
+
+async def maybe_update_session_summary(
+    session_doc: Any,
+    *,
+    session_data: dict,
+    messages: list[dict[str, str]],
+    diary_context: str | None,
+    config: dict | None = None,
+    now: datetime | None = None,
+) -> None:
+    """Generate and persist a bounded session summary when it is stale."""
+    if not settings.coach_summary_generation_enabled:
+        return
+
+    user_message_count = sum(1 for item in messages if item.get("role") == "user")
+    if user_message_count < settings.coach_summary_min_user_messages:
+        return
+
+    message_count = int(
+        session_data.get("message_count", len(messages)) or len(messages)
+    )
+    summary_message_count = int(session_data.get("summary_message_count", 0) or 0)
+    has_summary = bool(session_data.get("summary"))
+    if has_summary:
+        refresh_interval = max(settings.coach_summary_refresh_message_interval, 1)
+        if message_count - summary_message_count < refresh_interval:
+            return
+
+    summary = await generate_session_summary(
+        messages,
+        diary_context=diary_context,
+        config=config,
+    )
+    if not summary:
+        return
+
+    await session_doc.update(
+        {
+            "summary": summary,
+            "summary_generated_at": now or datetime.now(UTC),
+            "summary_message_count": message_count,
+        }
+    )

--- a/api/tests/test_ai_usage_service.py
+++ b/api/tests/test_ai_usage_service.py
@@ -26,6 +26,7 @@ def test_estimate_uses_gemini_prices_when_fallback_enabled(monkeypatch):
         message="今日は疲れた",
         history=[{"role": "assistant", "content": "前回の返答"}],
         diary_content="日記本文",
+        context_block="過去セッション要約",
         period="2026-07",
     )
 

--- a/api/tests/test_coach.py
+++ b/api/tests/test_coach.py
@@ -10,17 +10,30 @@ def test_coach_requires_auth(client):
 
 def test_coach_chat(auth_client, mock_firestore):
     """Test successful coach chat."""
-    with patch(
-        "app.routers.coach.coach_service.chat",
-        new_callable=AsyncMock,
-    ) as mock_chat, patch(
-        "app.routers.coach.ai_usage_service.reserve_monthly_budget",
-        new_callable=AsyncMock,
-    ) as reserve_budget, patch(
-        "app.routers.coach.prompt_service.get_active_config",
-        new_callable=AsyncMock,
-    ) as active_config:
+    with (
+        patch(
+            "app.routers.coach.coach_service.chat",
+            new_callable=AsyncMock,
+        ) as mock_chat,
+        patch(
+            "app.routers.coach.context_service.build_context_block",
+            new_callable=AsyncMock,
+        ) as build_context,
+        patch(
+            "app.routers.coach.context_service.maybe_update_session_summary",
+            new_callable=AsyncMock,
+        ) as update_summary,
+        patch(
+            "app.routers.coach.ai_usage_service.reserve_monthly_budget",
+            new_callable=AsyncMock,
+        ) as reserve_budget,
+        patch(
+            "app.routers.coach.prompt_service.get_active_config",
+            new_callable=AsyncMock,
+        ) as active_config,
+    ):
         mock_chat.return_value = "そう感じたんだね。"
+        build_context.return_value = "【過去セッション要約】\n- 前回の話"
         active_config.return_value = (
             {
                 "system_prompt": "system prompt",
@@ -51,6 +64,11 @@ def test_coach_chat(auth_client, mock_firestore):
     reserve_budget.assert_awaited_once()
     mock_chat.assert_awaited_once()
     assert mock_chat.call_args.kwargs["system_prompt"] == "system prompt"
+    assert (
+        mock_chat.call_args.kwargs["context_block"]
+        == "【過去セッション要約】\n- 前回の話"
+    )
+    update_summary.assert_awaited_once()
     data = response.json()["data"]
     assert data["message"] == "そう感じたんだね。"
     assert "session_id" in data

--- a/api/tests/test_coach_service.py
+++ b/api/tests/test_coach_service.py
@@ -32,6 +32,20 @@ def test_system_prompt_keeps_core_metaphor():
     assert "わたし" in prompt
 
 
+def test_build_user_content_includes_dynamic_context():
+    content = coach_service.build_user_content(
+        "この日記について話したいです",
+        diary_content="朝から緊張していた",
+        context_block="【過去セッション要約】\n- 仕事の疲れ",
+    )
+
+    assert "【参考コンテキスト】" in content
+    assert "仕事の疲れ" in content
+    assert "【日記の内容】" in content
+    assert "朝から緊張していた" in content
+    assert "【ユーザーのメッセージ】" in content
+
+
 @pytest.mark.asyncio
 async def test_chat_uses_coach_model_in_claude_mode(monkeypatch):
     """Claude モード (use_gemini_fallback=False) では Sonnet を使う."""
@@ -118,3 +132,22 @@ async def test_chat_uses_gemini_when_fallback_enabled(monkeypatch):
         # system_instruction は config 経由で渡される
         cfg = call_kwargs["config"]
         assert cfg.system_instruction == coach_service.SYSTEM_PROMPT
+
+
+@pytest.mark.asyncio
+async def test_quick_text_uses_gemini_quick_when_fallback_enabled(monkeypatch):
+    """要約などの短い抽出は Gemini fallback 時も quick モデルを使う."""
+    monkeypatch.setattr(settings, "use_gemini_fallback", True)
+
+    with patch("app.services.coach_service._get_gemini_client") as mock_get:
+        client = MagicMock()
+        response = MagicMock()
+        response.text = "要約"
+        client.models.generate_content.return_value = response
+        mock_get.return_value = client
+
+        result = await coach_service.quick_text("要約して")
+
+        assert result == "要約"
+        call_kwargs = client.models.generate_content.call_args.kwargs
+        assert call_kwargs["model"] == settings.gemini_model_quick

--- a/api/tests/test_context_service.py
+++ b/api/tests/test_context_service.py
@@ -1,0 +1,163 @@
+"""Coach context memory service tests."""
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.config import settings
+from app.services import context_service
+
+
+def test_trim_history_keeps_recent_valid_messages(monkeypatch):
+    monkeypatch.setattr(settings, "coach_context_history_max_messages", 2)
+    monkeypatch.setattr(settings, "coach_context_history_max_chars", 1_000)
+
+    history = [
+        {"role": "system", "content": "ignore"},
+        {"role": "user", "content": "first"},
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "third"},
+        {"role": "assistant", "content": ""},
+    ]
+
+    assert context_service.trim_history(history) == [
+        {"role": "assistant", "content": "second"},
+        {"role": "user", "content": "third"},
+    ]
+
+
+def test_format_context_block_includes_past_summaries():
+    block = context_service.format_context_block(
+        [
+            context_service.PastSessionSummary(
+                session_id="old-1",
+                summary="仕事の疲れについて話した",
+                last_message_at=datetime(2026, 7, 25, tzinfo=UTC),
+            )
+        ]
+    )
+
+    assert block is not None
+    assert "過去セッション要約" in block
+    assert "2026-07-25 仕事の疲れについて話した" in block
+
+
+@pytest.mark.asyncio
+async def test_get_past_session_summaries_filters_current_and_empty():
+    def make_doc(doc_id: str, data: dict) -> MagicMock:
+        doc = MagicMock()
+        doc.id = doc_id
+        doc.to_dict.return_value = data
+        return doc
+
+    async def stream():
+        yield make_doc("current", {"summary": "current"})
+        yield make_doc("old-1", {"summary": "前回の要約"})
+        yield make_doc("old-2", {"title": None})
+        yield make_doc("old-3", {"title": "タイトルだけ"})
+
+    query = MagicMock()
+    query.order_by.return_value = query
+    query.limit.return_value = query
+    query.stream.return_value = stream()
+
+    collection = MagicMock()
+    collection.where.return_value = query
+
+    db = MagicMock()
+    db.collection.return_value = collection
+
+    summaries = await context_service.get_past_session_summaries(
+        db,
+        user_id="user-1",
+        current_session_id="current",
+        limit=2,
+    )
+
+    assert [item.session_id for item in summaries] == ["old-1", "old-3"]
+    assert summaries[1].summary == "タイトルだけ"
+    collection.where.assert_called_once_with("user_id", "==", "user-1")
+
+
+@pytest.mark.asyncio
+async def test_generate_session_summary_uses_user_messages_only(monkeypatch):
+    captured: dict[str, str] = {}
+
+    async def fake_quick_text(prompt, *, max_tokens, config=None, system_prompt=None):
+        captured["prompt"] = prompt
+        captured["max_tokens"] = str(max_tokens)
+        return "仕事の疲れについて話した"
+
+    monkeypatch.setattr(context_service.coach_service, "quick_text", fake_quick_text)
+
+    result = await context_service.generate_session_summary(
+        [
+            {"role": "assistant", "content": "コーチの解釈は含めない"},
+            {"role": "user", "content": "今日は仕事で疲れた"},
+        ],
+        diary_context="朝から緊張していた",
+        config={"use_gemini_fallback": True},
+    )
+
+    assert result == "仕事の疲れについて話した"
+    assert "今日は仕事で疲れた" in captured["prompt"]
+    assert "朝から緊張していた" in captured["prompt"]
+    assert "コーチの解釈は含めない" not in captured["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_maybe_update_session_summary_persists_when_stale(monkeypatch):
+    generate = AsyncMock(return_value="仕事の疲れについて話した")
+    monkeypatch.setattr(context_service, "generate_session_summary", generate)
+
+    session_doc = MagicMock()
+    session_doc.update = AsyncMock()
+    now = datetime(2026, 8, 9, tzinfo=UTC)
+
+    await context_service.maybe_update_session_summary(
+        session_doc,
+        session_data={"message_count": 2},
+        messages=[
+            {"role": "user", "content": "今日は疲れた"},
+            {"role": "assistant", "content": "そう感じたんだね。"},
+        ],
+        diary_context=None,
+        config={"use_gemini_fallback": True},
+        now=now,
+    )
+
+    session_doc.update.assert_awaited_once()
+    payload = session_doc.update.await_args.args[0]
+    assert payload["summary"] == "仕事の疲れについて話した"
+    assert payload["summary_generated_at"] == now
+    assert payload["summary_message_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_maybe_update_session_summary_skips_fresh_summary(monkeypatch):
+    generate = AsyncMock(return_value="new")
+    monkeypatch.setattr(context_service, "generate_session_summary", generate)
+    monkeypatch.setattr(settings, "coach_summary_refresh_message_interval", 4)
+
+    session_doc = MagicMock()
+    session_doc.update = AsyncMock()
+
+    await context_service.maybe_update_session_summary(
+        session_doc,
+        session_data={
+            "summary": "existing",
+            "summary_message_count": 2,
+            "message_count": 4,
+        },
+        messages=[
+            {"role": "user", "content": "one"},
+            {"role": "assistant", "content": "two"},
+            {"role": "user", "content": "three"},
+            {"role": "assistant", "content": "four"},
+        ],
+        diary_context=None,
+    )
+
+    generate.assert_not_awaited()
+    session_doc.update.assert_not_awaited()

--- a/ios/Cycle/Features/Coach/Models/CoachSession.swift
+++ b/ios/Cycle/Features/Coach/Models/CoachSession.swift
@@ -47,7 +47,7 @@ struct CoachSession: Identifiable, Codable {
             serverId: data.sessionId,
             createdAt: data.createdAt,
             updatedAt: data.lastMessageAt ?? data.createdAt,
-            summary: data.title,
+            summary: data.summary ?? data.title,
             isActive: false
         )
     }
@@ -73,7 +73,7 @@ struct CoachSession: Identifiable, Codable {
             messages: messages,
             createdAt: detail.createdAt,
             updatedAt: detail.updatedAt ?? detail.createdAt,
-            summary: detail.title,
+            summary: detail.summary ?? detail.title,
             isActive: false
         )
     }

--- a/ios/Cycle/Features/Coach/Store/CoachStore.swift
+++ b/ios/Cycle/Features/Coach/Store/CoachStore.swift
@@ -392,6 +392,7 @@ class CoachStore: ObservableObject {
                 if let index = sessions.firstIndex(where: { $0.serverId == serverId }) {
                     sessions[index].messages = fullSession.messages
                     sessions[index].updatedAt = fullSession.updatedAt
+                    sessions[index].summary = fullSession.summary
                     saveSessions()
                 }
             }

--- a/ios/Cycle/Services/APIModels.swift
+++ b/ios/Cycle/Services/APIModels.swift
@@ -43,6 +43,7 @@ struct CreateSessionRequest: Encodable {
 struct SessionData: Decodable {
     let sessionId: String
     let title: String?
+    let summary: String?
     let cycleElement: String?
     let messageCount: Int?
     let lastMessageAt: Date?
@@ -59,6 +60,8 @@ struct SessionListData: Decodable {
 struct SessionDetailData: Decodable {
     let sessionId: String
     let title: String?
+    let summary: String?
+    let summaryGeneratedAt: Date?
     let cycleElement: String?
     let hasDiaryContext: Bool?
     let messages: [MessageData]


### PR DESCRIPTION
## Summary

- Add backend coach context memory for prior session summaries, bounded same-session history, and persisted diary context.
- Generate short session summaries from user utterances using the quick model path, with Gemini fallback support.
- Inject prior summaries into both `/coach` and `/coach/stream`, including LangGraph mode.
- Return `summary` on session list/detail APIs and let iOS prefer server summaries over titles.

Closes #26.
Partially addresses #117.

## Verification

- `uv run ruff check app/config.py app/models/session.py app/routers/coach.py app/routers/sessions.py app/services/ai_usage_service.py app/services/coach_graph.py app/services/coach_service.py app/services/context_service.py tests/test_ai_usage_service.py tests/test_coach.py tests/test_coach_service.py tests/test_context_service.py`
- `uv run pytest` (101 passed)
- `xcodebuild build -project ios/Cycle.xcodeproj -scheme Cycle -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -derivedDataPath /private/tmp/cycle-xcode-deriveddata`
- `xcodebuild test -project ios/Cycle.xcodeproj -scheme Cycle -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.3.1' -derivedDataPath /private/tmp/cycle-xcode-deriveddata -only-testing:CycleTests/CoachSessionTests` (4 passed)

## Notes

- `xcodebuild test ... -only-testing:CycleTests` failed in the unrelated `JournalViewModelTests.renameTag` test. A follow-up single-test rerun hit a Simulator Busy launch error before executing the test runner.
