### PR TITLE
chore: reconcile manual Terraform resources

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -79,3 +79,25 @@ Do the migration before removing the legacy root state from operation.
    terraform -chdir=infra/environments/prod plan
    terraform -chdir=infra/environments/dev plan
    ```
+
+## Manual Resource Reconciliation
+
+Some resources were created manually while release operations were being
+unblocked. Import them into the split state before applying the matching
+Terraform changes:
+
+```bash
+terraform -chdir=infra/environments/shared import \
+  'module.shared.google_secret_manager_secret.app_store_connect["app-store-connect-api-key"]' \
+  'projects/cycle-journal/secrets/app-store-connect-api-key'
+terraform -chdir=infra/environments/shared import \
+  'module.shared.google_secret_manager_secret.app_store_connect["app-store-connect-key-id"]' \
+  'projects/cycle-journal/secrets/app-store-connect-key-id'
+terraform -chdir=infra/environments/shared import \
+  'module.shared.google_secret_manager_secret.app_store_connect["app-store-connect-issuer-id"]' \
+  'projects/cycle-journal/secrets/app-store-connect-issuer-id'
+
+terraform -chdir=infra/environments/prod import \
+  'module.api.google_firestore_index.tasks_by_created_at' \
+  'projects/cycle-journal/databases/(default)/collectionGroups/tasks/indexes/CICAgJim14AK'
+```

--- a/infra/modules/api/main.tf
+++ b/infra/modules/api/main.tf
@@ -45,6 +45,8 @@ resource "google_secret_manager_secret" "apple_iap_private_key" {
 }
 
 resource "google_secret_manager_secret" "apple_apns_private_key" {
+  count = var.apple_apns_key_id == "" ? 0 : 1
+
   secret_id = "apple-apns-private-key-${var.environment}"
   project   = var.project_id
 
@@ -64,7 +66,10 @@ resource "google_secret_manager_secret" "jwt_secret" {
 
 resource "random_password" "jwt_secret" {
   length  = 64
+  lower   = true
+  numeric = true
   special = false
+  upper   = true
 }
 
 resource "google_secret_manager_secret_version" "jwt_secret" {
@@ -85,6 +90,22 @@ resource "google_firestore_index" "sessions_by_created_at" {
   project    = var.project_id
   database   = google_firestore_database.main.name
   collection = "sessions"
+
+  fields {
+    field_path = "user_id"
+    order      = "ASCENDING"
+  }
+
+  fields {
+    field_path = "created_at"
+    order      = "DESCENDING"
+  }
+}
+
+resource "google_firestore_index" "tasks_by_created_at" {
+  project    = var.project_id
+  database   = google_firestore_database.main.name
+  collection = "tasks"
 
   fields {
     field_path = "user_id"
@@ -189,33 +210,45 @@ resource "google_cloud_run_v2_service" "api" {
         }
       }
 
-      env {
-        name  = "APPLE_APNS_TEAM_ID"
-        value = var.apple_team_id
-      }
+      dynamic "env" {
+        for_each = var.apple_apns_key_id == "" ? [] : [1]
 
-      env {
-        name  = "APPLE_APNS_KEY_ID"
-        value = var.apple_apns_key_id
+        content {
+          name  = "APPLE_APNS_TEAM_ID"
+          value = var.apple_team_id
+        }
       }
 
       dynamic "env" {
         for_each = var.apple_apns_key_id == "" ? [] : [1]
 
         content {
+          name  = "APPLE_APNS_KEY_ID"
+          value = var.apple_apns_key_id
+        }
+      }
+
+      dynamic "env" {
+        for_each = var.apple_apns_key_id == "" ? [] : [google_secret_manager_secret.apple_apns_private_key[0].secret_id]
+
+        content {
           name = "APPLE_APNS_PRIVATE_KEY"
           value_source {
             secret_key_ref {
-              secret  = google_secret_manager_secret.apple_apns_private_key.secret_id
+              secret  = env.value
               version = "latest"
             }
           }
         }
       }
 
-      env {
-        name  = "APPLE_APNS_ENV"
-        value = var.apple_apns_env
+      dynamic "env" {
+        for_each = var.apple_apns_key_id == "" ? [] : [1]
+
+        content {
+          name  = "APPLE_APNS_ENV"
+          value = var.apple_apns_env
+        }
       }
 
       env {
@@ -261,6 +294,11 @@ resource "google_cloud_run_v2_service" "api" {
             version = "latest"
           }
         }
+      }
+
+      env {
+        name  = "CLAUDE_MAX_TOKENS"
+        value = tostring(var.claude_max_tokens)
       }
     }
   }

--- a/infra/modules/api/variables.tf
+++ b/infra/modules/api/variables.tf
@@ -53,6 +53,12 @@ variable "use_langgraph" {
   default     = false
 }
 
+variable "claude_max_tokens" {
+  description = "Claude max output tokens for API runtime"
+  type        = number
+  default     = 2000
+}
+
 variable "google_client_id" {
   description = "Google OAuth Client ID for iOS Sign-In"
   type        = string

--- a/infra/modules/shared/main.tf
+++ b/infra/modules/shared/main.tf
@@ -6,6 +6,12 @@ locals {
     "secretmanager.googleapis.com",
     "aiplatform.googleapis.com",
   ])
+
+  app_store_connect_secret_ids = toset([
+    "app-store-connect-api-key",
+    "app-store-connect-key-id",
+    "app-store-connect-issuer-id",
+  ])
 }
 
 resource "google_project_service" "apis" {
@@ -23,4 +29,19 @@ resource "google_artifact_registry_repository" "api" {
   description   = "CycleJournal API Docker images"
 
   depends_on = [google_project_service.apis]
+}
+
+resource "google_secret_manager_secret" "app_store_connect" {
+  for_each = local.app_store_connect_secret_ids
+
+  secret_id = each.key
+  project   = var.project_id
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [
+    google_project_service.apis["secretmanager.googleapis.com"],
+  ]
 }


### PR DESCRIPTION
## Summary

- Add the missing `tasks(user_id, created_at)` Firestore index to the split API module.
- Declare the manually-created App Store Connect Secret Manager secrets in the shared module.
- Add `CLAUDE_MAX_TOKENS=2000` to the API Cloud Run environment definition.
- Skip APNs Secret/env blocks when `apple_apns_key_id` is empty, avoiding unused drift.
- Document the manual-resource import commands in `infra/README.md`.

## State Reconciliation Performed

- Imported `app-store-connect-api-key`, `app-store-connect-key-id`, and `app-store-connect-issuer-id` into `infra/environments/shared` state.
- Imported prod Firestore index `projects/cycle-journal/databases/(default)/collectionGroups/tasks/indexes/CICAgJim14AK` into `infra/environments/prod` state.

## Verification

- `terraform fmt infra/modules/api/main.tf infra/modules/api/variables.tf infra/modules/shared/main.tf`
- `terraform -chdir=infra/environments/shared validate`
- `terraform -chdir=infra/environments/dev validate`
- `terraform -chdir=infra/environments/prod validate`
- `terraform -chdir=infra/environments/shared plan -detailed-exitcode -input=false` -> no changes
- `terraform -chdir=infra/environments/prod plan -detailed-exitcode -input=false` -> no add/destroy; remaining `random_password.jwt_secret` in-place provider/state diff only
- `terraform -chdir=infra/environments/dev plan -detailed-exitcode -input=false` -> expected `CLAUDE_MAX_TOKENS` env addition and `tasks_by_created_at` index creation; no destroy; same `random_password.jwt_secret` provider/state diff

Refs #99
