### PR TITLE
feat: write coach triage items to tasks

### DIFF
--- a/api/app/routers/coach.py
+++ b/api/app/routers/coach.py
@@ -5,6 +5,7 @@ import json
 import logging
 import uuid
 from datetime import UTC, datetime
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.responses import StreamingResponse
@@ -21,7 +22,7 @@ from app.services import (
     prompt_service,
 )
 from app.services.coach_graph import run_coach_flow
-from app.services.firestore_client import sessions_ref
+from app.services.firestore_client import sessions_ref, tasks_ref
 
 router = APIRouter(tags=["Coach"])
 logger = logging.getLogger("app.coach")
@@ -176,6 +177,28 @@ async def chat(
         coach_control,
         now=assistant_now,
     )
+    created_task_id = await _maybe_create_triage_task(
+        db=db,
+        user_id=user_id,
+        session_id=session_id,
+        session_data=session_data,
+        coach_control=coach_control,
+        cycle_element=body.context.cycle_element.value
+        if body.context and body.context.cycle_element
+        else None,
+        now=assistant_now,
+    )
+    if created_task_id:
+        candidate = coach_phase_service.task_write_candidate(
+            session_data.get("coach_state"),
+            coach_control,
+        )
+        if candidate:
+            coach_state = coach_phase_service.attach_task_to_state(
+                coach_state,
+                item_text=candidate["title"],
+                task_id=created_task_id,
+            )
     await messages_ref.document(assistant_msg_id).set(
         {
             "role": "assistant",
@@ -184,6 +207,7 @@ async def chat(
                 "model": settings.claude_model,
                 "prompt_version_id": prompt_version_id,
                 "coach_control": coach_control,
+                "created_task_id": created_task_id,
             },
             "created_at": assistant_now,
         }
@@ -370,6 +394,41 @@ async def _persist_fixed_coach_response(
     )
 
 
+async def _maybe_create_triage_task(
+    *,
+    db: AsyncClient,
+    user_id: str,
+    session_id: str,
+    session_data: dict,
+    coach_control: dict[str, Any] | None,
+    cycle_element: str | None,
+    now: datetime,
+) -> str | None:
+    candidate = coach_phase_service.task_write_candidate(
+        session_data.get("coach_state"),
+        coach_control,
+    )
+    if not candidate:
+        return None
+
+    task_id = str(uuid.uuid4())
+    task_data = {
+        "user_id": user_id,
+        "title": candidate["title"],
+        "description": None,
+        "status": "pending",
+        "session_id": session_id,
+        "cycle_element": cycle_element,
+        "due_date": None,
+        "completed_at": None,
+        "source": "coach_triage",
+        "created_at": now,
+        "updated_at": now,
+    }
+    await tasks_ref(db).document(task_id).set(task_data)
+    return task_id
+
+
 @router.post("/coach/stream")
 async def chat_stream(
     body: CoachRequest,
@@ -507,6 +566,28 @@ async def chat_stream(
                     now=datetime.now(UTC),
                 )
                 assistant_now = datetime.now(UTC)
+                created_task_id = await _maybe_create_triage_task(
+                    db=db,
+                    user_id=user_id,
+                    session_id=session_id,
+                    session_data=session_data,
+                    coach_control=coach_control,
+                    cycle_element=body.context.cycle_element.value
+                    if body.context and body.context.cycle_element
+                    else None,
+                    now=assistant_now,
+                )
+                if created_task_id:
+                    candidate = coach_phase_service.task_write_candidate(
+                        session_data.get("coach_state"),
+                        coach_control,
+                    )
+                    if candidate:
+                        coach_state = coach_phase_service.attach_task_to_state(
+                            coach_state,
+                            item_text=candidate["title"],
+                            task_id=created_task_id,
+                        )
                 assistant_msg_id = str(uuid.uuid4())
                 await messages_ref.document(assistant_msg_id).set(
                     {
@@ -517,6 +598,7 @@ async def chat_stream(
                             "streamed": True,
                             "prompt_version_id": prompt_version_id,
                             "coach_control": coach_control,
+                            "created_task_id": created_task_id,
                         },
                         "created_at": assistant_now,
                     }

--- a/api/app/services/coach_phase_service.py
+++ b/api/app/services/coach_phase_service.py
@@ -68,6 +68,7 @@ def _safe_items(value: Any) -> list[dict[str, Any]]:
                     "text": str(item.get("text")),
                     "status": item.get("status"),
                     "task_permission": bool(item.get("task_permission", False)),
+                    "task_id": item.get("task_id"),
                 }
             )
     return items
@@ -261,14 +262,72 @@ def _apply_report_items(
     if not item_text or placement not in {"片づく", "残る"}:
         return current_items
 
+    existing_task_id = next(
+        (
+            item.get("task_id")
+            for item in current_items
+            if item.get("text") == str(item_text) and item.get("task_id")
+        ),
+        None,
+    )
     next_item = {
         "text": str(item_text),
         "status": placement,
         "task_permission": bool(report.get("task_permission", False)),
+        "task_id": existing_task_id,
     }
     items = [item for item in current_items if item.get("text") != next_item["text"]]
     items.append(next_item)
     return items
+
+
+def task_write_candidate(
+    raw_state: Any,
+    control: dict[str, Any] | None,
+) -> dict[str, str] | None:
+    if not control:
+        return None
+    report = control.get("report") if isinstance(control.get("report"), dict) else {}
+    item_text = str(report.get("item") or "").strip()
+    if not item_text:
+        return None
+    if report.get("placement") != "片づく" or not bool(
+        report.get("task_permission", False)
+    ):
+        return None
+
+    state = normalize_state(raw_state)
+    for item in state["items"]:
+        if item.get("text") == item_text and item.get("task_id"):
+            return None
+    return {"title": item_text}
+
+
+def attach_task_to_state(
+    raw_state: Any,
+    *,
+    item_text: str,
+    task_id: str,
+) -> dict[str, Any]:
+    state = normalize_state(raw_state)
+    items = []
+    found = False
+    for item in state["items"]:
+        if item.get("text") == item_text:
+            item = {**item, "task_id": task_id}
+            found = True
+        items.append(item)
+    if not found:
+        items.append(
+            {
+                "text": item_text,
+                "status": "片づく",
+                "task_permission": True,
+                "task_id": task_id,
+            }
+        )
+    state["items"] = items
+    return state
 
 
 def detect_boundary_route(message: str) -> dict[str, str] | None:

--- a/api/tests/test_coach.py
+++ b/api/tests/test_coach.py
@@ -137,6 +137,71 @@ def test_coach_boundary_route_skips_model_call(auth_client, mock_firestore):
     assert update_payload["coach_state"]["layer8"] is True
 
 
+def test_coach_creates_task_from_permitted_triage_report(
+    auth_client,
+    mock_firestore,
+):
+    task_doc = MagicMock()
+    task_doc.set = AsyncMock()
+    task_collection = MagicMock()
+    task_collection.document.return_value = task_doc
+
+    with (
+        patch(
+            "app.routers.coach.coach_service.chat",
+            new_callable=AsyncMock,
+        ) as mock_chat,
+        patch(
+            "app.routers.coach.context_service.build_context_block",
+            new_callable=AsyncMock,
+        ) as build_context,
+        patch(
+            "app.routers.coach.coach_phase_service.build_phase_context",
+            return_value="PHASE",
+        ),
+        patch(
+            "app.routers.coach.context_service.maybe_update_session_summary",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "app.routers.coach.ai_usage_service.reserve_monthly_budget",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "app.routers.coach.prompt_service.get_active_config",
+            new_callable=AsyncMock,
+        ) as active_config,
+        patch("app.routers.coach.tasks_ref", return_value=task_collection),
+    ):
+        mock_chat.return_value = (
+            '請求書を置きました。\n\n<control>{"phase":"triage",'
+            '"phase_complete":false,"route":null,'
+            '"report":{"item":"請求書","placement":"片づく",'
+            '"task_permission":true}}</control>'
+        )
+        build_context.return_value = None
+        active_config.return_value = (
+            {
+                "system_prompt": "system prompt",
+                "use_langgraph": False,
+                "use_gemini_fallback": True,
+            },
+            "prompt-v1",
+        )
+
+        response = auth_client.post("/coach", json={"message": "請求書は片づく"})
+
+    assert response.status_code == 200
+    task_doc.set.assert_awaited_once()
+    task_payload = task_doc.set.await_args.args[0]
+    assert task_payload["title"] == "請求書"
+    assert task_payload["status"] == "pending"
+    assert task_payload["source"] == "coach_triage"
+    assert task_payload["session_id"] == response.json()["data"]["session_id"]
+    update_payload = mock_firestore._mock_doc.update.await_args.args[0]
+    assert update_payload["coach_state"]["items"][0]["task_id"]
+
+
 def test_coach_stream_filters_control_block(auth_client, mock_firestore):
     """SSE should not stream the hidden control block to the client."""
 

--- a/api/tests/test_coach_phase_service.py
+++ b/api/tests/test_coach_phase_service.py
@@ -63,8 +63,86 @@ def test_apply_control_state_stores_reported_session_material():
     )
 
     assert state["items"] == [
-        {"text": "請求書", "status": "片づく", "task_permission": True}
+        {
+            "text": "請求書",
+            "status": "片づく",
+            "task_permission": True,
+            "task_id": None,
+        }
     ]
+
+
+def test_task_write_candidate_requires_done_placement_and_permission():
+    candidate = coach_phase_service.task_write_candidate(
+        {"phase": "triage"},
+        {
+            "phase": "triage",
+            "report": {
+                "item": "請求書",
+                "placement": "片づく",
+                "task_permission": True,
+            },
+        },
+    )
+    denied = coach_phase_service.task_write_candidate(
+        {"phase": "triage"},
+        {
+            "phase": "triage",
+            "report": {
+                "item": "母のこと",
+                "placement": "残る",
+                "task_permission": True,
+            },
+        },
+    )
+
+    assert candidate == {"title": "請求書"}
+    assert denied is None
+
+
+def test_task_write_candidate_skips_existing_task_id():
+    candidate = coach_phase_service.task_write_candidate(
+        {
+            "phase": "triage",
+            "items": [
+                {
+                    "text": "請求書",
+                    "status": "片づく",
+                    "task_permission": True,
+                    "task_id": "task-1",
+                }
+            ],
+        },
+        {
+            "phase": "triage",
+            "report": {
+                "item": "請求書",
+                "placement": "片づく",
+                "task_permission": True,
+            },
+        },
+    )
+
+    assert candidate is None
+
+
+def test_attach_task_to_state_links_item():
+    state = coach_phase_service.attach_task_to_state(
+        {
+            "phase": "triage",
+            "items": [
+                {
+                    "text": "請求書",
+                    "status": "片づく",
+                    "task_permission": True,
+                }
+            ],
+        },
+        item_text="請求書",
+        task_id="task-1",
+    )
+
+    assert state["items"][0]["task_id"] == "task-1"
 
 
 def test_build_phase_context_contains_current_phase_and_control_contract():


### PR DESCRIPTION
## Summary
- Create a pending task when coach control reports a triage item as 片づく with task_permission:true
- Attach the created task_id back to coach_state so the same item is not recreated
- Apply the same write-out path for both /coach and /coach/stream

## Verification
- uv run ruff check .
- uv run pytest tests/test_coach.py tests/test_coach_phase_service.py
- uv run pytest

Refs #117