### PR TITLE
feat: add journal server sync

### DIFF
--- a/api/app/main.py
+++ b/api/app/main.py
@@ -7,7 +7,17 @@ from app.config import settings
 from app.exceptions import AppError, app_error_handler
 from app.logging_config import setup_logging
 from app.middleware.request_id import RequestIdMiddleware
-from app.routers import admin, auth, coach, health, iap, sessions, tasks, users
+from app.routers import (
+    admin,
+    auth,
+    coach,
+    health,
+    iap,
+    journals,
+    sessions,
+    tasks,
+    users,
+)
 
 setup_logging(project_id=settings.gcp_project_id)
 
@@ -34,5 +44,6 @@ app.include_router(admin.router)
 app.include_router(coach.router)
 app.include_router(sessions.router)
 app.include_router(tasks.router)
+app.include_router(journals.router)
 app.include_router(users.router)
 app.include_router(iap.router)

--- a/api/app/models/journal.py
+++ b/api/app/models/journal.py
@@ -1,0 +1,45 @@
+"""Journal sync models."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class JournalSyncItem(BaseModel):
+    journal_id: str = Field(..., min_length=1)
+    text: str = ""
+    tags: list[str] = []
+    entry_date: datetime
+    deleted_at: datetime | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+
+
+class JournalData(BaseModel):
+    journal_id: str
+    text: str = ""
+    tags: list[str] = []
+    entry_date: datetime
+    deleted_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+
+class JournalListData(BaseModel):
+    journals: list[JournalData]
+    total: int
+
+
+class JournalSyncRequest(BaseModel):
+    journals: list[JournalSyncItem] = []
+    deleted_journal_ids: list[str] = []
+    last_pulled_at: datetime | None = None
+
+
+class JournalSyncData(BaseModel):
+    journals: list[JournalData]
+    server_time: datetime
+    pushed_count: int
+    pulled_count: int
+    deleted_count: int
+    conflict_count: int

--- a/api/app/routers/journals.py
+++ b/api/app/routers/journals.py
@@ -1,0 +1,174 @@
+"""Journal endpoints - bidirectional local/server sync."""
+
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Depends
+from google.cloud.firestore import AsyncClient
+
+from app.dependencies import get_current_user, get_firestore
+from app.exceptions import ValidationError
+from app.models.journal import (
+    JournalData,
+    JournalListData,
+    JournalSyncData,
+    JournalSyncItem,
+    JournalSyncRequest,
+)
+from app.services.firestore_client import journals_ref
+
+router = APIRouter(prefix="/journals", tags=["Journals"])
+
+
+@router.get("")
+async def list_journals(
+    include_deleted: bool = False,
+    user_id: str = Depends(get_current_user),
+    db: AsyncClient = Depends(get_firestore),
+):
+    """Return all journals for the authenticated user."""
+    docs = await _load_user_journals(db, user_id)
+    journals = [
+        _doc_to_journal(doc_id, data)
+        for doc_id, data in docs
+        if include_deleted or data.get("deleted_at") is None
+    ]
+    journals.sort(key=lambda item: item.entry_date, reverse=True)
+    return {"data": JournalListData(journals=journals, total=len(journals))}
+
+
+@router.post("/sync")
+async def sync_journals(
+    body: JournalSyncRequest,
+    user_id: str = Depends(get_current_user),
+    db: AsyncClient = Depends(get_firestore),
+):
+    """Push local journals and return server journals changed since last pull.
+
+    Conflict policy: last-write-wins using `updated_at` from each side. Ambiguous
+    old local records use their entry date as the client update timestamp.
+    """
+    now = datetime.now(UTC)
+    ref = journals_ref(db)
+    pushed_count = 0
+    deleted_count = 0
+    conflict_count = 0
+
+    seen_ids: set[str] = set()
+    for item in body.journals:
+        if item.journal_id in seen_ids:
+            raise ValidationError("duplicate journal_id in sync payload")
+        seen_ids.add(item.journal_id)
+
+    for journal_id in body.deleted_journal_ids:
+        if not journal_id:
+            continue
+        doc_ref = ref.document(journal_id)
+        snapshot = await doc_ref.get()
+        if snapshot.exists:
+            data = snapshot.to_dict() or {}
+            if data.get("user_id") != user_id:
+                conflict_count += 1
+                continue
+            await doc_ref.update(
+                {
+                    "text": "",
+                    "tags": [],
+                    "deleted_at": now,
+                    "updated_at": now,
+                }
+            )
+            deleted_count += 1
+
+    for item in body.journals:
+        applied = await _apply_client_journal(ref, user_id, item, now)
+        if applied == "pushed":
+            pushed_count += 1
+        elif applied == "conflict":
+            conflict_count += 1
+
+    docs = await _load_user_journals(db, user_id)
+    journals = []
+    for doc_id, data in docs:
+        updated_at = data.get("updated_at")
+        if body.last_pulled_at is not None and updated_at is not None:
+            if _as_utc(updated_at) <= _as_utc(body.last_pulled_at):
+                continue
+        journals.append(_doc_to_journal(doc_id, data))
+    journals.sort(key=lambda item: item.updated_at, reverse=True)
+
+    return {
+        "data": JournalSyncData(
+            journals=journals,
+            server_time=now,
+            pushed_count=pushed_count,
+            pulled_count=len(journals),
+            deleted_count=deleted_count,
+            conflict_count=conflict_count,
+        )
+    }
+
+
+async def _apply_client_journal(
+    ref,
+    user_id: str,
+    item: JournalSyncItem,
+    now: datetime,
+) -> str:
+    doc_ref = ref.document(item.journal_id)
+    snapshot = await doc_ref.get()
+    client_updated_at = _as_utc(item.updated_at or item.created_at or item.entry_date)
+    created_at = _as_utc(item.created_at or item.entry_date)
+
+    if snapshot.exists:
+        current = snapshot.to_dict() or {}
+        if current.get("user_id") != user_id:
+            return "conflict"
+        server_updated_at = current.get("updated_at") or current.get("created_at")
+        if (
+            server_updated_at is not None
+            and _as_utc(server_updated_at) > client_updated_at
+        ):
+            return "conflict"
+        created_at = _as_utc(current.get("created_at") or created_at)
+
+    await doc_ref.set(
+        {
+            "user_id": user_id,
+            "text": item.text,
+            "tags": item.tags,
+            "entry_date": _as_utc(item.entry_date),
+            "deleted_at": _as_utc(item.deleted_at) if item.deleted_at else None,
+            "created_at": created_at,
+            "updated_at": client_updated_at or now,
+        }
+    )
+    return "pushed"
+
+
+async def _load_user_journals(db: AsyncClient, user_id: str) -> list[tuple[str, dict]]:
+    query = journals_ref(db).where("user_id", "==", user_id)
+    docs: list[tuple[str, dict]] = []
+    async for doc in query.stream():
+        docs.append((doc.id, doc.to_dict() or {}))
+    return docs
+
+
+def _doc_to_journal(journal_id: str, data: dict) -> JournalData:
+    entry_date = data.get("entry_date") or data.get("created_at") or datetime.now(UTC)
+    created_at = data.get("created_at") or entry_date
+    updated_at = data.get("updated_at") or created_at
+    return JournalData(
+        journal_id=journal_id,
+        text=data.get("text") or "",
+        tags=data.get("tags") or [],
+        entry_date=_as_utc(entry_date),
+        deleted_at=_as_utc(data["deleted_at"]) if data.get("deleted_at") else None,
+        created_at=_as_utc(created_at),
+        updated_at=_as_utc(updated_at),
+    )
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)

--- a/api/app/services/firestore_client.py
+++ b/api/app/services/firestore_client.py
@@ -30,6 +30,10 @@ def tasks_ref(db: AsyncClient):
     return db.collection("tasks")
 
 
+def journals_ref(db: AsyncClient):
+    return db.collection("journals")
+
+
 def refresh_tokens_ref(db: AsyncClient):
     return db.collection("refresh_tokens")
 

--- a/api/tests/test_journals.py
+++ b/api/tests/test_journals.py
@@ -1,0 +1,205 @@
+"""Journal sync endpoint tests."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def test_list_journals_requires_auth(client):
+    response = client.get("/journals")
+    assert response.status_code == 401
+
+
+def test_sync_journals_requires_auth(client):
+    response = client.post("/journals/sync", json={"journals": []})
+    assert response.status_code == 401
+
+
+def test_sync_pushes_local_journal(journal_client_factory):
+    client, db = journal_client_factory()
+
+    response = client.post(
+        "/journals/sync",
+        json={
+            "journals": [
+                {
+                    "journal_id": "journal-1",
+                    "text": "今日の記録",
+                    "tags": ["daily"],
+                    "entry_date": "2026-08-01T10:00:00Z",
+                    "updated_at": "2026-08-01T10:05:00Z",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["pushed_count"] == 1
+    assert data["conflict_count"] == 0
+    assert data["journals"][0]["journal_id"] == "journal-1"
+    assert db.store["journal-1"]["user_id"] == "test-user-123"
+    assert db.store["journal-1"]["text"] == "今日の記録"
+
+
+def test_sync_keeps_server_journal_when_server_is_newer(journal_client_factory):
+    client, db = journal_client_factory(
+        {
+            "journal-1": {
+                "user_id": "test-user-123",
+                "text": "server",
+                "tags": [],
+                "entry_date": _dt(2026, 8, 1, 10, 0),
+                "created_at": _dt(2026, 8, 1, 10, 0),
+                "updated_at": _dt(2026, 8, 2, 10, 0),
+                "deleted_at": None,
+            }
+        }
+    )
+
+    response = client.post(
+        "/journals/sync",
+        json={
+            "journals": [
+                {
+                    "journal_id": "journal-1",
+                    "text": "client",
+                    "tags": [],
+                    "entry_date": "2026-08-01T10:00:00Z",
+                    "updated_at": "2026-08-01T10:30:00Z",
+                }
+            ]
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["pushed_count"] == 0
+    assert data["conflict_count"] == 1
+    assert db.store["journal-1"]["text"] == "server"
+    assert data["journals"][0]["text"] == "server"
+
+
+def test_sync_marks_deleted_journal_as_tombstone(journal_client_factory):
+    client, db = journal_client_factory(
+        {
+            "journal-1": {
+                "user_id": "test-user-123",
+                "text": "remove me",
+                "tags": ["old"],
+                "entry_date": _dt(2026, 8, 1, 10, 0),
+                "created_at": _dt(2026, 8, 1, 10, 0),
+                "updated_at": _dt(2026, 8, 1, 10, 0),
+                "deleted_at": None,
+            }
+        }
+    )
+
+    response = client.post(
+        "/journals/sync",
+        json={"journals": [], "deleted_journal_ids": ["journal-1"]},
+    )
+
+    assert response.status_code == 200
+    data = response.json()["data"]
+    assert data["deleted_count"] == 1
+    assert db.store["journal-1"]["text"] == ""
+    assert db.store["journal-1"]["tags"] == []
+    assert db.store["journal-1"]["deleted_at"] is not None
+
+
+@pytest.fixture
+def journal_client_factory():
+    clients: list[TestClient] = []
+
+    def make(initial: dict[str, dict[str, Any]] | None = None):
+        client, db = _client_with_store(initial or {})
+        clients.append(client)
+        return client, db
+
+    yield make
+
+    if clients:
+        clients[-1].app.dependency_overrides.clear()
+
+
+def _client_with_store(initial: dict[str, dict[str, Any]]):
+    from app.dependencies import get_current_user, get_firestore
+    from app.main import app
+
+    db = _FakeFirestore(initial)
+    app.dependency_overrides[get_firestore] = lambda: db
+    app.dependency_overrides[get_current_user] = lambda: "test-user-123"
+    return TestClient(app), db
+
+
+def _dt(year: int, month: int, day: int, hour: int, minute: int) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+class _FakeFirestore:
+    def __init__(self, initial: dict[str, dict[str, Any]]):
+        self.store = dict(initial)
+
+    def collection(self, name: str):
+        assert name == "journals"
+        return _FakeCollection(self.store)
+
+
+class _FakeCollection:
+    def __init__(self, store: dict[str, dict[str, Any]]):
+        self.store = store
+
+    def document(self, doc_id: str):
+        return _FakeDocument(self.store, doc_id)
+
+    def where(self, field: str, op: str, value: Any):
+        return _FakeQuery(self.store, field, op, value)
+
+
+class _FakeDocument:
+    def __init__(self, store: dict[str, dict[str, Any]], doc_id: str):
+        self.store = store
+        self.id = doc_id
+
+    async def get(self):
+        return _FakeSnapshot(self.id, self.store.get(self.id))
+
+    async def set(self, data: dict[str, Any]):
+        self.store[self.id] = dict(data)
+
+    async def update(self, data: dict[str, Any]):
+        self.store[self.id].update(data)
+
+
+class _FakeSnapshot:
+    def __init__(self, doc_id: str, data: dict[str, Any] | None):
+        self.id = doc_id
+        self._data = data
+        self.exists = data is not None
+
+    def to_dict(self):
+        return dict(self._data or {})
+
+
+class _FakeQuery:
+    def __init__(
+        self,
+        store: dict[str, dict[str, Any]],
+        field: str,
+        op: str,
+        value: Any,
+    ):
+        self.store = store
+        self.field = field
+        self.op = op
+        self.value = value
+
+    async def stream(self):
+        for doc_id, data in self.store.items():
+            if self.op == "==" and data.get(self.field) == self.value:
+                yield _FakeSnapshot(doc_id, data)

--- a/ios/Cycle/App/ContentView.swift
+++ b/ios/Cycle/App/ContentView.swift
@@ -42,6 +42,9 @@ struct ContentView: View {
     @ViewBuilder
     private var authenticatedContent: some View {
         mainContent
+            .task {
+                await journalViewModel.syncWithServer()
+            }
     }
 
     private var splashView: some View {

--- a/ios/Cycle/Features/Journal/Model/JournalEntry.swift
+++ b/ios/Cycle/Features/Journal/Model/JournalEntry.swift
@@ -28,4 +28,15 @@ struct JournalEntry: Identifiable, Codable, Hashable {
 
     /// 削除日時（論理削除用）
     var deletedAt: Date?
+
+    /// 最終更新日時（サーバー同期の last-write-wins 判定用）
+    var updatedAt: Date?
+
+    var syncUpdatedAt: Date {
+        updatedAt ?? deletedAt ?? date
+    }
+
+    mutating func touch(_ now: Date = Date()) {
+        updatedAt = now
+    }
 }

--- a/ios/Cycle/Features/Journal/Store/JournalStore.swift
+++ b/ios/Cycle/Features/Journal/Store/JournalStore.swift
@@ -13,6 +13,8 @@ import Foundation
 /// ローカルストレージに保存・読み込み
 enum JournalStore {
     private static let file = "journals.json"
+    private static let lastSyncedAtKey = "journalLastSyncedAt"
+    private static let pendingDeletedIDsKey = "journalPendingDeletedIDs"
 
     /// 全てのジャーナルエントリを読み込み
     /// - Returns: 保存されているエントリの配列（失敗時は空配列）
@@ -24,5 +26,33 @@ enum JournalStore {
     /// - Parameter items: 保存するエントリの配列
     static func saveAll(_ items: [JournalEntry]) {
         JSONFileStore.save(items, to: file)
+    }
+
+    static func loadLastSyncedAt() -> Date? {
+        UserDefaults.standard.object(forKey: lastSyncedAtKey) as? Date
+    }
+
+    static func saveLastSyncedAt(_ date: Date?) {
+        if let date {
+            UserDefaults.standard.set(date, forKey: lastSyncedAtKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: lastSyncedAtKey)
+        }
+    }
+
+    static func loadPendingDeletedEntryIDs() -> [UUID] {
+        let ids = UserDefaults.standard.stringArray(forKey: pendingDeletedIDsKey) ?? []
+        return ids.compactMap(UUID.init(uuidString:))
+    }
+
+    static func addPendingDeletedEntryID(_ id: UUID) {
+        var ids = loadPendingDeletedEntryIDs()
+        guard !ids.contains(id) else { return }
+        ids.append(id)
+        savePendingDeletedEntryIDs(ids)
+    }
+
+    static func savePendingDeletedEntryIDs(_ ids: [UUID]) {
+        UserDefaults.standard.set(ids.map(\.uuidString), forKey: pendingDeletedIDsKey)
     }
 }

--- a/ios/Cycle/Features/Journal/ViewModel/JournalViewModel.swift
+++ b/ios/Cycle/Features/Journal/ViewModel/JournalViewModel.swift
@@ -45,11 +45,33 @@ final class JournalViewModel: ObservableObject {
     /// 検索画面のタブ選択（0: 検索, 1: 全て）
     @Published var searchViewTab: Int = 0
 
+    /// サーバー同期中かどうか
+    @Published private(set) var isSyncing: Bool = false
+
+    /// サーバー同期エラー。オフライン時はセットしない。
+    @Published private(set) var syncError: String?
+
+    private let journalService: JournalSyncing
+    private var cancellables = Set<AnyCancellable>()
+    private var syncTask: Task<Void, Never>?
+
     // MARK: - Initialization
 
-    init() {
+    init(
+        journalService: JournalSyncing = JournalService(),
+        networkMonitor: NetworkMonitor = .shared
+    ) {
+        self.journalService = journalService
         entries = JournalStore.loadAll()
         availableTags = loadAvailableTags()
+
+        networkMonitor.$isConnected
+            .removeDuplicates()
+            .filter { $0 }
+            .sink { [weak self] _ in
+                self?.scheduleSync()
+            }
+            .store(in: &cancellables)
     }
 
     /// データをリロード（外部からのデータ変更後に呼ぶ）
@@ -147,7 +169,7 @@ final class JournalViewModel: ObservableObject {
     /// 新しいエントリを追加
     func addEntry(text: String, tags: [String] = []) {
         guard let trimmedText = trimText(text), !trimmedText.isEmpty else { return }
-        entries.append(.init(text: trimmedText, tags: tags))
+        entries.append(.init(text: trimmedText, tags: tags, updatedAt: Date()))
         persist()
     }
 
@@ -156,6 +178,7 @@ final class JournalViewModel: ObservableObject {
         guard let index = findEntryIndex(entry) else { return }
         entries[index].text = newText
         entries[index].tags = newTags
+        entries[index].touch()
         persist()
     }
 
@@ -163,6 +186,7 @@ final class JournalViewModel: ObservableObject {
     func deleteEntry(_ entry: JournalEntry) {
         guard let index = findEntryIndex(entry) else { return }
         entries[index].deletedAt = Date()
+        entries[index].touch()
         persist()
     }
 
@@ -170,13 +194,43 @@ final class JournalViewModel: ObservableObject {
     func restoreEntry(_ entry: JournalEntry) {
         guard let index = findEntryIndex(entry) else { return }
         entries[index].deletedAt = nil
+        entries[index].touch()
         persist()
     }
 
     /// エントリを完全に削除（物理削除）
     func permanentlyDeleteEntry(_ entry: JournalEntry) {
+        JournalStore.addPendingDeletedEntryID(entry.id)
         entries.removeAll { $0.id == entry.id }
         persist()
+    }
+
+    // MARK: - Server Sync
+
+    func syncWithServer() async {
+        guard APIClient.shared.getAuthToken() != nil else { return }
+        guard !isSyncing else { return }
+
+        isSyncing = true
+        defer { isSyncing = false }
+
+        let pendingDeletedIDs = JournalStore.loadPendingDeletedEntryIDs()
+        do {
+            let response = try await journalService.sync(
+                entries: entries,
+                deletedEntryIds: pendingDeletedIDs,
+                lastPulledAt: JournalStore.loadLastSyncedAt()
+            )
+            mergeServerEntries(response.journals, ignoring: Set(pendingDeletedIDs))
+            JournalStore.savePendingDeletedEntryIDs([])
+            JournalStore.saveLastSyncedAt(response.serverTime)
+            syncError = nil
+            persist(sync: false)
+        } catch let error as APIError where error.isRetryable {
+            syncError = nil
+        } catch {
+            syncError = error.localizedDescription
+        }
     }
 
     // MARK: - Tag Management
@@ -320,8 +374,38 @@ final class JournalViewModel: ObservableObject {
     // MARK: - Private Helpers - Persistence
 
     /// エントリをストレージに保存
-    private func persist() {
+    private func persist(sync: Bool = true) {
         JournalStore.saveAll(entries)
+        if sync {
+            scheduleSync()
+        }
+    }
+
+    private func scheduleSync() {
+        guard APIClient.shared.getAuthToken() != nil else { return }
+        syncTask?.cancel()
+        syncTask = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            await self?.syncWithServer()
+        }
+    }
+
+    private func mergeServerEntries(_ journals: [JournalData], ignoring ignoredIDs: Set<UUID>) {
+        for journal in journals {
+            let remote = JournalEntry(apiData: journal)
+            if ignoredIDs.contains(remote.id) {
+                entries.removeAll { $0.id == remote.id }
+                continue
+            }
+
+            if let index = entries.firstIndex(where: { $0.id == remote.id }) {
+                if remote.syncUpdatedAt >= entries[index].syncUpdatedAt {
+                    entries[index] = remote
+                }
+            } else {
+                entries.append(remote)
+            }
+        }
     }
 
     /// UserDefaultsから利用可能なタグを読み込み

--- a/ios/Cycle/Services/APIModels.swift
+++ b/ios/Cycle/Services/APIModels.swift
@@ -133,6 +133,48 @@ struct ReflectionData: Decodable {
     let createdAt: Date
 }
 
+// MARK: - Journal API Models
+
+struct JournalSyncItem: Codable {
+    let journalId: String
+    let text: String
+    let tags: [String]
+    let entryDate: Date
+    let deletedAt: Date?
+    let createdAt: Date?
+    let updatedAt: Date?
+}
+
+struct JournalSyncRequest: Encodable {
+    let journals: [JournalSyncItem]
+    let deletedJournalIds: [String]
+    let lastPulledAt: Date?
+}
+
+struct JournalData: Decodable {
+    let journalId: String
+    let text: String
+    let tags: [String]
+    let entryDate: Date
+    let deletedAt: Date?
+    let createdAt: Date
+    let updatedAt: Date
+}
+
+struct JournalListData: Decodable {
+    let journals: [JournalData]
+    let total: Int
+}
+
+struct JournalSyncData: Decodable {
+    let journals: [JournalData]
+    let serverTime: Date
+    let pushedCount: Int
+    let pulledCount: Int
+    let deletedCount: Int
+    let conflictCount: Int
+}
+
 // MARK: - User API Models
 
 struct UserData: Decodable {

--- a/ios/Cycle/Services/JournalService.swift
+++ b/ios/Cycle/Services/JournalService.swift
@@ -1,0 +1,60 @@
+//
+//  JournalService.swift
+//  CycleJournal
+//
+
+import Foundation
+
+protocol JournalSyncing {
+    func sync(
+        entries: [JournalEntry],
+        deletedEntryIds: [UUID],
+        lastPulledAt: Date?
+    ) async throws -> JournalSyncData
+}
+
+class JournalService: JournalSyncing {
+    private let apiClient = APIClient.shared
+
+    func sync(
+        entries: [JournalEntry],
+        deletedEntryIds: [UUID],
+        lastPulledAt: Date?
+    ) async throws -> JournalSyncData {
+        let request = JournalSyncRequest(
+            journals: entries.map(JournalSyncItem.init(entry:)),
+            deletedJournalIds: deletedEntryIds.map(\.uuidString),
+            lastPulledAt: lastPulledAt
+        )
+
+        let response: APIResponse<JournalSyncData> = try await apiClient.post(
+            path: "/journals/sync",
+            body: request,
+            requiresAuth: true
+        )
+        return response.data
+    }
+}
+
+extension JournalSyncItem {
+    init(entry: JournalEntry) {
+        journalId = entry.id.uuidString
+        text = entry.text
+        tags = entry.tags
+        entryDate = entry.date
+        deletedAt = entry.deletedAt
+        createdAt = entry.date
+        updatedAt = entry.updatedAt ?? entry.syncUpdatedAt
+    }
+}
+
+extension JournalEntry {
+    init(apiData: JournalData) {
+        id = UUID(uuidString: apiData.journalId) ?? UUID()
+        date = apiData.entryDate
+        text = apiData.text
+        tags = apiData.tags
+        deletedAt = apiData.deletedAt
+        updatedAt = apiData.updatedAt
+    }
+}

--- a/ios/CycleTests/CycleTests.swift
+++ b/ios/CycleTests/CycleTests.swift
@@ -40,6 +40,12 @@ struct JournalEntryTests {
         #expect(decoded.tags == ["タグ1"])
         #expect(decoded.id == entry.id)
     }
+
+    @Test func syncUpdatedAtFallsBackToDate() {
+        let date = Date(timeIntervalSince1970: 100)
+        let entry = JournalEntry(date: date, text: "同期")
+        #expect(entry.syncUpdatedAt == date)
+    }
 }
 
 // MARK: - JournalViewModel Tests
@@ -94,6 +100,15 @@ struct JournalViewModelTests {
         #expect(updated?.tags == ["更新"])
     }
 
+    @Test func updateEntryTouchesUpdatedAt() {
+        let vm = JournalViewModel()
+        vm.addEntry(text: "元のテキスト")
+        guard let entry = vm.entries.last else { return }
+        vm.updateEntry(entry, newText: "更新後テキスト", newTags: [])
+        let updated = vm.entries.first { $0.id == entry.id }
+        #expect(updated?.updatedAt != nil)
+    }
+
     @Test func deleteEntry() {
         let vm = JournalViewModel()
         vm.addEntry(text: "削除対象")
@@ -120,6 +135,53 @@ struct JournalViewModelTests {
         let id = entry.id
         vm.permanentlyDeleteEntry(entry)
         #expect(vm.entries.contains { $0.id == id } == false)
+    }
+
+    @Test func permanentlyDeleteQueuesPendingSyncDelete() {
+        JournalStore.savePendingDeletedEntryIDs([])
+        let vm = JournalViewModel()
+        vm.addEntry(text: "同期削除対象")
+        guard let entry = vm.entries.last else { return }
+        vm.permanentlyDeleteEntry(entry)
+        #expect(JournalStore.loadPendingDeletedEntryIDs().contains(entry.id))
+        JournalStore.savePendingDeletedEntryIDs([])
+    }
+
+    @Test func syncWithServerAddsRemoteEntry() async {
+        JournalStore.savePendingDeletedEntryIDs([])
+        let id = UUID()
+        let entryDate = Date(timeIntervalSince1970: 100)
+        let updatedAt = Date(timeIntervalSince1970: 200)
+        let remote = JournalData(
+            journalId: id.uuidString,
+            text: "remote",
+            tags: ["server"],
+            entryDate: entryDate,
+            deletedAt: nil,
+            createdAt: entryDate,
+            updatedAt: updatedAt
+        )
+        let vm = JournalViewModel(
+            journalService: MockJournalSyncer(
+                response: JournalSyncData(
+                    journals: [remote],
+                    serverTime: updatedAt,
+                    pushedCount: 0,
+                    pulledCount: 1,
+                    deletedCount: 0,
+                    conflictCount: 0
+                )
+            )
+        )
+
+        APIClient.shared.setAuthToken("test-token")
+        defer { APIClient.shared.setAuthToken(nil) }
+
+        await vm.syncWithServer()
+
+        let synced = vm.entries.first { $0.id == id }
+        #expect(synced?.text == "remote")
+        #expect(synced?.tags == ["server"])
     }
 
     @Test func deletedEntriesNotInAllEntries() {
@@ -193,6 +255,22 @@ struct JournalViewModelTests {
         let targetDate = Calendar.current.date(byAdding: .day, value: -14, to: Date())!
         vm.jumpToDate(targetDate)
         #expect(Calendar.current.isDate(vm.selectedDate, inSameDayAs: targetDate))
+    }
+}
+
+private final class MockJournalSyncer: JournalSyncing {
+    let response: JournalSyncData
+
+    init(response: JournalSyncData) {
+        self.response = response
+    }
+
+    func sync(
+        entries: [JournalEntry],
+        deletedEntryIds: [UUID],
+        lastPulledAt: Date?
+    ) async throws -> JournalSyncData {
+        response
     }
 }
 


### PR DESCRIPTION
## Summary

- Add authenticated backend journal sync endpoints:
  - `GET /journals`
  - `POST /journals/sync`
- Store journals in Firestore `journals` with `user_id`, `entry_date`, `deleted_at`, `created_at`, and `updated_at`.
- Implement last-write-wins conflict handling based on `updated_at`.
- Add iOS `JournalService` and sync DTOs.
- Add `updatedAt` to local `JournalEntry` for conflict resolution.
- Queue physical local deletes in `JournalStore` so they are sent on the next successful sync.
- Trigger sync after local journal changes, on authenticated content load, and when network connectivity returns.

## Verification

- `uv run ruff check .` -> passed
- `uv run pytest` -> 112 passed
- `xcodebuild build -project ios/Cycle.xcodeproj -scheme Cycle -destination 'platform=iOS Simulator,name=iPhone 17'` -> passed
- `xcodebuild test ... -only-testing:CycleTests/JournalEntryTests -only-testing:CycleTests/JournalViewModelTests` -> new sync tests passed; existing `JournalViewModelTests.renameTag` still fails due UserDefaults tag-state leakage, which was already observed before this PR

## Notes

- This uses the app's current authenticated API/Firestore model. End-to-end encryption is not added in this PR.
- Deleted journals are synced as tombstones so other devices can remove/restore state consistently; physical local deletes are not reintroduced after sync.

Closes #25
