### PR TITLE
feat: lint coach responses before saving

### DIFF
--- a/api/app/routers/coach.py
+++ b/api/app/routers/coach.py
@@ -17,6 +17,7 @@ from app.models.coach import CoachData, CoachMetadata, CoachRequest
 from app.services import (
     ai_usage_service,
     coach_phase_service,
+    coach_response_lint,
     coach_service,
     context_service,
     prompt_service,
@@ -129,34 +130,53 @@ async def chat(
 
     system_prompt = str(prompt_config["system_prompt"])
 
-    # コーチ応答を取得（LangGraph or シンプル呼び出し）
-    detected_emotion = None
-    response_cycle_element = None
-
-    if bool(prompt_config.get("use_langgraph")):
-        flow_result = await run_coach_flow(
-            user_message=body.message,
-            history=history,
-            diary_content=effective_diary_content,
-            context_block=context_block,
-            system_prompt=system_prompt,
-            config=prompt_config,
-        )
-        response_text = flow_result["response"]
-        detected_emotion = flow_result.get("detected_emotion")
-        response_cycle_element = flow_result.get("cycle_element")
-    else:
-        response_text = await coach_service.chat(
-            user_message=body.message,
-            history=history,
-            diary_content=effective_diary_content,
-            context_block=context_block,
-            system_prompt=system_prompt,
-            config=prompt_config,
-        )
+    generation = await _generate_coach_response(
+        body=body,
+        history=history,
+        diary_content=effective_diary_content,
+        context_block=context_block,
+        system_prompt=system_prompt,
+        prompt_config=prompt_config,
+    )
+    response_text = str(generation["response_text"])
+    detected_emotion = generation.get("detected_emotion")
+    response_cycle_element = generation.get("response_cycle_element")
     visible_response_text, coach_control = coach_phase_service.extract_control_block(
         response_text
     )
+    coach_lint_violations = coach_response_lint.lint_visible_response(
+        visible_response_text,
+        raw_state=session_data.get("coach_state"),
+        control=coach_control,
+    )
+    coach_lint_regenerated = False
+    if coach_lint_violations:
+        retry_context_block = context_service.join_context_blocks(
+            [
+                context_block,
+                coach_response_lint.build_retry_context(coach_lint_violations),
+            ]
+        )
+        retry_generation = await _generate_coach_response(
+            body=body,
+            history=history,
+            diary_content=effective_diary_content,
+            context_block=retry_context_block,
+            system_prompt=system_prompt,
+            prompt_config=prompt_config,
+        )
+        response_text = str(retry_generation["response_text"])
+        detected_emotion = retry_generation.get("detected_emotion")
+        response_cycle_element = retry_generation.get("response_cycle_element")
+        visible_response_text, coach_control = (
+            coach_phase_service.extract_control_block(response_text)
+        )
+        coach_lint_regenerated = True
+        coach_lint_violations = coach_response_lint.lint_visible_response(
+            visible_response_text,
+            raw_state=session_data.get("coach_state"),
+            control=coach_control,
+        )
 
     # ユーザーメッセージを保存
     user_msg_id = str(uuid.uuid4())
@@ -208,6 +228,8 @@ async def chat(
                 "prompt_version_id": prompt_version_id,
                 "coach_control": coach_control,
                 "created_task_id": created_task_id,
+                "coach_lint_regenerated": coach_lint_regenerated,
+                "coach_lint_violations": coach_lint_violations,
             },
             "created_at": assistant_now,
         }
@@ -317,6 +339,45 @@ async def _remember_diary_context(
     session_data["diary_context"] = diary_context
     session_data["has_diary_context"] = diary_context is not None
     return diary_context
+
+
+async def _generate_coach_response(
+    *,
+    body: CoachRequest,
+    history: list[dict[str, str]],
+    diary_content: str | None,
+    context_block: str | None,
+    system_prompt: str,
+    prompt_config: dict[str, Any],
+) -> dict[str, Any]:
+    if bool(prompt_config.get("use_langgraph")):
+        flow_result = await run_coach_flow(
+            user_message=body.message,
+            history=history,
+            diary_content=diary_content,
+            context_block=context_block,
+            system_prompt=system_prompt,
+            config=prompt_config,
+        )
+        return {
+            "response_text": flow_result["response"],
+            "detected_emotion": flow_result.get("detected_emotion"),
+            "response_cycle_element": flow_result.get("cycle_element"),
+        }
+
+    response_text = await coach_service.chat(
+        user_message=body.message,
+        history=history,
+        diary_content=diary_content,
+        context_block=context_block,
+        system_prompt=system_prompt,
+        config=prompt_config,
+    )
+    return {
+        "response_text": response_text,
+        "detected_emotion": None,
+        "response_cycle_element": None,
+    }
 
 
 async def _try_update_summary(

--- a/api/app/services/coach_response_lint.py
+++ b/api/app/services/coach_response_lint.py
@@ -1,0 +1,133 @@
+"""Mechanical lint for visible coach responses."""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from app.services import coach_phase_service
+
+MAX_REGEN_ATTEMPTS = 1
+
+PHASE_SENTENCE_LIMITS = {
+    "acknowledge": 2,
+    "triage": 2,
+    "space": 2,
+    "naming": 3,
+    "reflection": 2,
+}
+
+FORBIDDEN_PATTERNS = {
+    "praise_or_evaluation": (
+        "すごい",
+        "えらい",
+        "よく頑張",
+        "正しい",
+        "間違い",
+        "強いですね",
+        "前向きですね",
+    ),
+    "advice_or_instruction": (
+        "したほうがいい",
+        "すべき",
+        "してみて",
+        "してみましょう",
+        "しましょう",
+        "まず",
+        "大切です",
+        "おすすめ",
+    ),
+    "diagnosis": (
+        "診断",
+        "うつ病",
+        "トラウマ",
+        "典型的",
+        "症状",
+    ),
+    "guarantee_or_comfort": (
+        "大丈夫",
+        "安心してください",
+        "きっとうまく",
+        "頑張って",
+    ),
+    "interpretation": (
+        "つまり",
+        "要するに",
+        "まとめると",
+        "本当は",
+        "その奥",
+        "心理",
+    ),
+}
+
+QUESTION_PATTERNS = re.compile(r"(ですか|ますか|でしょうか|だろうか)[。.!！]?", re.I)
+SENTENCE_SPLIT_RE = re.compile(r"[^。！？!?\n]+[。！？!?]?")
+
+
+def lint_visible_response(
+    visible_text: str,
+    *,
+    raw_state: Any,
+    control: dict[str, Any] | None,
+) -> list[str]:
+    """Return mechanical lint violations for a user-visible coach response."""
+    if _is_layer8(control):
+        return []
+
+    state = coach_phase_service.normalize_state(raw_state)
+    phase = coach_phase_service.normalize_phase(
+        control.get("phase") if control else None
+    ) or state["phase"]
+    sentences = _split_sentences(visible_text)
+    violations: list[str] = []
+
+    sentence_limit = PHASE_SENTENCE_LIMITS[phase]
+    if len(sentences) > sentence_limit:
+        violations.append(
+            f"sentence_count>{sentence_limit} ({len(sentences)} sentences)"
+        )
+
+    for index, sentence in enumerate(sentences, 1):
+        if len(sentence) > 70:
+            violations.append(f"sentence_{index}_too_long ({len(sentence)} chars)")
+
+    question_count = _question_count(visible_text)
+    question_limit = 0 if phase == "reflection" else 1
+    if question_count > question_limit:
+        violations.append(f"question_count>{question_limit} ({question_count})")
+
+    for category, patterns in FORBIDDEN_PATTERNS.items():
+        hit = next((pattern for pattern in patterns if pattern in visible_text), None)
+        if hit:
+            violations.append(f"forbidden_{category}:{hit}")
+
+    return violations
+
+
+def build_retry_context(violations: list[str]) -> str:
+    joined = "\n".join(f"- {violation}" for violation in violations)
+    return (
+        "【前回応答の機械検証】\n"
+        "前回の発話は返却前検証で止まりました。次の違反を直して、同じ入力へ再応答してください。\n"
+        f"{joined}\n"
+        "発話は現在フェーズの規則に合わせ、直後に<control>を一つだけ付けてください。"
+    )
+
+
+def _is_layer8(control: dict[str, Any] | None) -> bool:
+    if not control:
+        return False
+    report = control.get("report") if isinstance(control.get("report"), dict) else {}
+    route = coach_phase_service.normalize_route(control.get("route"))
+    return bool(control.get("layer8") or report.get("layer8") or route == "layer8")
+
+
+def _split_sentences(text: str) -> list[str]:
+    sentences = [match.group(0).strip() for match in SENTENCE_SPLIT_RE.finditer(text)]
+    return [sentence for sentence in sentences if sentence]
+
+
+def _question_count(text: str) -> int:
+    punctuation_questions = text.count("?") + text.count("？")
+    phrase_questions = len(QUESTION_PATTERNS.findall(text))
+    return max(punctuation_questions, phrase_questions)

--- a/api/tests/test_coach.py
+++ b/api/tests/test_coach.py
@@ -202,6 +202,69 @@ def test_coach_creates_task_from_permitted_triage_report(
     assert update_payload["coach_state"]["items"][0]["task_id"]
 
 
+def test_coach_regenerates_once_when_response_lint_fails(
+    auth_client,
+    mock_firestore,
+):
+    with (
+        patch(
+            "app.routers.coach.coach_service.chat",
+            new_callable=AsyncMock,
+        ) as mock_chat,
+        patch(
+            "app.routers.coach.context_service.build_context_block",
+            new_callable=AsyncMock,
+        ) as build_context,
+        patch(
+            "app.routers.coach.coach_phase_service.build_phase_context",
+            return_value="PHASE",
+        ),
+        patch(
+            "app.routers.coach.context_service.maybe_update_session_summary",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "app.routers.coach.ai_usage_service.reserve_monthly_budget",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "app.routers.coach.prompt_service.get_active_config",
+            new_callable=AsyncMock,
+        ) as active_config,
+    ):
+        mock_chat.side_effect = [
+            (
+                '大丈夫です。まず休みましょう。\n\n<control>{"phase":"triage",'
+                '"phase_complete":false,"route":null,"report":{}}</control>'
+            ),
+            (
+                '疲れが、あります。\n\n<control>{"phase":"triage",'
+                '"phase_complete":false,"route":null,"report":{}}</control>'
+            ),
+        ]
+        build_context.return_value = None
+        active_config.return_value = (
+            {
+                "system_prompt": "system prompt",
+                "use_langgraph": False,
+                "use_gemini_fallback": True,
+            },
+            "prompt-v1",
+        )
+
+        response = auth_client.post("/coach", json={"message": "今日は疲れた"})
+
+    assert response.status_code == 200
+    assert response.json()["data"]["message"] == "疲れが、あります。"
+    assert mock_chat.await_count == 2
+    retry_context = mock_chat.await_args_list[1].kwargs["context_block"]
+    assert "前回応答の機械検証" in retry_context
+    assistant_write = mock_firestore._mock_subcollection.document.return_value.set
+    assistant_payload = assistant_write.await_args_list[-1].args[0]
+    assert assistant_payload["metadata"]["coach_lint_regenerated"] is True
+    assert assistant_payload["metadata"]["coach_lint_violations"] == []
+
+
 def test_coach_stream_filters_control_block(auth_client, mock_firestore):
     """SSE should not stream the hidden control block to the client."""
 

--- a/api/tests/test_coach_response_lint.py
+++ b/api/tests/test_coach_response_lint.py
@@ -1,0 +1,26 @@
+"""Coach visible response lint tests."""
+
+from app.services import coach_response_lint
+
+
+def test_lint_visible_response_detects_mechanical_violations():
+    violations = coach_response_lint.lint_visible_response(
+        "大丈夫です。まず休みましょう。どうしますか？もう一つ聞いてもいいですか？",
+        raw_state={"phase": "triage"},
+        control={"phase": "triage", "report": {}},
+    )
+
+    assert "sentence_count>2 (4 sentences)" in violations
+    assert "question_count>1 (2)" in violations
+    assert "forbidden_guarantee_or_comfort:大丈夫" in violations
+    assert "forbidden_advice_or_instruction:まず" in violations
+
+
+def test_lint_visible_response_skips_layer8():
+    violations = coach_response_lint.lint_visible_response(
+        "いま危険があるなら、地域の緊急窓口へ連絡してください。",
+        raw_state={"phase": "triage"},
+        control={"phase": "triage", "route": "layer8", "report": {"layer8": True}},
+    )
+
+    assert violations == []


### PR DESCRIPTION
## Summary
- Add mechanical lint for visible coach responses: sentence count, sentence length, question count, and forbidden phrase categories
- Skip lint for Layer8 responses
- Regenerate /coach responses once before saving/returning when lint fails, with violations injected as retry context
- Persist lint metadata on assistant messages

## Scope note
- /coach/stream still streams live chunks and does not regenerate after tokens have been sent. It remains a follow-up if strict streaming lint is required.

## Verification
- uv run ruff check .
- uv run pytest tests/test_coach.py tests/test_coach_phase_service.py tests/test_coach_response_lint.py
- uv run pytest

Refs #117