### PR TITLE
Add coach phase control state

### DIFF
--- a/api/app/routers/coach.py
+++ b/api/app/routers/coach.py
@@ -15,6 +15,7 @@ from app.dependencies import get_current_user, get_firestore
 from app.models.coach import CoachData, CoachMetadata, CoachRequest
 from app.services import (
     ai_usage_service,
+    coach_phase_service,
     coach_service,
     context_service,
     prompt_service,
@@ -69,10 +70,14 @@ async def chat(
         ]
     )
 
-    context_block = await context_service.build_context_block(
+    memory_context_block = await context_service.build_context_block(
         db,
         user_id=user_id,
         current_session_id=session_id,
+    )
+    phase_context_block = coach_phase_service.build_phase_context(session_data)
+    context_block = context_service.join_context_blocks(
+        [memory_context_block, phase_context_block]
     )
 
     estimate = ai_usage_service.estimate_coach_request(
@@ -115,6 +120,9 @@ async def chat(
             system_prompt=system_prompt,
             config=prompt_config,
         )
+    visible_response_text, coach_control = coach_phase_service.extract_control_block(
+        response_text
+    )
 
     # ユーザーメッセージを保存
     user_msg_id = str(uuid.uuid4())
@@ -130,13 +138,19 @@ async def chat(
     # アシスタント応答を保存
     assistant_msg_id = str(uuid.uuid4())
     assistant_now = datetime.now(UTC)
+    coach_state = coach_phase_service.apply_control_state(
+        session_data.get("coach_state"),
+        coach_control,
+        now=assistant_now,
+    )
     await messages_ref.document(assistant_msg_id).set(
         {
             "role": "assistant",
-            "content": response_text,
+            "content": visible_response_text,
             "metadata": {
                 "model": settings.claude_model,
                 "prompt_version_id": prompt_version_id,
+                "coach_control": coach_control,
             },
             "created_at": assistant_now,
         }
@@ -150,6 +164,7 @@ async def chat(
             "message_count": next_message_count,
             "last_message_at": assistant_now,
             "updated_at": assistant_now,
+            "coach_state": coach_state,
         }
     )
     summary_session_data = {**session_data, "message_count": next_message_count}
@@ -159,7 +174,7 @@ async def chat(
         messages=[
             *history,
             {"role": "user", "content": body.message},
-            {"role": "assistant", "content": response_text},
+            {"role": "assistant", "content": visible_response_text},
         ],
         diary_context=effective_diary_content,
         prompt_config=prompt_config,
@@ -173,7 +188,7 @@ async def chat(
 
     return {
         "data": CoachData(
-            message=response_text,
+            message=visible_response_text,
             session_id=session_id,
             metadata=CoachMetadata(
                 stage=settings.environment,
@@ -299,10 +314,14 @@ async def chat_stream(
             for doc in history_docs
         ]
     )
-    context_block = await context_service.build_context_block(
+    memory_context_block = await context_service.build_context_block(
         db,
         user_id=user_id,
         current_session_id=session_id,
+    )
+    phase_context_block = coach_phase_service.build_phase_context(session_data)
+    context_block = context_service.join_context_blocks(
+        [memory_context_block, phase_context_block]
     )
     prompt_config, prompt_version_id = await prompt_service.get_active_config(db)
     system_prompt = str(prompt_config["system_prompt"])
@@ -329,6 +348,7 @@ async def chat_stream(
         # SSE 起動メッセージ
         yield f"event: session\ndata: {json.dumps({'session_id': session_id})}\n\n"
         accumulated = ""
+        control_filter = coach_phase_service.ControlBlockStreamFilter()
         try:
 
             async def consume():
@@ -342,7 +362,12 @@ async def chat_stream(
                     config=prompt_config,
                 ):
                     accumulated += chunk
-                    yield chunk
+                    visible_chunk = control_filter.feed(chunk)
+                    if visible_chunk:
+                        yield visible_chunk
+                visible_tail = control_filter.flush()
+                if visible_tail:
+                    yield visible_tail
 
             async for chunk in _with_timeout(
                 consume(), settings.coach_stream_timeout_seconds
@@ -361,16 +386,25 @@ async def chat_stream(
         finally:
             # 完了後に assistant メッセージを保存（部分応答でも残す）
             if accumulated:
+                visible_response_text, coach_control = (
+                    coach_phase_service.extract_control_block(accumulated)
+                )
+                coach_state = coach_phase_service.apply_control_state(
+                    session_data.get("coach_state"),
+                    coach_control,
+                    now=datetime.now(UTC),
+                )
                 assistant_now = datetime.now(UTC)
                 assistant_msg_id = str(uuid.uuid4())
                 await messages_ref.document(assistant_msg_id).set(
                     {
                         "role": "assistant",
-                        "content": accumulated,
+                        "content": visible_response_text,
                         "metadata": {
                             "model": settings.claude_model,
                             "streamed": True,
                             "prompt_version_id": prompt_version_id,
+                            "coach_control": coach_control,
                         },
                         "created_at": assistant_now,
                     }
@@ -382,6 +416,7 @@ async def chat_stream(
                         "message_count": next_message_count,
                         "last_message_at": assistant_now,
                         "updated_at": assistant_now,
+                        "coach_state": coach_state,
                     }
                 )
                 summary_session_data = {
@@ -394,7 +429,7 @@ async def chat_stream(
                     messages=[
                         *history,
                         {"role": "user", "content": body.message},
-                        {"role": "assistant", "content": accumulated},
+                        {"role": "assistant", "content": visible_response_text},
                     ],
                     diary_context=effective_diary_content,
                     prompt_config=prompt_config,

--- a/api/app/services/coach_phase_service.py
+++ b/api/app/services/coach_phase_service.py
@@ -1,0 +1,218 @@
+"""Coach phase state and `<control>` block handling."""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from typing import Any
+
+CONTROL_BLOCK_RE = re.compile(
+    r"<control>\s*(\{.*?\})\s*</control>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+PHASE_ORDER = ["acknowledge", "triage", "space", "naming", "reflection"]
+PHASE_LABELS = {
+    "acknowledge": "1_承認",
+    "triage": "2_トリアージ",
+    "space": "3_余",
+    "naming": "4_命名",
+    "reflection": "5_反映",
+}
+PHASE_ALIASES = {
+    "acknowledge": "acknowledge",
+    "承認": "acknowledge",
+    "1": "acknowledge",
+    "1_承認": "acknowledge",
+    "triage": "triage",
+    "トリアージ": "triage",
+    "2": "triage",
+    "2_トリアージ": "triage",
+    "space": "space",
+    "余": "space",
+    "3": "space",
+    "3_余": "space",
+    "naming": "naming",
+    "命名": "naming",
+    "4": "naming",
+    "4_命名": "naming",
+    "reflection": "reflection",
+    "反映": "reflection",
+    "5": "reflection",
+    "5_反映": "reflection",
+}
+
+PHASE_INSTRUCTIONS = {
+    "acknowledge": (
+        "Phase 1 承認: 2文以内。ユーザーの言葉をそのまま受け、説明や安全宣言はしない。"
+        "受け取れたら phase_complete=true とし、route は triage。"
+    ),
+    "triage": (
+        "Phase 2 トリアージ: 2文以内、質問は1つまで。話題を1つだけ扱い、"
+        "分類や優先順位はユーザーに決めてもらう。タスク化は明示許可がある時だけ。"
+    ),
+    "space": (
+        "Phase 3 余: 2文以内。「なぜ」「いつから」で掘らない。"
+        "残る感覚があれば naming、なければ reflection へ進む。"
+    ),
+    "naming": (
+        "Phase 4 命名: 3文以内。ユーザーの言葉だけを使い、根や名前を静かに置く。"
+        "診断や深読みはしない。"
+    ),
+    "reflection": (
+        "Phase 5 反映: 2文以内、質問しない。今日の言葉を短く返して閉じる。"
+        "必要なら session_end=true。"
+    ),
+}
+
+ACTION_CORE_CHECKLIST = (
+    "action_core: 返答は最大3文。質問は0または1つ。"
+    "評価・助言・診断・安易な安心づけをしない。ユーザーの言葉を鏡のように扱い、"
+    "こちらの解釈を足しすぎない。"
+)
+
+
+def normalize_phase(value: Any) -> str | None:
+    if value is None:
+        return None
+    return PHASE_ALIASES.get(str(value).strip())
+
+
+def normalize_state(raw_state: Any) -> dict[str, Any]:
+    state = raw_state if isinstance(raw_state, dict) else {}
+    phase = normalize_phase(state.get("phase")) or "acknowledge"
+    report = state.get("report") if isinstance(state.get("report"), dict) else {}
+    return {
+        "phase": phase,
+        "phase_label": PHASE_LABELS[phase],
+        "phase_complete": bool(state.get("phase_complete", False)),
+        "route": normalize_phase(state.get("route")),
+        "report": report,
+        "layer8": bool(state.get("layer8", False)),
+        "session_end": bool(state.get("session_end", False)),
+        "last_control": state.get("last_control")
+        if isinstance(state.get("last_control"), dict)
+        else None,
+        "updated_at": state.get("updated_at"),
+    }
+
+
+def build_phase_context(session_data: dict) -> str:
+    state = normalize_state(session_data.get("coach_state"))
+    phase = state["phase"]
+    control_example = {
+        "phase": phase,
+        "phase_complete": False,
+        "route": None,
+        "report": {},
+        "layer8": False,
+        "session_end": False,
+    }
+    return (
+        "【Cycle進行状態】\n"
+        f"現在フェーズ: {state['phase_label']}\n"
+        f"{PHASE_INSTRUCTIONS[phase]}\n"
+        f"{ACTION_CORE_CHECKLIST}\n\n"
+        "【制御出力】\n"
+        "ユーザーに見せる本文の後に、必ず `<control>` JSON を1つだけ付けてください。"
+        "本文と `<control>` の間には空行を置いてください。APIはこの制御情報を保存し、"
+        "ユーザーには本文のみを表示します。\n"
+        f"<control>{json.dumps(control_example, ensure_ascii=False)}</control>"
+    )
+
+
+def extract_control_block(response_text: str) -> tuple[str, dict[str, Any] | None]:
+    """Strip the control block from visible text and return parsed control JSON."""
+    match = CONTROL_BLOCK_RE.search(response_text)
+    control = None
+    if match:
+        try:
+            parsed = json.loads(match.group(1))
+            if isinstance(parsed, dict):
+                control = parsed
+        except json.JSONDecodeError:
+            control = None
+
+    visible_text = CONTROL_BLOCK_RE.sub("", response_text).strip()
+    return visible_text, control
+
+
+def apply_control_state(
+    raw_state: Any,
+    control: dict[str, Any] | None,
+    *,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    state = normalize_state(raw_state)
+    if not control:
+        state["updated_at"] = now or datetime.now(UTC)
+        return state
+
+    control_phase = normalize_phase(control.get("phase"))
+    route = normalize_phase(control.get("route"))
+    phase_complete = bool(control.get("phase_complete", False))
+    next_phase = state["phase"]
+    if phase_complete and route:
+        next_phase = route
+    elif control_phase:
+        next_phase = control_phase
+
+    report = control.get("report") if isinstance(control.get("report"), dict) else {}
+    normalized_control = {
+        "phase": control_phase or state["phase"],
+        "phase_complete": phase_complete,
+        "route": route,
+        "report": report,
+        "layer8": bool(control.get("layer8", False)),
+        "session_end": bool(control.get("session_end", False)),
+    }
+    return {
+        "phase": next_phase,
+        "phase_label": PHASE_LABELS[next_phase],
+        "phase_complete": phase_complete,
+        "route": route,
+        "report": report,
+        "layer8": state["layer8"] or normalized_control["layer8"],
+        "session_end": state["session_end"] or normalized_control["session_end"],
+        "last_control": normalized_control,
+        "updated_at": now or datetime.now(UTC),
+    }
+
+
+class ControlBlockStreamFilter:
+    """Hide a trailing `<control>` block while preserving streamed visible text."""
+
+    _tag = "<control"
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._in_control = False
+
+    def feed(self, chunk: str) -> str:
+        if self._in_control:
+            return ""
+
+        self._buffer += chunk
+        marker = self._buffer.lower().find(self._tag)
+        if marker >= 0:
+            visible = self._buffer[:marker]
+            self._buffer = ""
+            self._in_control = True
+            return visible
+
+        keep = len(self._tag) - 1
+        if len(self._buffer) <= keep:
+            return ""
+
+        visible = self._buffer[:-keep]
+        self._buffer = self._buffer[-keep:]
+        return visible
+
+    def flush(self) -> str:
+        if self._in_control:
+            self._buffer = ""
+            return ""
+        visible = self._buffer
+        self._buffer = ""
+        return visible

--- a/api/app/services/context_service.py
+++ b/api/app/services/context_service.py
@@ -117,6 +117,14 @@ def format_context_block(summaries: list[PastSessionSummary]) -> str | None:
     return "\n".join(lines)
 
 
+def join_context_blocks(blocks: list[str | None]) -> str | None:
+    """Join optional dynamic prompt blocks into one bounded user-side context."""
+    normalized = [block.strip() for block in blocks if block and block.strip()]
+    if not normalized:
+        return None
+    return "\n\n".join(normalized)
+
+
 async def build_context_block(
     db: AsyncClient,
     *,

--- a/api/tests/test_coach.py
+++ b/api/tests/test_coach.py
@@ -1,5 +1,6 @@
 """Coach endpoint tests."""
 
+import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
 
@@ -20,6 +21,10 @@ def test_coach_chat(auth_client, mock_firestore):
             new_callable=AsyncMock,
         ) as build_context,
         patch(
+            "app.routers.coach.coach_phase_service.build_phase_context",
+            return_value="PHASE",
+        ),
+        patch(
             "app.routers.coach.context_service.maybe_update_session_summary",
             new_callable=AsyncMock,
         ) as update_summary,
@@ -32,7 +37,10 @@ def test_coach_chat(auth_client, mock_firestore):
             new_callable=AsyncMock,
         ) as active_config,
     ):
-        mock_chat.return_value = "そう感じたんだね。"
+        mock_chat.return_value = (
+            'そう感じたんだね。\n\n<control>{"phase":"acknowledge",'
+            '"phase_complete":true,"route":"triage","report":{}}</control>'
+        )
         build_context.return_value = "【過去セッション要約】\n- 前回の話"
         active_config.return_value = (
             {
@@ -66,9 +74,77 @@ def test_coach_chat(auth_client, mock_firestore):
     assert mock_chat.call_args.kwargs["system_prompt"] == "system prompt"
     assert (
         mock_chat.call_args.kwargs["context_block"]
-        == "【過去セッション要約】\n- 前回の話"
+        == "【過去セッション要約】\n- 前回の話\n\nPHASE"
     )
     update_summary.assert_awaited_once()
+    assert (
+        update_summary.await_args.kwargs["messages"][-1]["content"]
+        == "そう感じたんだね。"
+    )
+    update_payload = mock_firestore._mock_doc.update.await_args.args[0]
+    assert update_payload["coach_state"]["phase"] == "triage"
     data = response.json()["data"]
     assert data["message"] == "そう感じたんだね。"
     assert "session_id" in data
+
+
+def test_coach_stream_filters_control_block(auth_client, mock_firestore):
+    """SSE should not stream the hidden control block to the client."""
+
+    async def fake_stream(**kwargs):
+        yield "そう"
+        yield "感じたんだね。<con"
+        yield (
+            'trol>{"phase":"acknowledge","phase_complete":true,'
+            '"route":"triage","report":{}}</control>'
+        )
+
+    with (
+        patch(
+            "app.routers.coach.coach_service.chat_stream",
+            return_value=fake_stream(),
+        ),
+        patch(
+            "app.routers.coach.context_service.build_context_block",
+            new_callable=AsyncMock,
+        ) as build_context,
+        patch(
+            "app.routers.coach.coach_phase_service.build_phase_context",
+            return_value="PHASE",
+        ),
+        patch(
+            "app.routers.coach.context_service.maybe_update_session_summary",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "app.routers.coach.ai_usage_service.reserve_monthly_budget",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "app.routers.coach.prompt_service.get_active_config",
+            new_callable=AsyncMock,
+        ) as active_config,
+    ):
+        build_context.return_value = None
+        active_config.return_value = (
+            {
+                "system_prompt": "system prompt",
+                "use_langgraph": False,
+                "use_gemini_fallback": True,
+            },
+            "prompt-v1",
+        )
+        response = auth_client.post("/coach/stream", json={"message": "今日は疲れた"})
+
+    assert response.status_code == 200
+    chunks = []
+    for line in response.text.splitlines():
+        if not line.startswith("data: "):
+            continue
+        data = json.loads(line.removeprefix("data: "))
+        if "chunk" in data:
+            chunks.append(data["chunk"])
+    assert "".join(chunks) == "そう感じたんだね。"
+    assert "<control>" not in response.text
+    update_payload = mock_firestore._mock_doc.update.await_args.args[0]
+    assert update_payload["coach_state"]["phase"] == "triage"

--- a/api/tests/test_coach_phase_service.py
+++ b/api/tests/test_coach_phase_service.py
@@ -1,0 +1,59 @@
+"""Coach phase/control service tests."""
+
+from datetime import UTC, datetime
+
+from app.services import coach_phase_service
+
+
+def test_extract_control_block_strips_visible_text():
+    visible, control = coach_phase_service.extract_control_block(
+        'そう感じたんだね。\n\n<control>{"phase":"acknowledge","phase_complete":true,"route":"triage","report":{}}</control>'
+    )
+
+    assert visible == "そう感じたんだね。"
+    assert control == {
+        "phase": "acknowledge",
+        "phase_complete": True,
+        "route": "triage",
+        "report": {},
+    }
+
+
+def test_apply_control_state_routes_to_next_phase():
+    state = coach_phase_service.apply_control_state(
+        {"phase": "acknowledge"},
+        {"phase": "acknowledge", "phase_complete": True, "route": "triage"},
+        now=datetime(2026, 8, 9, tzinfo=UTC),
+    )
+
+    assert state["phase"] == "triage"
+    assert state["phase_label"] == "2_トリアージ"
+    assert state["last_control"]["route"] == "triage"
+
+
+def test_build_phase_context_contains_current_phase_and_control_contract():
+    context = coach_phase_service.build_phase_context(
+        {"coach_state": {"phase": "space"}}
+    )
+
+    assert "3_余" in context
+    assert "<control>" in context
+    assert "action_core" in context
+
+
+def test_stream_filter_hides_split_control_block():
+    stream_filter = coach_phase_service.ControlBlockStreamFilter()
+    output = []
+    for chunk in [
+        "そう",
+        "感じたんだね。<con",
+        'trol>{"phase":"acknowledge"}</control>',
+    ]:
+        emitted = stream_filter.feed(chunk)
+        if emitted:
+            output.append(emitted)
+    tail = stream_filter.flush()
+    if tail:
+        output.append(tail)
+
+    assert "".join(output) == "そう感じたんだね。"

--- a/api/tests/test_context_service.py
+++ b/api/tests/test_context_service.py
@@ -43,6 +43,10 @@ def test_format_context_block_includes_past_summaries():
     assert "2026-07-25 仕事の疲れについて話した" in block
 
 
+def test_join_context_blocks_skips_empty_parts():
+    assert context_service.join_context_blocks([None, " A ", "", "B"]) == "A\n\nB"
+
+
 @pytest.mark.asyncio
 async def test_get_past_session_summaries_filters_current_and_empty():
     def make_doc(doc_id: str, data: dict) -> MagicMock:


### PR DESCRIPTION
## Summary

- Add `coach_phase_service` for the 5-phase state machine foundation from Prompt_0706.
- Inject the current phase/action-core guidance into the dynamic coach context.
- Parse and strip `<control>{...}</control>` from sync coach responses before returning/saving visible text.
- Persist normalized `coach_state` on the session, including phase transitions and layer8/session_end flags.
- Filter split `<control>` blocks out of SSE chunks so hidden control JSON does not appear in the iOS chat UI.

Further addresses #117.

## Verification

- `uv run ruff check app/routers/coach.py app/services/context_service.py app/services/coach_phase_service.py tests/test_coach.py tests/test_context_service.py tests/test_coach_phase_service.py`
- `uv run pytest tests/test_coach_phase_service.py tests/test_context_service.py tests/test_coach.py tests/test_coach_service.py tests/test_coach_graph.py tests/test_ai_usage_service.py` (32 passed)
- `uv run pytest` (107 passed)

## Notes

- This keeps the phase prompt as dynamic user-side context so the cacheable system prompt prefix remains stable.
- Remaining #117 work: richer 8-layer/static-core prompt modules, dedicated layer8 routing, and admin-managed phase/action-core prompt versioning.
