### PR TITLE
feat: lint streamed coach vocabulary

### DIFF
--- a/api/app/models/admin.py
+++ b/api/app/models/admin.py
@@ -22,6 +22,7 @@ class PromptConfig(BaseModel):
     coach_action_core_checklist: str | None = None
     coach_layer8_crisis_prompt: str | None = None
     coach_professional_boundary_prompt: str | None = None
+    coach_vocabulary_lint_enabled: bool = True
 
 
 class PromptVersionCreateRequest(BaseModel):

--- a/api/app/routers/coach.py
+++ b/api/app/routers/coach.py
@@ -130,53 +130,22 @@ async def chat(
 
     system_prompt = str(prompt_config["system_prompt"])
 
-    generation = await _generate_coach_response(
+    generation = await _generate_linted_coach_response(
         body=body,
         history=history,
         diary_content=effective_diary_content,
         context_block=context_block,
+        memory_context_block=memory_context_block,
         system_prompt=system_prompt,
         prompt_config=prompt_config,
+        raw_state=session_data.get("coach_state"),
     )
-    response_text = str(generation["response_text"])
+    visible_response_text = str(generation["visible_response_text"])
+    coach_control = generation.get("coach_control")
     detected_emotion = generation.get("detected_emotion")
     response_cycle_element = generation.get("response_cycle_element")
-    visible_response_text, coach_control = coach_phase_service.extract_control_block(
-        response_text
-    )
-    coach_lint_violations = coach_response_lint.lint_visible_response(
-        visible_response_text,
-        raw_state=session_data.get("coach_state"),
-        control=coach_control,
-    )
-    coach_lint_regenerated = False
-    if coach_lint_violations:
-        retry_context_block = context_service.join_context_blocks(
-            [
-                context_block,
-                coach_response_lint.build_retry_context(coach_lint_violations),
-            ]
-        )
-        retry_generation = await _generate_coach_response(
-            body=body,
-            history=history,
-            diary_content=effective_diary_content,
-            context_block=retry_context_block,
-            system_prompt=system_prompt,
-            prompt_config=prompt_config,
-        )
-        response_text = str(retry_generation["response_text"])
-        detected_emotion = retry_generation.get("detected_emotion")
-        response_cycle_element = retry_generation.get("response_cycle_element")
-        visible_response_text, coach_control = (
-            coach_phase_service.extract_control_block(response_text)
-        )
-        coach_lint_regenerated = True
-        coach_lint_violations = coach_response_lint.lint_visible_response(
-            visible_response_text,
-            raw_state=session_data.get("coach_state"),
-            control=coach_control,
-        )
+    coach_lint_regenerated = bool(generation.get("coach_lint_regenerated"))
+    coach_lint_violations = generation.get("coach_lint_violations")
 
     # ユーザーメッセージを保存
     user_msg_id = str(uuid.uuid4())
@@ -380,6 +349,100 @@ async def _generate_coach_response(
     }
 
 
+async def _generate_linted_coach_response(
+    *,
+    body: CoachRequest,
+    history: list[dict[str, str]],
+    diary_content: str | None,
+    context_block: str | None,
+    memory_context_block: str | None,
+    system_prompt: str,
+    prompt_config: dict[str, Any],
+    raw_state: Any,
+) -> dict[str, Any]:
+    generation = await _generate_coach_response(
+        body=body,
+        history=history,
+        diary_content=diary_content,
+        context_block=context_block,
+        system_prompt=system_prompt,
+        prompt_config=prompt_config,
+    )
+    response_text = str(generation["response_text"])
+    visible_text, coach_control = coach_phase_service.extract_control_block(
+        response_text
+    )
+    vocabulary_sources = _vocabulary_sources(
+        body=body,
+        history=history,
+        diary_content=diary_content,
+        memory_context_block=memory_context_block,
+    )
+    lint_violations = coach_response_lint.lint_visible_response(
+        visible_text,
+        raw_state=raw_state,
+        control=coach_control,
+        vocabulary_sources=vocabulary_sources,
+        enable_vocabulary_lint=bool(
+            prompt_config.get("coach_vocabulary_lint_enabled") is True
+        ),
+    )
+    regenerated = False
+
+    if lint_violations:
+        retry_context_block = context_service.join_context_blocks(
+            [
+                context_block,
+                coach_response_lint.build_retry_context(lint_violations),
+            ]
+        )
+        generation = await _generate_coach_response(
+            body=body,
+            history=history,
+            diary_content=diary_content,
+            context_block=retry_context_block,
+            system_prompt=system_prompt,
+            prompt_config=prompt_config,
+        )
+        response_text = str(generation["response_text"])
+        visible_text, coach_control = coach_phase_service.extract_control_block(
+            response_text
+        )
+        regenerated = True
+        lint_violations = coach_response_lint.lint_visible_response(
+            visible_text,
+            raw_state=raw_state,
+            control=coach_control,
+            vocabulary_sources=vocabulary_sources,
+            enable_vocabulary_lint=bool(
+                prompt_config.get("coach_vocabulary_lint_enabled") is True
+            ),
+        )
+
+    return {
+        **generation,
+        "visible_response_text": visible_text,
+        "coach_control": coach_control,
+        "coach_lint_regenerated": regenerated,
+        "coach_lint_violations": lint_violations,
+    }
+
+
+def _vocabulary_sources(
+    *,
+    body: CoachRequest,
+    history: list[dict[str, str]],
+    diary_content: str | None,
+    memory_context_block: str | None,
+) -> list[str | None]:
+    return [
+        *(item["content"] for item in history if item.get("role") == "user"),
+        diary_content,
+        memory_context_block,
+        body.message,
+    ]
+
+
 async def _try_update_summary(
     *,
     session_doc,
@@ -579,32 +642,22 @@ async def chat_stream(
     async def event_source():
         # SSE 起動メッセージ
         yield f"event: session\ndata: {json.dumps({'session_id': session_id})}\n\n"
-        accumulated = ""
-        control_filter = coach_phase_service.ControlBlockStreamFilter()
+        generation = None
         try:
-
-            async def consume():
-                nonlocal accumulated
-                async for chunk in coach_service.chat_stream(
-                    user_message=body.message,
+            async with asyncio.timeout(settings.coach_stream_timeout_seconds):
+                generation = await _generate_linted_coach_response(
+                    body=body,
                     history=history,
                     diary_content=effective_diary_content,
                     context_block=context_block,
+                    memory_context_block=memory_context_block,
                     system_prompt=system_prompt,
-                    config=prompt_config,
-                ):
-                    accumulated += chunk
-                    visible_chunk = control_filter.feed(chunk)
-                    if visible_chunk:
-                        yield visible_chunk
-                visible_tail = control_filter.flush()
-                if visible_tail:
-                    yield visible_tail
-
-            async for chunk in _with_timeout(
-                consume(), settings.coach_stream_timeout_seconds
-            ):
-                yield f"data: {json.dumps({'chunk': chunk})}\n\n"
+                    prompt_config=prompt_config,
+                    raw_state=session_data.get("coach_state"),
+                )
+            visible_response_text = str(generation["visible_response_text"])
+            if visible_response_text:
+                yield f"data: {json.dumps({'chunk': visible_response_text})}\n\n"
         except TimeoutError:
             logger.warning("coach stream timeout", extra={"session_id": session_id})
             yield f"event: error\ndata: {json.dumps({'reason': 'timeout'})}\n\n"
@@ -616,11 +669,9 @@ async def chat_stream(
                 + "\n\n"
             )
         finally:
-            # 完了後に assistant メッセージを保存（部分応答でも残す）
-            if accumulated:
-                visible_response_text, coach_control = (
-                    coach_phase_service.extract_control_block(accumulated)
-                )
+            if generation:
+                visible_response_text = str(generation["visible_response_text"])
+                coach_control = generation.get("coach_control")
                 coach_state = coach_phase_service.apply_control_state(
                     session_data.get("coach_state"),
                     coach_control,
@@ -660,6 +711,12 @@ async def chat_stream(
                             "prompt_version_id": prompt_version_id,
                             "coach_control": coach_control,
                             "created_task_id": created_task_id,
+                            "coach_lint_regenerated": bool(
+                                generation.get("coach_lint_regenerated")
+                            ),
+                            "coach_lint_violations": generation.get(
+                                "coach_lint_violations"
+                            ),
                         },
                         "created_at": assistant_now,
                     }

--- a/api/app/services/coach_response_lint.py
+++ b/api/app/services/coach_response_lint.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from app.services import coach_phase_service
+from app.services import coach_phase_service, coach_vocabulary_service
 
 MAX_REGEN_ATTEMPTS = 1
 
@@ -69,6 +69,8 @@ def lint_visible_response(
     *,
     raw_state: Any,
     control: dict[str, Any] | None,
+    vocabulary_sources: list[str | None] | None = None,
+    enable_vocabulary_lint: bool = False,
 ) -> list[str]:
     """Return mechanical lint violations for a user-visible coach response."""
     if _is_layer8(control):
@@ -101,6 +103,14 @@ def lint_visible_response(
         if hit:
             violations.append(f"forbidden_{category}:{hit}")
 
+    if enable_vocabulary_lint:
+        violations.extend(
+            _vocabulary_violations(
+                visible_text,
+                vocabulary_sources=vocabulary_sources or [],
+            )
+        )
+
     return violations
 
 
@@ -131,3 +141,14 @@ def _question_count(text: str) -> int:
     punctuation_questions = text.count("?") + text.count("？")
     phrase_questions = len(QUESTION_PATTERNS.findall(text))
     return max(punctuation_questions, phrase_questions)
+
+
+def _vocabulary_violations(
+    visible_text: str,
+    *,
+    vocabulary_sources: list[str | None],
+) -> list[str]:
+    allowed = coach_vocabulary_service.allowed_lemmas(vocabulary_sources)
+    response_lemmas = coach_vocabulary_service.content_lemmas(visible_text)
+    extra = sorted(response_lemmas - allowed)
+    return [f"new_content_word:{lemma}" for lemma in extra[:5]]

--- a/api/app/services/coach_vocabulary_service.py
+++ b/api/app/services/coach_vocabulary_service.py
@@ -1,0 +1,74 @@
+"""Vocabulary extraction for coach response linting."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+CONTENT_POS = {"名詞", "動詞", "形容詞", "副詞"}
+
+ALLOWED_CORE_LEMMAS = {
+    "ある",
+    "あり",
+    "いる",
+    "い",
+    "見る",
+    "見える",
+    "言葉",
+    "する",
+    "置く",
+    "片づく",
+    "片付く",
+    "残る",
+    "届く",
+    "止める",
+    "難しい",
+    "しんどい",
+}
+
+STRUCTURAL_LEMMAS = {
+    "いま",
+    "今",
+    "今日",
+    "ここ",
+    "こと",
+    "もの",
+    "一つ",
+    "二つ",
+    "三つ",
+    "まま",
+    "そう",
+    "感じる",
+    "話",
+}
+
+
+@lru_cache(maxsize=1)
+def _tokenizer():
+    from janome.tokenizer import Tokenizer
+
+    return Tokenizer()
+
+
+def content_lemmas(text: str) -> set[str]:
+    lemmas: set[str] = set()
+    for token in _tokenizer().tokenize(text):
+        part = str(token.part_of_speech).split(",", 1)[0]
+        if part not in CONTENT_POS:
+            continue
+        surface = str(token.surface).strip()
+        if not surface:
+            continue
+        base = str(token.base_form)
+        lemmas.add(surface)
+        if base != "*":
+            lemmas.add(base)
+    return lemmas
+
+
+def allowed_lemmas(sources: list[str | None]) -> set[str]:
+    allowed = set(ALLOWED_CORE_LEMMAS)
+    allowed.update(STRUCTURAL_LEMMAS)
+    for source in sources:
+        if source:
+            allowed.update(content_lemmas(source))
+    return allowed

--- a/api/app/services/prompt_service.py
+++ b/api/app/services/prompt_service.py
@@ -41,6 +41,7 @@ def default_config() -> dict[str, Any]:
         "coach_professional_boundary_prompt": (
             coach_prompt_core.PROFESSIONAL_BOUNDARY_PROMPT
         ),
+        "coach_vocabulary_lint_enabled": True,
     }
 
 

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "langchain-core>=0.3.0",
     "app-store-server-library>=1.5.0",
     "cryptography>=42.0.0",
+    "janome>=0.5.0",
 ]
 
 [project.optional-dependencies]

--- a/api/tests/test_coach.py
+++ b/api/tests/test_coach.py
@@ -268,19 +268,11 @@ def test_coach_regenerates_once_when_response_lint_fails(
 def test_coach_stream_filters_control_block(auth_client, mock_firestore):
     """SSE should not stream the hidden control block to the client."""
 
-    async def fake_stream(**kwargs):
-        yield "そう"
-        yield "感じたんだね。<con"
-        yield (
-            'trol>{"phase":"acknowledge","phase_complete":true,'
-            '"route":"triage","report":{}}</control>'
-        )
-
     with (
         patch(
-            "app.routers.coach.coach_service.chat_stream",
-            return_value=fake_stream(),
-        ),
+            "app.routers.coach.coach_service.chat",
+            new_callable=AsyncMock,
+        ) as mock_chat,
         patch(
             "app.routers.coach.context_service.build_context_block",
             new_callable=AsyncMock,
@@ -311,6 +303,10 @@ def test_coach_stream_filters_control_block(auth_client, mock_firestore):
             },
             "prompt-v1",
         )
+        mock_chat.return_value = (
+            'そう感じたんだね。\n\n<control>{"phase":"acknowledge",'
+            '"phase_complete":true,"route":"triage","report":{}}</control>'
+        )
         response = auth_client.post("/coach/stream", json={"message": "今日は疲れた"})
 
     assert response.status_code == 200
@@ -325,3 +321,69 @@ def test_coach_stream_filters_control_block(auth_client, mock_firestore):
     assert "<control>" not in response.text
     update_payload = mock_firestore._mock_doc.update.await_args.args[0]
     assert update_payload["coach_state"]["phase"] == "triage"
+
+
+def test_coach_stream_regenerates_before_streaming(auth_client, mock_firestore):
+    """SSE buffers enough to lint before emitting the visible chunk."""
+
+    with (
+        patch(
+            "app.routers.coach.coach_service.chat",
+            new_callable=AsyncMock,
+        ) as mock_chat,
+        patch(
+            "app.routers.coach.context_service.build_context_block",
+            new_callable=AsyncMock,
+        ) as build_context,
+        patch(
+            "app.routers.coach.coach_phase_service.build_phase_context",
+            return_value="PHASE",
+        ),
+        patch(
+            "app.routers.coach.context_service.maybe_update_session_summary",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "app.routers.coach.ai_usage_service.reserve_monthly_budget",
+            new_callable=AsyncMock,
+        ),
+        patch(
+            "app.routers.coach.prompt_service.get_active_config",
+            new_callable=AsyncMock,
+        ) as active_config,
+    ):
+        mock_chat.side_effect = [
+            (
+                '大丈夫です。まず休みましょう。\n\n<control>{"phase":"triage",'
+                '"phase_complete":false,"route":null,"report":{}}</control>'
+            ),
+            (
+                '疲れが、あります。\n\n<control>{"phase":"triage",'
+                '"phase_complete":false,"route":null,"report":{}}</control>'
+            ),
+        ]
+        build_context.return_value = None
+        active_config.return_value = (
+            {
+                "system_prompt": "system prompt",
+                "use_langgraph": False,
+                "use_gemini_fallback": True,
+            },
+            "prompt-v1",
+        )
+        response = auth_client.post("/coach/stream", json={"message": "今日は疲れた"})
+
+    assert response.status_code == 200
+    assert mock_chat.await_count == 2
+    chunks = []
+    for line in response.text.splitlines():
+        if not line.startswith("data: "):
+            continue
+        data = json.loads(line.removeprefix("data: "))
+        if "chunk" in data:
+            chunks.append(data["chunk"])
+    assert "".join(chunks) == "疲れが、あります。"
+    assert "大丈夫です" not in response.text
+    assistant_write = mock_firestore._mock_subcollection.document.return_value.set
+    assistant_payload = assistant_write.await_args_list[-1].args[0]
+    assert assistant_payload["metadata"]["coach_lint_regenerated"] is True

--- a/api/tests/test_coach_response_lint.py
+++ b/api/tests/test_coach_response_lint.py
@@ -24,3 +24,27 @@ def test_lint_visible_response_skips_layer8():
     )
 
     assert violations == []
+
+
+def test_lint_visible_response_allows_user_vocabulary_and_core_verbs():
+    violations = coach_response_lint.lint_visible_response(
+        "疲れが、あります。",
+        raw_state={"phase": "triage"},
+        control={"phase": "triage", "report": {}},
+        vocabulary_sources=["今日は疲れた"],
+        enable_vocabulary_lint=True,
+    )
+
+    assert violations == []
+
+
+def test_lint_visible_response_detects_new_content_words():
+    violations = coach_response_lint.lint_visible_response(
+        "疲れと海が、あります。",
+        raw_state={"phase": "triage"},
+        control={"phase": "triage", "report": {}},
+        vocabulary_sources=["今日は疲れた"],
+        enable_vocabulary_lint=True,
+    )
+
+    assert "new_content_word:海" in violations

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -424,6 +424,7 @@ dependencies = [
     { name = "google-genai" },
     { name = "h2" },
     { name = "httpx" },
+    { name = "janome" },
     { name = "langchain-core" },
     { name = "langgraph" },
     { name = "pydantic-settings" },
@@ -452,6 +453,7 @@ requires-dist = [
     { name = "h2", specifier = ">=4.1.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27.0" },
+    { name = "janome", specifier = ">=0.5.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
     { name = "langgraph", specifier = ">=0.2.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8.0" },
@@ -779,6 +781,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "janome"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/4e/dc2b1a89a4ffafbf9bf49c8e11f69e28ba8b3ef81d11afe6e9f96caee6cc/Janome-0.5.0.tar.gz", hash = "sha256:ce4a3ed7a4635c2f80139639327d5b1e0381858ad74a3c4a61e8cc83f820400e", size = 18829020, upload-time = "2023-07-01T10:53:09.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/7d/70f4069f4bbf0fca023e82a1fbbade6f5216365d4fe259fee1950723eca5/Janome-0.5.0-py2.py3-none-any.whl", hash = "sha256:d098670394a77881ce2f6b7d696c0ea5ff74c0c8cf74a8a882159ec82c0e6dc7", size = 19654103, upload-time = "2023-07-01T10:52:58.572Z" },
 ]
 
 [[package]]

--- a/web/src/app/admin/page.tsx
+++ b/web/src/app/admin/page.tsx
@@ -367,6 +367,19 @@ function PromptAdmin({
                   <div className="text-[12px] font-semibold text-muted-foreground">
                     Coach runtime prompts
                   </div>
+                  <label className="flex items-center gap-2 text-[13px] font-semibold">
+                    <input
+                      type="checkbox"
+                      checked={config.coachVocabularyLintEnabled ?? true}
+                      onChange={(event) =>
+                        setConfig({
+                          ...config,
+                          coachVocabularyLintEnabled: event.target.checked
+                        })
+                      }
+                    />
+                    Vocabulary lint
+                  </label>
                   <PromptArea
                     label="Action core checklist"
                     value={config.coachActionCoreChecklist ?? ""}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -149,6 +149,7 @@ export interface PromptConfig {
   coachActionCoreChecklist?: string | null;
   coachLayer8CrisisPrompt?: string | null;
   coachProfessionalBoundaryPrompt?: string | null;
+  coachVocabularyLintEnabled?: boolean;
 }
 
 export interface PromptTestData {


### PR DESCRIPTION
## Summary
- Reuse the /coach response lint path for /coach/stream by buffering generation before emitting the SSE chunk
- Add Janome-based content-word extraction for vocabulary/lemma checks
- Add a coach_vocabulary_lint_enabled prompt config flag and admin UI toggle
- Include user history, diary context, memory summaries, and the current user message as vocabulary sources

## Behavior note
Strict stream lint means /coach/stream now emits the final visible response as a single SSE chunk after validation, instead of forwarding model chunks live.

## Verification
- uv run ruff check .
- uv run pytest tests/test_coach.py tests/test_coach_response_lint.py tests/test_coach_phase_service.py tests/test_admin_prompts.py
- uv run pytest
- npm run lint
- npm run build

Refs #117